### PR TITLE
Redirect members from KPCC Plus to off air page

### DIFF
--- a/app/controllers/listen_controller.rb
+++ b/app/controllers/listen_controller.rb
@@ -1,5 +1,5 @@
 class ListenController < ApplicationController
-  before_filter :check_if_air_status, :require_pledge_token, only: [:pledge_free_stream]
+  before_filter :check_pledge_status, :require_pledge_token, only: [:pledge_free_stream]
 
   def index
     # grab eight hours worth of schedule, starting now
@@ -44,7 +44,7 @@ class ListenController < ApplicationController
 
   private
 
-  def check_if_air_status
+  def check_pledge_status
     return redirect_to("/listen_live/pledge-free/off-air") if !PLEDGE_DRIVE
   end
 

--- a/app/controllers/listen_controller.rb
+++ b/app/controllers/listen_controller.rb
@@ -1,5 +1,5 @@
 class ListenController < ApplicationController
-  before_filter :require_pledge_token, only: [:pledge_free_stream]
+  before_filter :check_if_air_status, :require_pledge_token, only: [:pledge_free_stream]
 
   def index
     # grab eight hours worth of schedule, starting now
@@ -29,7 +29,7 @@ class ListenController < ApplicationController
       authorized_user = parse_user_query.get.first
 
       # redirect to flat page if we can't find a valid user
-      return redirect_to '/pledge-free/error' unless authorized_user.present?
+      return redirect_to '/listen_live/pledge-free/error' unless authorized_user.present?
 
       authorized_user["viewsLeft"] = Parse::Increment.new(-1)
       authorized_user.save
@@ -39,13 +39,16 @@ class ListenController < ApplicationController
       end
       cookies.permanent[:member_session] = params[:pledgeToken]
       render layout: false
-
     end
   end
 
   private
 
+  def check_if_air_status
+    return redirect_to("/listen_live/pledge-free/off-air") if !PLEDGE_DRIVE
+  end
+
   def require_pledge_token
-    redirect_to '/pledge-free/error' unless params.has_key?(:pledgeToken) || cookies[:member_session].present?
+    redirect_to '/listen_live/pledge-free/error' unless params.has_key?(:pledgeToken) || cookies[:member_session].present?
   end
 end

--- a/app/views/listen/pledge_free_error.html.erb
+++ b/app/views/listen/pledge_free_error.html.erb
@@ -1,0 +1,13 @@
+<h1>Pledge-Free Stream: Error</h1>
+
+<p><strong>Oh no! Something went wrong</strong></p>
+
+<p>You're so close to hearing KPCC pledge-free, but the link you have used is not working.</p>
+
+<p>If you haven't pledged , you can <a href="https://scprcontribute.publicradio.org">make your donation online at kpcc.org</a>. When you give $60 or more, you’ll see a check-box for the pledge-free stream. Check that box, and we’ll send you an email with your unique link within 30 minutes of your donation.</p>
+
+<p>If you have pledged but haven’t received an email , you can email us at <a href="mailto:membership@kpcc.org?subject=Pledge%20Free%20Stream">membership@kpcc.org</a>, or give us a call at 626.583.5121, and we’ll see what the holdup is. Our member service lines are open 7am-7pm, Monday-Friday and 10am-4pm on Saturdays during the drive.</p>
+
+<p>For more information , please visit our <a href="http://www.scpr.org/pledge-free">Pledge-Free Stream FAQ</a>.</p>
+
+<div class="vert-divider"></div>

--- a/app/views/listen/pledge_free_off_air.html.erb
+++ b/app/views/listen/pledge_free_off_air.html.erb
@@ -1,0 +1,10 @@
+<h1>Sorry, KPCC Plus is Off-Air</h1>
+
+<p><strong>We aren’t in Membership Drive mode right now.</strong></p>
+
+<p>Not to worry - simply <a href="http://scpr.org/listen_live">visit the Listen Live page</a> to hear the normal programming you know and love.</p>
+
+<p>If you are a current member, we’ll e-mail you a link to access KPCC Plus again during our next drive. For more information about KPCC Plus, please visit the FAQs page.</p>
+
+<p>Happy listening!</p>
+<div class="vert-divider"></div>

--- a/app/views/listen/pledge_free_off_air.html.erb
+++ b/app/views/listen/pledge_free_off_air.html.erb
@@ -4,7 +4,7 @@
 
 <p>Not to worry - simply <a href="http://scpr.org/listen_live">visit the Listen Live page</a> to hear the normal programming you know and love.</p>
 
-<p>If you are a current member, we’ll e-mail you a link to access KPCC Plus again during our next drive. For more information about KPCC Plus, please visit the FAQs page.</p>
+<p>If you are a current member, we’ll e-mail you a link to access KPCC Plus again during our next drive. For more information about KPCC Plus, please visit the <a href="http://scpr.org/pledge-free">FAQs page</a>.</p>
 
 <p>Happy listening!</p>
 <div class="vert-divider"></div>

--- a/config/initializers/pledge_drive.rb
+++ b/config/initializers/pledge_drive.rb
@@ -1,0 +1,3 @@
+## Change to true to enable features/behavior that should happen
+## only during a drive
+PLEDGE_DRIVE = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Scprv4::Application.routes.draw do
   # Listen Live
   get '/listen_live/' => 'listen#index', as: :listen
   get '/listen_live/pledge-free' => 'listen#pledge_free_stream', as: :listen_pledge_free
+  get '/listen_live/pledge-free/off-air' => 'listen#pledge_free_off_air', as: :listen_pledge_free_off_air
+  get '/listen_live/pledge-free/error' => 'listen#pledge_free_error', as: :listen_pledge_free_error
 
 
   # Sections


### PR DESCRIPTION
#361
*It won't let me reopen the other pull request because I force pushed.*
The pledge free stream now redirects to a flatpage with a message and a link to the regular live stream.

Instead of using Flatpages, I changed the error page and off air page to be their own templates.

The only thing that's different than what is represented in the image below are the share icons, which don't share up with this implementation.

EDIT: Oh, and I linked the FAQ page reference to spcr.org/pledge-free.

![image](https://cloud.githubusercontent.com/assets/5193330/10922290/2d0760be-822f-11e5-8196-dab22749c725.png)
