### PR TITLE
Provide context in audio links that don't currently have it

### DIFF
--- a/app/views/programs/kpcc/_segment.html.erb
+++ b/app/views/programs/kpcc/_segment.html.erb
@@ -11,7 +11,7 @@
 
             <%= render_asset article, context:"segments" %>
 
-            <%= content_widget "new/primary_audio", article %>
+            <%= content_widget "new/primary_audio", article, context: article.show.slug %>
 
 
             <%= render 'shared/new/social_share', article: article.to_article, cssClass: "pinned" %>
@@ -21,7 +21,7 @@
 
               <div class="primary">
 
-              <%= content_widget "new/extra_audio", article %>
+              <%= content_widget "new/extra_audio", article, context: article.show.slug %>
 
 
               <div class="prose-body">

--- a/app/views/programs/kpcc/_segment_preview.html.erb
+++ b/app/views/programs/kpcc/_segment_preview.html.erb
@@ -14,7 +14,7 @@
 
             <%= render_asset article, context:"segments" %>
 
-            <%= content_widget "new/primary_audio", article %>
+            <%= content_widget "new/primary_audio", article, context: article.show.slug %>
 
 
             <%= render 'shared/new/social_share', article: article.to_article, cssClass: "pinned" %>
@@ -24,7 +24,7 @@
 
               <div class="primary">
 
-              <%= content_widget "new/extra_audio", article %>
+              <%= content_widget "new/extra_audio", article, context: article.show.slug %>
 
 
               <div class="prose-body">

--- a/app/views/programs/kpcc/episode.html.erb
+++ b/app/views/programs/kpcc/episode.html.erb
@@ -22,7 +22,7 @@
       <div class="prose">
 
         <% if audio = @episode.audio.first %>
-          <%= content_widget "new/primary_audio", @episode, prompt: "Listen to this episode." %>
+          <%= content_widget "new/primary_audio", @episode, prompt: "Listen to this episode.", context: @episode.program.slug %>
         <% end %>
 
 

--- a/app/views/shared/new/_single.html.erb
+++ b/app/views/shared/new/_single.html.erb
@@ -13,7 +13,7 @@
                         <ul>
                         <% audio.each_with_index do |audio, index| %>
                             <li class="story-audio" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player">
-                                <a href="<%= url_with_params audio.url, via: 'website', context: 'news' %>" class="play-btn audio-toggler track-event" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
+                                <a href="<%= raw url_with_params audio.url, via: 'website', context: 'news' %>" class="play-btn audio-toggler track-event" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
                                     <b><%= format_clip_duration audio.duration %></b>
                                     <span><%= index == 0 ? "Listen" : "Extra Audio" %></span>
                                 </a>

--- a/app/views/shared/new/_single.html.erb
+++ b/app/views/shared/new/_single.html.erb
@@ -13,7 +13,7 @@
                         <ul>
                         <% audio.each_with_index do |audio, index| %>
                             <li class="story-audio" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player">
-                                <a href="<%= audio.url %>" class="play-btn audio-toggler track-event" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
+                                <a href="<%= url_with_params audio.url, via: 'website', context: 'news' %>" class="play-btn audio-toggler track-event" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
                                     <b><%= format_clip_duration audio.duration %></b>
                                     <span><%= index == 0 ? "Listen" : "Extra Audio" %></span>
                                 </a>

--- a/app/views/shared/new/_single_blog.html.erb
+++ b/app/views/shared/new/_single_blog.html.erb
@@ -13,7 +13,7 @@
                         <% audio.each_with_index do |audio, index| %>
                             <li class="story-audio">
                             <li class="story-audio" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player">
-                                <a href="<%= raw url_with_params audio.url, via: 'website', context: @episode.show.slug %>" class="play-btn audio-toggler" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
+                                <a href="<%= raw url_with_params audio.url, via: 'website', context: article.blog.slug %>" class="play-btn audio-toggler" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
                                     <b><%= format_clip_duration audio.duration %></b>
                                     <span><%= index == 0 ? "Listen" : "Extra Audio" %></span>
                                 </a>

--- a/app/views/shared/new/_single_blog.html.erb
+++ b/app/views/shared/new/_single_blog.html.erb
@@ -13,7 +13,7 @@
                         <% audio.each_with_index do |audio, index| %>
                             <li class="story-audio">
                             <li class="story-audio" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player">
-                                <a href="<%= audio.url %>" class="play-btn audio-toggler" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
+                                <a href="<%= raw url_with_params audio.url, via: 'website', context: @episode.show.slug %>" class="play-btn audio-toggler" title="<%= h(article.short_title) %>" data-duration="<%= audio.duration %>">
                                     <b><%= format_clip_duration audio.duration %></b>
                                     <span><%= index == 0 ? "Listen" : "Extra Audio" %></span>
                                 </a>


### PR DESCRIPTION
#365 #358

Audio links that did not include context & via params now do.  Will add more if any are found.