### PR TITLE
Fix the outpost preview to reflect unsaved changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'render_anywhere'
 gem 'dalli'
 
 ## Outpost
-gem 'outpost-cms', path: "~/workspace/outpost"
+gem 'outpost-cms', github:"SCPR/outpost", tag:"v0.1.6"
 gem 'outpost-publishing'
 gem 'outpost-asset_host'
 gem 'outpost-aggregator'
@@ -78,9 +78,6 @@ gem 'uglifier', '>= 1.3'
 
 group :development do
   gem 'pry'
-  gem 'pry-byebug'
-  gem 'binding_of_caller'
-  gem 'better_errors'
 end
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'render_anywhere'
 gem 'dalli'
 
 ## Outpost
-gem 'outpost-cms', github:"SCPR/outpost", tag:"v0.1.7"
+gem 'outpost-cms', path: "~/workspace/outpost"
 gem 'outpost-publishing'
 gem 'outpost-asset_host'
 gem 'outpost-aggregator'
@@ -78,6 +78,9 @@ gem 'uglifier', '>= 1.3'
 
 group :development do
   gem 'pry'
+  gem 'pry-byebug'
+  gem 'binding_of_caller'
+  gem 'better_errors'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,18 @@ GIT
       secretary-rails (>= 1.0.0, < 3)
 
 GIT
+  remote: git://github.com/SCPR/outpost.git
+  revision: 925b5a833c7d140f1eac4360aa2e930c568d2aee
+  tag: v0.1.6
+  specs:
+    outpost-cms (0.1.6)
+      bcrypt-ruby (>= 3.0.0, < 4)
+      jquery-rails (~> 3.0)
+      kaminari (~> 0.15.1)
+      rails (>= 3.2, < 5)
+      select2-rails (= 3.4.1)
+
+GIT
   remote: git://github.com/SCPR/resque-pool.git
   revision: dc5523cbc452c8ebc5d117e90a01f01c6165db3f
   specs:
@@ -53,16 +65,6 @@ GIT
       builder (< 4)
       rspec (>= 2, < 4)
       rspec-core (!= 2.12.0)
-
-PATH
-  remote: ~/workspace/outpost
-  specs:
-    outpost-cms (0.1.6)
-      bcrypt-ruby (>= 3.0.0, < 4)
-      jquery-rails (~> 3.0)
-      kaminari (~> 0.15.1)
-      rails (>= 3.2, < 5)
-      select2-rails (= 3.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -111,17 +113,9 @@ GEM
     bcrypt (3.1.7)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
-    better_errors (2.1.1)
-      coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
-      rack (>= 0.9.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.2)
-    byebug (4.0.5)
-      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -145,14 +139,12 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     dalli (2.7.2)
     database_cleaner (1.4.1)
     dbsync (1.0.0.beta4)
       cocaine (>= 0.5.0, < 0.6)
-    debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     diffy (3.0.7)
     eco (1.0.0)
@@ -275,9 +267,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.1.0)
-      byebug (~> 4.0)
-      pry (~> 0.10)
     rack (1.6.1)
     rack-protection (1.5.3)
       rack
@@ -444,8 +433,6 @@ DEPENDENCIES
   asset_host_client!
   audio_vision (~> 1.0)
   bcrypt-ruby (~> 3.1.0)
-  better_errors
-  binding_of_caller
   bootstrap-sass (~> 2.2)
   capybara (~> 2.0)
   carrierwave (~> 0.6)
@@ -486,7 +473,6 @@ DEPENDENCIES
   pmp (= 0.4.0)
   postmark-rails (~> 0.6.0)
   pry
