### PR TITLE
Eloqua naming conventions

### DIFF
--- a/app/models/breaking_news_alert.rb
+++ b/app/models/breaking_news_alert.rb
@@ -154,7 +154,7 @@ class BreakingNewsAlert < ActiveRecord::Base
         :formats    => [:text],
         :locals     => { alert: self }).to_s,
 
-      :name        => "[scpr-alert] #{self.headline[0..30]}",
+      :name        => "[alert #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
       :description => "SCPR Breaking News Alert\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{alert_subject}",
       :subject     => alert_subject,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -121,7 +121,7 @@ class Edition < ActiveRecord::Base
     eloqua_emails.create({
       :html_template   => "/editions/email/template",
       :plain_text_template   => "/editions/email/template",
-      :name        => "[tsl #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
+      :name        => "[tsl #{Time.zone.now.strftime("%Y%m%-d")}] #{self.title[0..30]}",
       :description => "SCPR Short List\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{subject}",
       :subject     => subject,
@@ -135,7 +135,7 @@ class Edition < ActiveRecord::Base
     eloqua_emails.create({
       :html_template   => "/editions/email/monday/template",
       :plain_text_template   => "/editions/email/monday/template",
-      :name        => "[tslm #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
+      :name        => "[tslm #{Time.zone.now.strftime("%Y%m%-d")}] #{self.title[0..30]}",
       :description => "SCPR Monday Short List\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{subject}",
       :subject     => subject,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -121,7 +121,7 @@ class Edition < ActiveRecord::Base
     eloqua_emails.create({
       :html_template   => "/editions/email/template",
       :plain_text_template   => "/editions/email/template",
-      :name        => "[scpr-edition] #{self.title[0..30]}",
+      :name        => "[short-list #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
       :description => "SCPR Short List\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{subject}",
       :subject     => subject,
@@ -135,7 +135,7 @@ class Edition < ActiveRecord::Base
     eloqua_emails.create({
       :html_template   => "/editions/email/monday/template",
       :plain_text_template   => "/editions/email/monday/template",
-      :name        => "[scpr-edition-monday] #{self.title[0..30]}",
+      :name        => "[short-list-monday #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
       :description => "SCPR Monday Short List\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{subject}",
       :subject     => subject,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -121,7 +121,7 @@ class Edition < ActiveRecord::Base
     eloqua_emails.create({
       :html_template   => "/editions/email/template",
       :plain_text_template   => "/editions/email/template",
-      :name        => "[short-list #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
+      :name        => "[tsl #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
       :description => "SCPR Short List\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{subject}",
       :subject     => subject,
@@ -135,7 +135,7 @@ class Edition < ActiveRecord::Base
     eloqua_emails.create({
       :html_template   => "/editions/email/monday/template",
       :plain_text_template   => "/editions/email/monday/template",
-      :name        => "[short-list-monday #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
+      :name        => "[tslm #{Time.zone.now.strftime("%Y%m%-d")}] #{self.headline[0..30]}",
       :description => "SCPR Monday Short List\n" \
                       "Sent: #{Time.zone.now}\nSubject: #{subject}",
       :subject     => subject,

--- a/spec/models/breaking_news_alert_spec.rb
+++ b/spec/models/breaking_news_alert_spec.rb
@@ -162,7 +162,7 @@ describe BreakingNewsAlert do
     describe 'name' do
       it 'is a string with part of the headline in it' do
         alert.as_eloqua_email[:name]
-          .should eq "[scpr-alert] #{alert.headline[0..30]}"
+          .should match /\[alert \d{8}\] #{alert.headline[0..30]}/
       end
     end
 


### PR DESCRIPTION
#357

To make it easier for Jason to parse through scpr.org generated emails in Eloqua, I have changed the naming conventions for those emails.

The short list, for example, was originally:
```[scpr-edition] Lorem ipsum dolor sit amet...```

And is now:
```[tsl 20151027] Lorem ipsum dolor sit amet...```

The abbreviation for the Monday Short List is ```tslm```

The name for a Breaking News alert was changed from "scpr-alert" to simply "alert".