### PR TITLE
Remove float value that was being sent with audio complete event.

### DIFF
--- a/app/assets/javascripts/audio.js.coffee
+++ b/app/assets/javascripts/audio.js.coffee
@@ -38,7 +38,6 @@ class scpr.Audio
                     @sendEvent
                         action: 'complete'
                         nonInteraction: true
-                        value: @duration()
                     @state.started = false
             loadstart: () =>
                 @state = {}

--- a/app/assets/javascripts/audio.js.coffee
+++ b/app/assets/javascripts/audio.js.coffee
@@ -20,6 +20,7 @@ class scpr.Audio
                     @sendEvent
                         action: 'start'
                         nonInteraction: false
+                        value: 1
                     @state.started = true
             timeupdate: (e) =>
                 time = e.jPlayer.status.currentTime
@@ -38,6 +39,7 @@ class scpr.Audio
                     @sendEvent
                         action: 'complete'
                         nonInteraction: true
+                        value: 1
                     @state.started = false
             loadstart: () =>
                 @state = {}


### PR DESCRIPTION
Even though I can't immediately confirm this with my GA account(Real-time is not reflecting all of the events that I'm sending it), I have a hunch that most of the 'complete' events were not showing up because GA expects an integer as the event value and not a float; the event was still sending a value, which I had initially set to the current time of the audio.  If we look at the 'complete' events that do show up in GA, they all have non-float values(which is likely to happen occasionally).

Instead, I have changed it to just send a value of 1.  I'd like to merge this and wait and see if these events start coming in.