-  pry-byebug
   rack-utf8_sanitizer
   rails (~> 4.2.0)
   rb-fsevent (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,18 +17,6 @@ GIT
       secretary-rails (>= 1.0.0, < 3)
 
 GIT
-  remote: git://github.com/SCPR/outpost.git
-  revision: 883d71e563127f3d848d77a3e46c0b74dc46b08c
-  tag: v0.1.7
-  specs:
-    outpost-cms (0.1.7)
-      bcrypt-ruby (>= 3.0.0, < 4)
-      jquery-rails (~> 3.0)
-      kaminari (~> 0.15.1)
-      rails (>= 3.2, < 5)
-      select2-rails (= 3.4.1)
-
-GIT
   remote: git://github.com/SCPR/resque-pool.git
   revision: dc5523cbc452c8ebc5d117e90a01f01c6165db3f
   specs:
@@ -65,6 +53,16 @@ GIT
       builder (< 4)
       rspec (>= 2, < 4)
       rspec-core (!= 2.12.0)
+
+PATH
+  remote: ~/workspace/outpost
+  specs:
+    outpost-cms (0.1.6)
+      bcrypt-ruby (>= 3.0.0, < 4)
+      jquery-rails (~> 3.0)
+      kaminari (~> 0.15.1)
+      rails (>= 3.2, < 5)
+      select2-rails (= 3.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -113,9 +111,17 @@ GEM
     bcrypt (3.1.7)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -139,12 +145,14 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     dalli (2.7.2)
     database_cleaner (1.4.1)
     dbsync (1.0.0.beta4)
       cocaine (>= 0.5.0, < 0.6)
+    debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     diffy (3.0.7)
     eco (1.0.0)
@@ -267,6 +275,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     rack (1.6.1)
     rack-protection (1.5.3)
       rack
@@ -433,6 +444,8 @@ DEPENDENCIES
   asset_host_client!
   audio_vision (~> 1.0)
   bcrypt-ruby (~> 3.1.0)
+  better_errors
+  binding_of_caller
   bootstrap-sass (~> 2.2)
   capybara (~> 2.0)
   carrierwave (~> 0.6)
@@ -473,6 +486,7 @@ DEPENDENCIES
   pmp (= 0.4.0)
   postmark-rails (~> 0.6.0)
   pry
+  pry-byebug
   rack-utf8_sanitizer
   rails (~> 4.2.0)
   rb-fsevent (~> 0.9)

--- a/app/controllers/outpost/news_stories_controller.rb
+++ b/app/controllers/outpost/news_stories_controller.rb
@@ -24,11 +24,11 @@ class Outpost::NewsStoriesController < Outpost::ResourceController
   #----------------
 
   def preview
-    @entry = Outpost.obj_by_key(unescaped_params[:obj_key]) || NewsStory.new
+    @entry = Outpost.obj_by_key(params[:obj_key]) || NewsStory.new
 
     with_rollback @entry do
 
-      @entry.assign_attributes(unescaped_params[:news_story])
+      @entry.assign_attributes(unescape_params(params[:news_story]))
 
       if @entry.unconditionally_valid?
         @title = @entry.to_title
@@ -45,9 +45,9 @@ class Outpost::NewsStoriesController < Outpost::ResourceController
 
   private
 
-  def unescaped_params
+  def unescape_params params
     # Takes params values that are interpreted as binary and convert them to UTF-8.
-    @unescaped_params ||= params.transform_values { |v|
+    params.transform_values { |v|
       if v.respond_to?(:encoding) && v.encoding.to_s.include?("ASCII-8BIT")
         begin 
           CGI.unescape v 

--- a/app/controllers/outpost/news_stories_controller.rb
+++ b/app/controllers/outpost/news_stories_controller.rb
@@ -24,10 +24,11 @@ class Outpost::NewsStoriesController < Outpost::ResourceController
   #----------------
 
   def preview
-    @entry = Outpost.obj_by_key(params[:obj_key]) || NewsStory.new
+    @entry = Outpost.obj_by_key(unescaped_params[:obj_key]) || NewsStory.new
 
     with_rollback @entry do
-      @entry.assign_attributes(params[:news_story])
+
+      @entry.assign_attributes(unescaped_params[:news_story])
 
       if @entry.unconditionally_valid?
         @title = @entry.to_title
@@ -40,5 +41,14 @@ class Outpost::NewsStoriesController < Outpost::ResourceController
         render_preview_validation_errors(@entry)
       end
     end
+  end
+  private
+  def unescaped_params
+    # Attempts to take params values that are interpreted as binary and convert them to UTF-8.
+    @unescaped_params ||= ->{
+      request.body.rewind
+      output = ActionController::Parameters.new Rack::Utils.parse_nested_query(CGI.unescape(request.body.read))
+      output
+    }.call
   end
 end

--- a/spec/controllers/outpost/news_stories_controller_spec.rb
+++ b/spec/controllers/outpost/news_stories_controller_spec.rb
@@ -43,6 +43,14 @@ describe Outpost::NewsStoriesController do
         response.should render_template "shared/new/_single_preview"
       end
 
+      it "assigns attributes that have not yet been saved" do
+        news_story = build :news_story, headline: "This is a story"
+        news_story.headline = "This is a different story"
+        post :preview, obj_key: news_story.obj_key, news_story: news_story.attributes
+        assigns(:entry).headline.should eq "This is a different story"
+        response.should render_template "shared/new/_single_preview"
+      end
+
       it "renders validation errors if the object is not unconditionally valid" do
         news_story = build :news_story, headline: "okay"
         post :preview, obj_key: news_story.obj_key, news_story: news_story.attributes.merge(headline: "")


### PR DESCRIPTION
My previous solution wasn't displaying updated news story content because, for some reason, Rails wasn't parsing nested attributes from the JSON form data.  I'd have preferred that solution but I couldn't get it to work without having to do something kind of janky on the SCPRv4 side.

So instead I have reverted to using the version of Outpost before my previous change and am now transforming the keys of the news story attributes from the parameters.  I've previewed dozens of news stories in staging and they all seem to work and reflect changes that have not yet been saved.

If anyone has any suggestions on how to better accomplish this, please let me know.  I made a bunch of different attempts that ended up having different side-effects.  