### PR TITLE
Speed Up Programs Endpoint; Remove `.to_program` from Programs

### DIFF
--- a/app/controllers/api/public/v2/episodes_controller.rb
+++ b/app/controllers/api/public/v2/episodes_controller.rb
@@ -19,7 +19,7 @@ module Api::Public::V2
 
     def index
       if @program
-        @episodes = @program.episodes
+        @episodes = @program.episodes.published
       else
         @episodes = ShowEpisode.published
       end

--- a/app/controllers/api/public/v3/episodes_controller.rb
+++ b/app/controllers/api/public/v3/episodes_controller.rb
@@ -21,7 +21,7 @@ module Api::Public::V3
 
     def index
       if @program
-        @episodes = @program.episodes
+        @episodes = @program.episodes.published
       else
         @episodes = ShowEpisode.published
       end

--- a/app/models/external_episode.rb
+++ b/app/models/external_episode.rb
@@ -45,7 +45,7 @@ class ExternalEpisode < ActiveRecord::Base
       :summary            => self.summary,
       :air_date           => self.air_date,
       :audio              => self.audio.available,
-      :program            => self.external_program.to_program,
+      :program            => self.external_program,
       :segments           => self.external_segments.map(&:to_article)
     })
   end

--- a/app/models/external_program.rb
+++ b/app/models/external_program.rb
@@ -89,28 +89,9 @@ class ExternalProgram < ActiveRecord::Base
     }
   end
 
-
-  def to_program
-    @to_program ||= Program.new({
-      :original_object    => self,
-      :id                 => self.obj_key,
-      :source             => self.source,
-      :title              => self.title,
-      :slug               => self.slug,
-      :description        => self.description,
-      :host               => self.host,
-      :air_status         => self.air_status,
-      :airtime            => self.airtime,
-      :podcast_url        => self.podcast_url,
-      :rss_url            => self.get_link('rss'),
-      :episodes           => self.external_episodes.order("air_date desc"),
-      :segments           => self.external_segments.order("published_at desc"),
-      # External Programs are always assumed to be segmented.
-      # Maybe this isn't always the case, but this is okay for now.
-      :is_segmented   => true
-    })
+  def rss_url
+    self.get_link('rss')
   end
-
 
   def published?
     self.air_status != "hidden"

--- a/app/models/external_program.rb
+++ b/app/models/external_program.rb
@@ -105,6 +105,10 @@ class ExternalProgram < ActiveRecord::Base
     self.importer.sync(self)
   end
 
+  def is_segmented?
+    true
+  end
+
   private
 
   def slug_is_unique_in_programs_namespace

--- a/app/models/kpcc_program.rb
+++ b/app/models/kpcc_program.rb
@@ -91,26 +91,12 @@ class KpccProgram < ActiveRecord::Base
     }
   end
 
+  def podcast_url
+    self.get_link('podcast')
+  end
 
-  def to_program
-    @to_program ||= Program.new({
-      :original_object    => self,
-      :id                 => self.obj_key,
-      :source             => 'kpcc',
-      :title              => self.title,
-      :slug               => self.slug,
-      :description        => self.description,
-      :host               => self.host,
-      :air_status         => self.air_status,
-      :airtime            => self.airtime,
-      :podcast_url        => self.get_link('podcast'),
-      :rss_url            => self.get_link('rss'),
-      :episodes           => self.episodes.published,
-      :segments           => self.segments.published,
-      :blog               => self.blog,
-      :is_featured        => self.is_featured?,
-      :is_segmented       => self.is_segmented?
-    })
+  def rss_url
+    self.get_link('rss')
   end
 
   def featured_articles

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -7,14 +7,14 @@ class Program
 
   class << self
     def all
-      (KpccProgram.all + ExternalProgram.all).map(&:to_program)
+      (KpccProgram.all + ExternalProgram.all)
     end
 
     def find_by_slug(slug)
       program = KpccProgram.find_by_slug(slug) ||
       ExternalProgram.find_by_slug(slug)
 
-      program.try(:to_program)
+      program
     end
 
     def find_by_slug!(slug)
@@ -22,68 +22,7 @@ class Program
     end
 
     def where(conditions)
