### PR TITLE
Make the pledge status in api/public/v3/schedule_occurrences optional.

### DIFF
--- a/app/controllers/api/public/v3/schedule_occurrences_controller.rb
+++ b/app/controllers/api/public/v3/schedule_occurrences_controller.rb
@@ -20,6 +20,7 @@ module Api::Public::V3
     def index
       @schedule_occurrences = ScheduleOccurrence.block(@start_time, @length)
       @pledge_drive = true
+      @display_pledge_status = params[:pledge_status]
       respond_with @schedule_occurrences
     end
 

--- a/app/views/api/public/v3/schedule_occurrences/index.json.jbuilder
+++ b/app/views/api/public/v3/schedule_occurrences/index.json.jbuilder
@@ -1,6 +1,8 @@
 json.partial! api_view_path("shared", "meta")
 
-#json.pledge_drive @pledge_drive || false
+if @display_pledge_status
+  json.pledge_drive @pledge_drive || false
+end
 json.schedule_occurrences do
   json.partial! api_view_path("schedule_occurrences", "collection"),
     schedule_occurrences: @schedule_occurrences

--- a/spec/controllers/api/public/v3/schedule_occurrences_controller_spec.rb
+++ b/spec/controllers/api/public/v3/schedule_occurrences_controller_spec.rb
@@ -37,10 +37,19 @@ describe Api::Public::V3::ScheduleOccurrencesController do
       response.body.should match /error/
     end
 
-    it "indicates if there is a pledge drive" do
-      get :index, request_params
-      pledge_drive_status = JSON.parse(response.body)["pledge_drive"]
-      expect((pledge_drive_status == true || pledge_drive_status == false)).to eq true
+    context "pledge_status parameter is present" do 
+      it "indicates if there is a pledge drive" do
+        get :index, request_params.merge({pledge_status: true})
+        pledge_drive_status = JSON.parse(response.body)["pledge_drive"]
+        expect((pledge_drive_status == true || pledge_drive_status == false)).to eq true
+      end
+    end
+    context "pledge_status parameter is not present" do
+      it "does not include pledge status" do
+        get :index, request_params
+        pledge_drive_status = JSON.parse(response.body)["pledge_drive"]
+        expect(pledge_drive_status).to eq nil
+      end
     end
 
   end


### PR DESCRIPTION
Just include ```pledge_status=true``` as a query parameter.