### PR TITLE
Add episode ID to response object

### DIFF
--- a/app/controllers/api/public/v3/base_controller.rb
+++ b/app/controllers/api/public/v3/base_controller.rb
@@ -1,5 +1,5 @@
 module Api::Public::V3
-  VERSION   = Gem::Version.new("3.1.0")
+  VERSION   = Gem::Version.new("3.1.1")
   TYPE      = "public"
 
   class BaseController < ::ActionController::Base

--- a/app/views/api/public/v3/episodes/_episode.json.jbuilder
+++ b/app/views/api/public/v3/episodes/_episode.json.jbuilder
@@ -1,4 +1,5 @@
 json.cache! [Api::Public::V3::VERSION, "v2", episode] do
+  json.id       episode.id
   json.title    episode.title
   json.summary  episode.summary.to_s.html_safe
 


### PR DESCRIPTION
This would be good to have since there's an endpoint to fetch an episode by its numerical ID but no way to find the ID through the API. This isn't blocking me on anything, so no rush or obligation.