-      (KpccProgram.where(conditions) + ExternalProgram.where(conditions))
-      .map(&:to_program)
-    end
-  end
-
-
-  attr_accessor \
-    :original_object,
-    :id,
-    :source,
-    :title,
-    :slug,
-    :teaser,
-    :description,
-    :host,
-    :air_status,
-    :airtime,
-    :podcast_url,
-    :rss_url,
-    :episodes,
-    :segments,
-    :blog,
-    :is_featured,
-    :is_segmented
-
-  alias_method :is_featured?, :is_featured
-  alias_method :is_segmented?, :is_segmented
-
-
-  def initialize(attributes={})
-    @original_object  = attributes[:original_object]
-    @id               = attributes[:id]
-    @source           = attributes[:source]
-    @title            = attributes[:title]
-    @slug             = attributes[:slug]
-    @description      = attributes[:description]
-    @host             = attributes[:host]
-    @air_status       = attributes[:air_status]
-    @airtime          = attributes[:airtime]
-    @podcast_url      = attributes[:podcast_url]
-    @rss_url          = attributes[:rss_url]
-    @blog             = attributes[:blog]
-
-    # Force to boolean
-    @is_featured  = !!attributes[:is_featured]
-    @is_segmented  = !!attributes[:is_segmented]
-
-    # Don't force these into an array, so it doesn't load ALL
-    # of the episodes/segments (which could be thousands).
-    @episodes   = attributes[:episodes]
-    @segments   = attributes[:segments]
-  end
-
-  def to_program
-    self
-  end
-
-  # Delegate get_link to original object,
-  # just so we don't have to redefine it.
-  def get_link(type)
-    if self.original_object
-      self.original_object.get_link(type)
+      (KpccProgram.includes(:related_links).where(conditions) + ExternalProgram.includes(:related_links).where(conditions))
     end
   end
 end

--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -153,7 +153,7 @@ class ShowEpisode < ActiveRecord::Base
       :air_date           => self.air_date,
       :assets             => self.assets,
       :audio              => self.audio.available,
-      :program            => self.show.to_program,
+      :program            => self.show,
       :segments           => self.segments.published.map(&:to_article)
     })
   end

--- a/app/presenters/program_presenter.rb
+++ b/app/presenters/program_presenter.rb
@@ -77,6 +77,6 @@ class ProgramPresenter < ApplicationPresenter
   private
 
   def abstract_program
-    @abstract_program ||= program.to_program
+    @abstract_program ||= program
   end
 end

--- a/app/views/api/public/v2/events/_event.json.jbuilder
+++ b/app/views/api/public/v2/events/_event.json.jbuilder
@@ -43,7 +43,7 @@ json.cache! [Api::Public::V2::VERSION, "v2", event] do
   if event.kpcc_program.present?
     json.program do
       json.partial! "api/public/v2/programs/program",
-        program: event.kpcc_program.to_program
+        program: event.kpcc_program
     end
   end
 

--- a/app/views/api/public/v2/schedule_occurrences/_schedule_occurrence.json.jbuilder
+++ b/app/views/api/public/v2/schedule_occurrences/_schedule_occurrence.json.jbuilder
@@ -8,7 +8,7 @@ json.cache! [Api::Public::V2::VERSION, "v1", schedule_occurrence] do
   if schedule_occurrence.program.present?
     json.program do
       json.partial! "api/public/v2/programs/program",
-        :program => schedule_occurrence.program.to_program
+        :program => schedule_occurrence.program
     end
   end
 end

--- a/app/views/api/public/v3/events/_event.json.jbuilder
+++ b/app/views/api/public/v3/events/_event.json.jbuilder
@@ -44,7 +44,7 @@ json.cache! [Api::Public::V3::VERSION, "v2", event] do
   if event.kpcc_program.present?
     json.program do
       json.partial! api_view_path("programs", "program"),
-        program: event.kpcc_program.to_program
+        program: event.kpcc_program
     end
   end
 

--- a/app/views/api/public/v3/schedule_occurrences/_schedule_occurrence.json.jbuilder
+++ b/app/views/api/public/v3/schedule_occurrences/_schedule_occurrence.json.jbuilder
@@ -9,7 +9,7 @@ json.cache! [Api::Public::V3::VERSION, "v1", schedule_occurrence] do
   if schedule_occurrence.program.present?
     json.program do
       json.partial! api_view_path("programs", "program"),
-        :program => schedule_occurrence.program.to_program
+        :program => schedule_occurrence.program
     end
   end
 end

--- a/spec/controllers/api/public/v2/programs_controller_spec.rb
+++ b/spec/controllers/api/public/v2/programs_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::Public::V2::ProgramsController do
     it "finds the object if it exists" do
       program = create :kpcc_program, slug: 'hello'
       get :show, { id: program.slug }.merge(request_params)
-      assigns(:program).should eq program.to_program
+      assigns(:program).should eq program
       response.should render_template "show"
     end
 
@@ -28,7 +28,7 @@ describe Api::Public::V2::ProgramsController do
       external_program   = create :external_program
 
       get :index, request_params
-      assigns(:programs).should eq [kpcc_program, external_program].map(&:to_program)
+      assigns(:programs).should eq [kpcc_program, external_program]
     end
   end
 end

