### PR TITLE
Enco id validation

### DIFF
--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -92,7 +92,7 @@ class Audio < ActiveRecord::Base
   validate :enco_info_is_present_together
   validate :audio_file_is_mp3
   validates :url, url: { allow_blank: true }
-  validates :enco_number, numericality: {only_integer: true}
+  validates :enco_number, numericality: {only_integer: true}, allow_blank: true
 
 
   before_save :determine_source, if: :audio_source_changed?

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -92,6 +92,7 @@ class Audio < ActiveRecord::Base
   validate :enco_info_is_present_together
   validate :audio_file_is_mp3
   validates :url, url: { allow_blank: true }
+  validates :enco_number, numericality: {only_integer: true}
 
 
   before_save :determine_source, if: :audio_source_changed?

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -227,7 +227,7 @@ describe Audio do
     end
 
     describe "enco_number format" do
-      context "containing non-numeric characters" do
+      context "trailing whitespace" do
         it "returns an error" do
           audio = build :audio,
             :enco_number    => "12345 ",
@@ -238,7 +238,7 @@ describe Audio do
           audio.errors[:enco_number].should include "must be an integer"
         end
       end
-      context "containing only numerical characters" do
+      context "exclusively numerical characters" do
         it "is valid" do
           audio = build :audio,
             :enco_number    => "12345",

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -225,6 +225,31 @@ describe Audio do
       audio.errors.keys.should include :enco_date
       audio.errors[:base].first.should match /must both be present/
     end
+
+    describe "enco_number format" do
+      context "containing non-numeric characters" do
+        it "returns an error" do
+          audio = build :audio,
+            :enco_number    => "12345 ",
+            :enco_date      => Date.today
+
+          audio.valid?.should eq false
+          audio.errors.keys.should include :enco_number
+          audio.errors[:enco_number].should include "must be an integer"
+        end
+      end
+      context "containing only numerical characters" do
+        it "is valid" do
+          audio = build :audio,
+            :enco_number    => "12345",
+            :enco_date      => Date.today
+
+          audio.valid?.should eq true
+          audio.errors.keys.should_not include :enco_number
+        end
+      end
+    end
+
   end
 
 


### PR DESCRIPTION
#248

Adds a validation so that the enco_number can only be numeric, so this rejects word characters and whitespace.