### PR TITLE
Make NPR article importer adapt to failures and download more than 20 articles at a time.

### DIFF
--- a/app/importers/npr_article_importer.rb
+++ b/app/importers/npr_article_importer.rb
@@ -23,10 +23,11 @@ module NprArticleImporter
       # more often than that!
 
       npr_stories = []
-      offset    = 0
-
+      offset      = 0
+      start_date  = RemoteArticle.where(source: "npr").last.try(:published_at) || 1.hour.ago
+      end_date    = Time.zone.now
       begin
-        response  = fetch_stories(offset)
+        response  = fetch_stories(offset, start_date, end_date)
         npr_stories   += response
         offset    += 20
       end until response.size < 20
@@ -61,14 +62,14 @@ module NprArticleImporter
       added
     end
 
-    def fetch_stories offset
+    def fetch_stories offset, start_date, end_date
       NPR::Story.where(
           :id     => IMPORT_IDS,
-          :date   => ((RemoteArticle.where(source: "npr").last.try(:published_at) || 1.hour.ago)..Time.zone.now))
+          :date   => (start_date..end_date))
         .set(
           :requiredAssets   => 'text',
           :action           => "or")
-        .order("date descending").limit(20).offset(offset).to_a
+        .order("date ascending").limit(20).offset(offset).to_a
     end
 
 

--- a/app/importers/npr_article_importer.rb
+++ b/app/importers/npr_article_importer.rb
@@ -27,7 +27,7 @@ module NprArticleImporter
       start_date  = RemoteArticle.where(source: "npr").last.try(:published_at) || 1.hour.ago
       end_date    = Time.zone.now
       begin
-        response  = fetch_stories(offset, start_date, end_date)
+        response  = fetch_stories(start_date, end_date, offset)
         npr_stories   += response
         offset    += 20
       end until response.size < 20
@@ -62,7 +62,7 @@ module NprArticleImporter
       added
     end
 
-    def fetch_stories offset, start_date, end_date
+    def fetch_stories start_date, end_date, offset
       NPR::Story.where(
           :id     => IMPORT_IDS,
           :date   => (start_date..end_date))


### PR DESCRIPTION
#240

This extends upon my original change, except the importer will now download more than 20 articles by downloading multiple batches of 20(which is a limit of the NPR API).  I have confirmed that it downloads more than 20 unique articles at a time.