--- a/spec/controllers/api/public/v3/programs_controller_spec.rb
+++ b/spec/controllers/api/public/v3/programs_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::Public::V3::ProgramsController do
     it "finds the object if it exists" do
       program = create :kpcc_program, slug: 'hello'
       get :show, { id: program.slug }.merge(request_params)
-      assigns(:program).should eq program.to_program
+      assigns(:program).should eq program
       response.should render_template "show"
     end
 
@@ -30,7 +30,7 @@ describe Api::Public::V3::ProgramsController do
         another_program = create :kpcc_program, air_status: "onair"
 
         get :index, { air_status: "archive,online" }.merge(request_params)
-        assigns(:programs).should eq [kpcc_program, external_program].map(&:to_program)
+        assigns(:programs).should eq [kpcc_program, external_program]
       end
     end
 
@@ -40,7 +40,7 @@ describe Api::Public::V3::ProgramsController do
         external_program   = create :external_program
 
         get :index, request_params
-        assigns(:programs).should eq [kpcc_program, external_program].map(&:to_program)
+        assigns(:programs).should eq [kpcc_program, external_program]
       end
     end
   end

--- a/spec/models/external_episode_spec.rb
+++ b/spec/models/external_episode_spec.rb
@@ -42,7 +42,7 @@ describe ExternalEpisode do
     expired_episode = nil
     before :each do
       program = create :external_program, :from_rss, air_status: "onair", days_to_expiry: 3
-      5.times do 
+      5.times do
         program.episodes << create(:external_episode, air_date: Time.now)
       end
       program.episodes << (expired_episode = create(:external_episode, air_date: 4.days.ago))

--- a/spec/models/external_program_spec.rb
+++ b/spec/models/external_program_spec.rb
@@ -88,13 +88,6 @@ describe ExternalProgram do
     end
   end
 
-  describe '#to_program' do
-    it 'turns it into a program' do
-      program = build :external_program
-      program.to_program.should be_a Program
-    end
-  end
-
   describe 'slug uniqueness validation' do
     it 'validates that the slug is unique across the program models' do
       kpcc_program = create :kpcc_program, slug: "same"

--- a/spec/models/kpcc_program_spec.rb
+++ b/spec/models/kpcc_program_spec.rb
@@ -14,13 +14,6 @@ describe KpccProgram do
     end
   end
 
-  describe '#to_program' do
-    it 'turns it into a program' do
-      program = build :kpcc_program
-      program.to_program.should be_a Program
-    end
-  end
-
   describe 'slug uniqueness validation' do
     it 'validates that the slug is unique across the program models' do
       external_program = create :external_program, slug: "same"

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -6,7 +6,7 @@ describe Program do
       kpcc      = create :kpcc_program
       external  = create :external_program
 
-      Program.all.should eq [kpcc, external].map(&:to_program)
+      Program.all.should eq [kpcc, external]
     end
   end
 
@@ -15,20 +15,20 @@ describe Program do
       kpcc      = create :kpcc_program
       external  = create :external_program
 
-      Program.find_by_slug(kpcc.slug).should eq kpcc.to_program
+      Program.find_by_slug(kpcc.slug).should eq kpcc
     end
 
     it "looks at ExternalProgram if no KPCC program is available" do
       external  = create :external_program
 
-      Program.find_by_slug(external.slug).should eq external.to_program
+      Program.find_by_slug(external.slug).should eq external
     end
   end
 
   describe '::find_by_slug!' do
     it 'finds program by slug if available' do
       program = create :kpcc_program
-      Program.find_by_slug!(program.slug).should eq program.to_program
+      Program.find_by_slug!(program.slug).should eq program
     end
 
     it 'raise AR::RNF if slug is not found' do
@@ -45,19 +45,17 @@ describe Program do
 
     it 'passes in the conditions to each Program model' do
       Program.where(air_status: %w{online onair})
-      .should eq [@kpcc_program.to_program, @external_program.to_program]
+      .should eq [@kpcc_program, @external_program]
     end
 
     it 'returns all programs if conditions is an empty hash' do
-      Program.where({}).sort
-      .should eq [@kpcc_program, @external_program,@another_program]
-      .map(&:to_program).sort
+      Program.where({}).sort_by(&:obj_key)
+      .should eq [@kpcc_program, @external_program,@another_program].sort_by(&:obj_key)
     end
 
     it "returns all programs if conditions is nil" do
-      Program.where(nil).sort
-      .should eq [@kpcc_program, @external_program,@another_program]
-      .map(&:to_program).sort
+      Program.where(nil).sort_by(&:obj_key)
+      .should eq [@kpcc_program, @external_program,@another_program].sort_by(&:obj_key)
     end
   end
 end


### PR DESCRIPTION
This has to come after #264. 

Speed up how we load programs, partially by removing the `.to_program` concept.