### PR TITLE
Test redirects in the programs controller spec.

### DIFF
--- a/spec/controllers/programs_controller_spec.rb
+++ b/spec/controllers/programs_controller_spec.rb
@@ -15,6 +15,7 @@ describe ProgramsController do
         }
 
       assigns(:episode).should eq episode
+      expect(response).to redirect_to episode.public_path
     end
 
     it "assigns @date if date is given" do
@@ -43,6 +44,19 @@ describe ProgramsController do
         }
 
       assigns(:episode).should eq episode
+    end
+
+    it "finds no episode" do
+      program = create :kpcc_program
+      post :archive,
+        show: program.slug,
+        archive: {
+          "date(1i)" => "2001",
+          "date(2i)" => "1",
+          "date(3i)" => "1"
+        }
+      assigns(:episode).should eq nil
+      expect(response).to redirect_to featured_show_path(program.slug, anchor: "archive")
     end
   end
 
@@ -213,6 +227,25 @@ describe ProgramsController do
         segment = create :show_segment
         get :segment, segment.route_hash
         assigns(:segment).should eq segment
+      end
+    end
+
+    describe "public path" do 
+      context "the request path matches the public path" do
+        it "renders the correct layout" do
+          segment = create :show_segment
+          get :segment, segment.route_hash
+          expect(response).to render_template 'programs/kpcc/segment'
+        end
+      end
+      context "the request path does not match the public path for" do
+        it "redirect to the public path" do
+          segment = create :show_segment
+          route_hash = segment.route_hash
+          route_hash[:show] = "show-x" 
+          get :segment, route_hash
+          expect(response).to redirect_to segment.public_path
+        end
       end
     end
   end


### PR DESCRIPTION
Addresses issue #275.

I added testing for redirects in actions that use them.

The only one that I neglected to add a redirect test for was the #featured_show action, which does not have any testing for it at all.  I did not test it because I was not sure if it would be a waste of time(since, hypothetically, the old episode layout may get phased out).  Shall I leave it alone or test that as well?