### PR TITLE
Prevent news stories from crashing on save when being published and having tags added

### DIFF
--- a/app/concerns/concern/associations/tags_association.rb
+++ b/app/concerns/concern/associations/tags_association.rb
@@ -35,7 +35,7 @@ module Concern
       end
 
       def update_tag_timestamps_from_add(tag)
-        if self.respond_to?(:published_at) && self.published?
+        if self.respond_to?(:published_at) && self.published_at
           tag.update_timestamps(self.published_at)
         end
       end


### PR DESCRIPTION
There was an issue with news stories trying to update tags with its published_at timestamp before it had a chance to assign its published_at.  This fixes that by checking for the published_at existence before trying to update the tags and then let the tags get updated on after_save when the published_at has now been added.