### PR TITLE
Add sanitization concern to clean up trailing whitespaces in model URL attributes.

### DIFF
--- a/app/concerns/concern/sanitizers/url_sanitizer.rb
+++ b/app/concerns/concern/sanitizers/url_sanitizer.rb
@@ -1,0 +1,14 @@
+module Concern
+  module Sanitizers
+    module UrlSanitizer
+      ## TO USE:
+      ## before_save ->{ sanitize_urls :url }
+      extend ActiveSupport::Concern
+      def sanitize_urls *attr_names
+        attr_names.each do |attr_name|
+          send("#{attr_name}=", send(attr_name).strip) if send(attr_name).respond_to?(:strip)
+        end
+      end
+    end 
+  end 
+end

--- a/app/models/breaking_news_alert.rb
+++ b/app/models/breaking_news_alert.rb
@@ -13,6 +13,10 @@ class BreakingNewsAlert < ActiveRecord::Base
 
   include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
+  include Concern::Sanitizers::UrlSanitizer
+
+  before_validation ->{ sanitize_urls :alert_url }
+
   ALERT_TYPES = {
     "break"   => "Breaking News",
     "audio"   => "Listen Live",

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,9 @@ class Event < ActiveRecord::Base
   include Concern::Callbacks::TouchCallback
   include Concern::Methods::CommentMethods
   include Concern::Methods::AssetDisplayMethods
+  include Concern::Sanitizers::UrlSanitizer
+
+  before_validation ->{ sanitize_urls :sponsor_url, :location_url, :rsvp_url }
 
   self.disqus_identifier_base = "events"
   self.public_route_key = "event"

--- a/app/models/related_link.rb
+++ b/app/models/related_link.rb
@@ -1,4 +1,8 @@
 class RelatedLink < ActiveRecord::Base
+  include Concern::Sanitizers::UrlSanitizer
+
+  before_validation ->{ sanitize_urls :url }
+
   TYPES = [
     ["Website", "website"],
     ["Related Story", "related"],

--- a/spec/concerns/concern/sanitizers/url_sanitizer_spec.rb
+++ b/spec/concerns/concern/sanitizers/url_sanitizer_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe Concern::Sanitizers::UrlSanitizer do
+  # Don't use a factory here because it fills in attributes that we don't want
+  # it to. We don't want the Generate* callbacks to be run.
+  subject { 
+    fake = Class.new
+    fake.class_eval{
+      attr_accessor :url
+      include Concern::Sanitizers::UrlSanitizer
+    }
+    fake.new
+  }
+
+  context "url contains leading and trailing whitespace" do
+    it "removes the whitespaces" do
+      subject.url = "  http://exampleurl.com  " 
+      subject.sanitize_urls :url
+      expect(subject.url).to eq "http://exampleurl.com"
+    end
+    it "does not mess with inline whitespaces" do
+      subject.url = "http://example url.com" 
+      subject.sanitize_urls :url
+      expect(subject.url).to eq "http://example url.com"
+    end
+  end
+
+  context "url doesn't contain leading and trailing whitespace" do
+    before :each do
+      subject.url = "http://exampleurl.com" 
+    end
+    it "does nothing to the url" do
+      subject.sanitize_urls :url
+      expect(subject.url).to eq "http://exampleurl.com"
+    end
+  end
+
+end

--- a/spec/models/breaking_news_alert_spec.rb
+++ b/spec/models/breaking_news_alert_spec.rb
@@ -13,6 +13,17 @@ describe BreakingNewsAlert do
     end
   end
 
+  describe 'alert url' do
+    context "validation" do
+      it "removes trailing whitespace" do
+        alert = create :breaking_news_alert, :unpublished
+        alert.alert_url = " http://someurl.com/ "
+        alert.valid?
+        alert.alert_url.should eq "http://someurl.com/"
+      end
+    end
+  end
+
 
   describe '#publish_mobile_notification' do
     before :each do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -258,4 +258,16 @@ describe Event do
       event.to_article.should be_a Article
     end
   end
+
+  describe "url sanitization" do
+    context "before validation" do 
+      it "removes trailing whitespaces from url attributes" do
+        event = build :event, sponsor_url: " http://someurl.com/ ", location_url: " http://someurl.com/ ", rsvp_url: " http://someurl.com/ "
+        event.valid?
+        expect(event.sponsor_url).to eq "http://someurl.com/"
+        expect(event.location_url).to eq "http://someurl.com/"
+        expect(event.rsvp_url).to eq "http://someurl.com/"
+      end
+    end
+  end
 end

--- a/spec/models/related_link_spec.rb
+++ b/spec/models/related_link_spec.rb
@@ -18,6 +18,14 @@ describe RelatedLink do
     end
   end
 
+  describe 'url sanitization' do
+    it 'should clean trailing whitespace' do
+      link = build :related_link, url: " http://scpr.org/news "
+      link.should be_valid
+      expect(link.url).to eq "http://scpr.org/news"
+    end
+  end
+
   describe "domain" do
     it "returns nil if link is blank" do
       link = build :related_link, url: nil


### PR DESCRIPTION
Addresses issue #279.  Adds a method that can be called by a 'before' callback which will strip preceding and trailing whitespaces in specified URL attributes.