### PR TITLE
Use the slug of a podcast's program as the context for a podcast epis…

### DIFF
--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -82,6 +82,19 @@ class Podcast < ActiveRecord::Base
     { slug: self.slug }
   end
 
+  ## This is to provide the correct context parameter
+  ## for a podcast item URL since some of the podcast
+  ## slugs don't match their programs, making things 
+  ## difficult for analytics.  It first relies on the 
+  ## source slug and falls back on the slug attribute.
+  def context
+    if source = self.source
+      source.slug || self.slug
+    else
+      self.slug
+    end
+  end
+
 
   private
 

--- a/app/views/podcasts/podcast.xml.builder
+++ b/app/views/podcasts/podcast.xml.builder
@@ -49,7 +49,7 @@ cache ["v2", @podcast, @consumer], expires_in: 1.hour do # Podcasts will refresh
 
           item.enclosure({
             :url => url_with_params(audio.podcast_url, {
-              :context    => @podcast.slug,
+              :context    => @podcast.context,
               :via        => "podcast",
               :consumer   => @consumer,
             }),


### PR DESCRIPTION
#364 

Podcasts now provide a "context" which is the source program's slug or falls back on the existing slug attribute.