### PR TITLE
PMP Importer should attribute the correct organization name to AHP articles and add their audio

### DIFF
--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -93,7 +93,7 @@ module PmpArticleImporter
         # Right now we're only pulling in Marketplace stories.
         news_agency = remote_article.news_agency || "PMP"
 
-        article.source        = news_agency.downcase
+        article.source        = news_agency.downcase.gsub(" ", "_")
         article.news_agency   = news_agency
       end
 

--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -3,8 +3,6 @@ module PmpArticleImporter
 
   SOURCE     = "pmp"
   ENDPOINT   = "https://api.pmp.io/"
-  TAG        = "marketplace"
-  COLLECTION = "4c6e24e5-484f-49e8-be8d-452cfddd6252"
   PROFILE    = "story"
   LIMIT      = 10
 
@@ -22,8 +20,8 @@ module PmpArticleImporter
       ## Stories are downloaded in two ways: a query on a tag(marketplace) and from
       ## a collection that is specific to veteran stories.  Both sets of results are
       ## concatenated to the stories array.
-      stories.concat download_stories("Marketplace", tag: TAG)
-      stories.concat download_stories("American Homefront Project", collection: COLLECTION)
+      stories.concat download_stories("Marketplace", tag: "marketplace")
+      stories.concat download_stories("American Homefront Project", collection: "4c6e24e5-484f-49e8-be8d-452cfddd6252")
 
       stories
     end

--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -26,12 +26,12 @@ module PmpArticleImporter
       stories
     end
 
-    def download_stories publisher_name, query={}
+    def download_stories news_agency_name, query={}
       added = []
       stories = pmp.root.query['urn:collectiondoc:query:docs']
         .where({profile: PROFILE, limit: LIMIT}.merge(query))
         .retrieve.items
-      log "#{stories.size} PMP stories from #{publisher_name} found"
+      log "#{stories.size} PMP stories from #{news_agency_name} found"
       stories.reject { |s|
         RemoteArticle.exists?(source: SOURCE, article_id: s.guid)
       }.each do |story|
@@ -54,7 +54,7 @@ module PmpArticleImporter
           :published_at   => published,
           :url            => url,
           :is_new         => true,
-          :publisher      => publisher_name
+          :news_agency      => news_agency_name
         )
 
         if cached_article.save
@@ -91,10 +91,10 @@ module PmpArticleImporter
         # TODO: This is temporary, at some point we'll need to figure out
         # how to determine the "source" of an article from PMP.
         # Right now we're only pulling in Marketplace stories.
-        publisher = remote_article.publisher || "PMP"
+        news_agency = remote_article.news_agency || "PMP"
 
-        article.source        = publisher.downcase
-        article.news_agency   = publisher
+        article.source        = news_agency.downcase
+        article.news_agency   = news_agency
       end
 
       # Bylines

--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -93,8 +93,10 @@ module PmpArticleImporter
         # TODO: This is temporary, at some point we'll need to figure out
         # how to determine the "source" of an article from PMP.
         # Right now we're only pulling in Marketplace stories.
-        article.source        = remote_article.publisher.downcase
-        article.news_agency   = remote_article.publisher
+        publisher = remote_article.publisher || "PMP"
+
+        article.source        = publisher.downcase
+        article.news_agency   = publisher
       end
 
       # Bylines

--- a/app/models/content_byline.rb
+++ b/app/models/content_byline.rb
@@ -39,7 +39,10 @@ class ContentByline < ActiveRecord::Base
       extra     = elements[:extra]
 
       names = [primary, secondary].reject { |e| e.blank? }.join(" with ")
-      [names, extra].reject { |e| e.blank? }.join(" | ")
+      # Sometimes the primary byline of a story might be the same as its 
+      # secondary or extra(as with remote articles), so we call #uniq on
+      # the array of names to prevent duplication.
+      [names, extra].reject { |e| e.blank? }.uniq.join(" | ")
     end
   end
 

--- a/app/models/news_story.rb
+++ b/app/models/news_story.rb
@@ -50,7 +50,8 @@ class NewsStory < ActiveRecord::Base
     ['New America Media',           'new_america'],
     ['NPR & KPCC',                  'npr_kpcc'],
     ['Center for Health Reporting', 'chr'],
-    ['Marketplace',                 'marketplace']
+    ['Marketplace',                 'marketplace'],
+    ['American Homefront Porject',  'american_homefront_project']
   ]
 
   scope :with_article_includes, ->() { includes(:category,:assets,:audio,:tags,:bylines,bylines:[:user]) }

--- a/app/models/news_story.rb
+++ b/app/models/news_story.rb
@@ -51,7 +51,7 @@ class NewsStory < ActiveRecord::Base
     ['NPR & KPCC',                  'npr_kpcc'],
     ['Center for Health Reporting', 'chr'],
     ['Marketplace',                 'marketplace'],
-    ['American Homefront Porject',  'american_homefront_project']
+    ['American Homefront Project',  'american_homefront_project']
   ]
 
   scope :with_article_includes, ->() { includes(:category,:assets,:audio,:tags,:bylines,bylines:[:user]) }

--- a/db/migrate/20151029212124_add_publisher_field_to_remote_article.rb
+++ b/db/migrate/20151029212124_add_publisher_field_to_remote_article.rb
@@ -1,0 +1,5 @@
+class AddPublisherFieldToRemoteArticle < ActiveRecord::Migration
+  def change
+    add_column :remote_articles, :publisher, :string, index: true
+  end
+end

--- a/db/migrate/20151029212124_add_publisher_field_to_remote_article.rb
+++ b/db/migrate/20151029212124_add_publisher_field_to_remote_article.rb
@@ -1,5 +1,5 @@
 class AddPublisherFieldToRemoteArticle < ActiveRecord::Migration
   def change
-    add_column :remote_articles, :publisher, :string, index: true
+    add_column :remote_articles, :news_agency, :string, index: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -733,7 +733,7 @@ ActiveRecord::Schema.define(version: 20151029212124) do
     t.string   "source",       limit: 255
     t.datetime "created_at",                                     null: false
     t.datetime "updated_at",                                     null: false
-    t.string   "publisher",    limit: 255
+    t.string   "news_agency",  limit: 255
   end
 
   add_index "remote_articles", ["article_id", "source"], name: "index_remote_articles_on_article_id_and_source", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150827162731) do
+ActiveRecord::Schema.define(version: 20151029212124) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -733,6 +733,7 @@ ActiveRecord::Schema.define(version: 20150827162731) do
     t.string   "source",       limit: 255
     t.datetime "created_at",                                     null: false
     t.datetime "updated_at",                                     null: false
+    t.string   "publisher",    limit: 255
   end
 
   add_index "remote_articles", ["article_id", "source"], name: "index_remote_articles_on_article_id_and_source", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151029212124) do
+ActiveRecord::Schema.define(version: 20151030202328) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255

--- a/spec/factories/remote_articles.rb
+++ b/spec/factories/remote_articles.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
     url "http://marketplace.org/wat.html"
     article_id "fe111285-92c5-f5de-7b34-8a720d5fc750"
     is_new true
-    news_agency {["Marketplace", "NPR", "American Homefront Project"].sample}
+    news_agency "Marketplace"
   end
 
 end

--- a/spec/factories/remote_articles.rb
+++ b/spec/factories/remote_articles.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     url "http://npr.org/wat.html"
     article_id 12345
     is_new true
+    publisher "NPR"
   end
 
   factory :pmp_article, class: "RemoteArticle" do
@@ -20,6 +21,7 @@ FactoryGirl.define do
     url "http://marketplace.org/wat.html"
     article_id "fe111285-92c5-f5de-7b34-8a720d5fc750"
     is_new true
+    publisher {["Marketplace", "NPR", "American Homefront Project"].sample}
   end
 
 end

--- a/spec/factories/remote_articles.rb
+++ b/spec/factories/remote_articles.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     url "http://npr.org/wat.html"
     article_id 12345
     is_new true
-    publisher "NPR"
+    news_agency "NPR"
   end
 
   factory :pmp_article, class: "RemoteArticle" do
@@ -21,7 +21,7 @@ FactoryGirl.define do
     url "http://marketplace.org/wat.html"
     article_id "fe111285-92c5-f5de-7b34-8a720d5fc750"
     is_new true
-    publisher {["Marketplace", "NPR", "American Homefront Project"].sample}
+    news_agency {["Marketplace", "NPR", "American Homefront Project"].sample}
   end
 
 end

--- a/spec/fixtures/api/pmp/ahp_stories.json
+++ b/spec/fixtures/api/pmp/ahp_stories.json
@@ -1,0 +1,695 @@
+{
+  "version": "1.0",
+  "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=story",
+  "links": {
+    "item": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs/2512a8ec-2a12-7111-d9c1-6e2c3690dbe8"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/4d39cdbe-1d80-22a9-ed5b-8cd87414f206"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/eefd52da-9525-48c7-616d-2dea652b0dc9"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/18ec6d38-0342-7365-f4d5-33c613bff41e"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/870ecf61-b920-f14f-c3ed-17b93c2d7ec6"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/41e9d664-7115-97af-f0ba-c11b4c4821e7"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/e9cb2193-84f4-492d-1314-a6e2ee623eb7"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/fc317f6f-2172-d0ba-e40c-b6cb57b3656f"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/fe111285-92c5-f5de-7b34-8a720d5fc750"
+      }
+    ],
+    "navigation": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b",
+        "rels": [
+          "self"
+        ],
+        "totalitems": 535,
+        "totalpages": 54,
+        "pagenum": 1
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b&offset=10",
+        "rels": [
+          "next"
+        ],
+        "pagenum": 2
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b",
+        "rels": [
+          "first"
+        ],
+        "pagenum": 1
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b&offset=530",
+        "rels": [
+          "last"
+        ],
+        "pagenum": 54
+      }
+    ],
+    "query": [
+      {
+        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for users",
+        "rels": [
+          "urn:collectiondoc:query:users"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/groups{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for groups",
+        "rels": [
+          "urn:collectiondoc:query:groups"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/profiles{/guid}",
+        "title": "Access profiles",
+        "rels": [
+          "urn:collectiondoc:hreftpl:profiles"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/profiles{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for profiles",
+        "rels": [
+          "urn:collectiondoc:query:profiles"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/schemas{/guid}",
+        "title": "Access schemas",
+        "rels": [
+          "urn:collectiondoc:hreftpl:schemas"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for schemas",
+        "rels": [
+          "urn:collectiondoc:query:schemas"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/docs{/guid}{?limit,offset}",
+        "title": "Access documents",
+        "rels": [
+          "urn:collectiondoc:hreftpl:docs"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval",
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/docs{?guid,limit,offset,tag,collection,text,searchsort,has,author,distributor,distributorgroup,startdate,enddate,profile,language}",
+        "title": "Query for documents",
+        "rels": [
+          "urn:collectiondoc:query:docs"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval",
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "author": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "distributor": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "distributorgroup": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "startdate": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "enddate": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "profile": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "language": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/guids",
+        "title": "Generate guids",
+        "rels": [
+          "urn:collectiondoc:query:guids"
+        ],
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "accept-post": [
+            "application/x-www-form-urlencoded"
+          ]
+        },
+        "type": "application/json"
+      }
+    ],
+    "edit": [
+      {
+        "href-template": "https://publish-sandbox.pmp.io/docs{/guid}",
+        "title": "Document Save",
+        "rels": [
+          "urn:collectiondoc:form:documentsave"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Collection.doc-JSON-Media-Type"
+        }
+      },
+      {
+        "href-template": "https://publish-sandbox.pmp.io/profiles{/guid}",
+        "title": "Profile Save",
+        "rels": [
+          "urn:collectiondoc:form:profilesave"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Profile-profile"
+        }
+      },
+      {
+        "href-template": "https://publish-sandbox.pmp.io/schemas{/guid}",
+        "title": "Schema Save",
+        "rels": [
+          "urn:collectiondoc:form:schemasave"
+        ],
+        "href-vars": {
+          "guid": "xhttp://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Schema-profile"
+        }
+      },
+      {
+        "href": "https://publish-sandbox.pmp.io/files",
+        "title": "Upload a rich media file",
+        "rels": [
+          "urn:collectiondoc:form:mediaupload"
+        ],
+        "href-vars": {
+          "submission": "http://docs.pmp.io/wiki/Media-File-Upload"
+        },
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "accept-post": [
+            "multipart/form-data"
+          ]
+        }
+      }
+    ],
+    "auth": [
+      {
+        "href": "https://api-sandbox.pmp.io/auth/access_token",
+        "title": "Issue OAuth2 Token",
+        "rels": [
+          "urn:collectiondoc:form:issuetoken"
+        ],
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Authentication-Model#token-management"
+        }
+      },
+      {
+        "href": "https://publish-sandbox.pmp.io/auth/access_token",
+        "title": "Revoke OAuth2 Token",
+        "rels": [
+          "urn:collectiondoc:form:revoketoken"
+        ],
+        "hints": {
+          "allow": [
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Authentication-Model#revoke-a-token"
+        }
+      }
+    ]
+  },
+  "items": [
+    {
+      "version": "1.0",
+      "href": "https://api-sandbox.pmp.io/docs/2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
+      "attributes": {
+        "valid": {
+          "from": "2013-09-30T20:43:01+00:00",
+          "to": "3013-09-30T20:43:01+00:00"
+        },
+        "created": "2014-01-30T05:30:53+00:00",
+        "modified": "2014-01-30T05:30:53+00:00",
+        "contenttemplated": "<p>This final note today,&nbsp;in which the phrase time is money,&nbsp;is established once again as a truism.</p>\n<p>From the 2013 Drive-Thru Performance Study,&nbsp;by the fast-food trade publication QSR Magazine:&nbsp;Last year, the average McDonald's drive-through customer waited 189.5 seconds for her order. That's a&nbsp;tad more than three minutes.</p>\n<p>It matters, because the big chains do 60-70 percent of their business at the drive-through window.</p>\n<p>The record?&nbsp;Wendy's...back in 2003.&nbsp;116 seconds, or less than two minutes.</p>\n<p>Nobody's been close since.</p>",
+        "guid": "x2512a8ec-2a12-7111-d9c1-6e2c3690dbe9",
+        "teaser": "A new survey looks at the average time spent in the drive-through window.",
+        "contentencoded": "<p>This final note today,&nbsp;in which the phrase time is money,&nbsp;is established once again as a truism.</p>\n<p>From the 2013 Drive-Thru Performance Study,&nbsp;by the fast-food trade publication QSR Magazine:&nbsp;Last year, the average McDonald's drive-through customer waited 189.5 seconds for her order. That's a&nbsp;tad more than three minutes.</p>\n<p>It matters, because the big chains do 60-70 percent of their business at the drive-through window.</p>\n<p>The record?&nbsp;Wendy's...back in 2003.&nbsp;116 seconds, or less than two minutes.</p>\n<p>Nobody's been close since.</p>",
+        "byline": "Ryssdal, Kai",
+        "hreflang": "en",
+        "description": "A new survey looks at the average time spent in the drive-through window.",
+        "tags": [
+          "Final Note",
+          "APM_TESTING",
+          "PMP:Marketplace_PMP",
+          "Marketplace for Monday, September 30, 2013",
+          "2512a8ec2a127111d9c16e2c3690dbe8",
+          "Marketplace",
+          "Business"
+        ],
+        "published": "2013-09-30T20:43:01+00:00",
+        "title": "Serving billions and billions: In less than 3 minutes"
+      },
+      "links": {
+        "profile": [
+          {
+            "href": "https://api-sandbox.pmp.io/profiles/story",
+            "title": "APMStory"
+          }
+        ],
+        "distributor": [],
+        "copyright": [
+          {
+            "href": "http://www.publicradio.org/terms",
+            "title": "Copyright (C) 2013 American Public Media Group"
+          }
+        ],
+        "item": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/300b3409-4631-3f60-bd8f-e15e47b652b5"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df",
+            "title": "Marketplace for Monday, September 30, 2013"
+          }
+        ],
+        "alternate": [
+          {
+            "href": "http://www.marketplace.org/topics/business/final-note/serving-billions-and-billions-less-3-minutes",
+            "type": "text/html"
+          }
+        ],
+        "creator": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+          }
+        ],
+        "navigation": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs?guid=x2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
+            "rels": [
+              "self"
+            ],
+            "totalitems": 1,
+            "totalpages": 1,
+            "pagenum": 1
+          }
+        ]
+      },
+      "items": [
+        {
+          "version": "1.0",
+          "href": "https://api-sandbox.pmp.io/docs/300b3409-4631-3f60-bd8f-e15e47b652b6",
+          "attributes": {
+            "valid": {
+              "from": "2013-05-23T23:46:03+00:00",
+              "to": "3013-05-23T23:46:03+00:00"
+            },
+            "created": "2014-01-30T05:30:36+00:00",
+            "modified": "2014-01-30T05:30:36+00:00",
+            "byline": "Mitchell Hartman",
+            "hreflang": "en",
+            "description": "At a McDonald's Drive-Through in Portland, Oregon, the Angus burgers have already been discontinued, though they're still available at other McDonald's in the city. The company has also discontinued the fruit and walnut salad and chicken selects, while adding a new egg-whites McMuffin.",
+            "tags": [
+              "Final Note",
+              "APM_TESTING",
+              "PMP:Marketplace_PMP",
+              "Marketplace for Monday, September 30, 2013",
+              "Marketplace",
+              "Business",
+              "300b340946313f60bd8fe15e47b652b5"
+            ],
+            "published": "2013-09-30T20:43:01+00:00",
+            "guid": "x300b3409-4631-3f60-bd8f-e15e47b652b5",
+            "title": "McDonald's Drive Thru with cancelled Angus burgers 2.jpg"
+          },
+          "links": {
+            "profile": [
+              {
+                "href": "https://api-sandbox.pmp.io/profiles/image",
+                "title": "APMImage"
+              }
+            ],
+            "enclosure": [
+              {
+                "href": "http://www.marketplace.org/sites/default/files/styles/primary-image-610x340/public/McDonald's%20Drive%20Thru%20with%20cancelled%20Angus%20burgers%202.jpg",
+                "type": "image/jpeg",
+                "meta": {
+                  "width": "610",
+                  "crop": "primary",
+                  "height": "340"
+                }
+              },
+              {
+                "href": "http://www.marketplace.org/sites/default/files/styles/square_thumbnail/public/McDonald's%20Drive%20Thru%20with%20cancelled%20Angus%20burgers%202.jpg",
+                "type": "image/jpeg",
+                "meta": {
+                  "width": 180,
+                  "crop": "small",
+                  "height": 180
+                }
+              }
+            ],
+            "distributor": [],
+            "copyright": [
+              {
+                "href": "http://www.publicradio.org/terms",
+                "title": "Copyright (C) 2013 American Public Media Group"
+              }
+            ],
+            "collection": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+                "title": "Marketplace"
+              },
+              {
+                "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+                "title": "Marketplace"
+              }
+            ],
+            "creator": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+              }
+            ],
+            "item": [],
+            "navigation": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs?guid=x300b3409-4631-3f60-bd8f-e15e47b652b5",
+                "rels": [
+                  "self"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "version": "1.0",
+      "href": "https://api-sandbox.pmp.io/docs/4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
+      "attributes": {
+        "valid": {
+          "from": "2013-09-30T19:52:58+00:00",
+          "to": "3013-09-30T19:52:58+00:00"
+        },
+        "created": "2014-01-30T05:30:51+00:00",
+        "modified": "2014-01-30T05:30:51+00:00",
+        "contenttemplated": "<p>As the House and Senate continue kicking spending plans back and forth, here is what you need to know:</p>\n<p><strong>A government shutdown does not mean an Obamacare shutdown</strong>. Even though House Republicans are pushing for changes to the Affordable Care Act, it is funded in such a way that it will continue even if there is a partial government shutdown. This means the “exchanges,” where people can search for coverage plans, <a href=\"http://www.marketplace.org/topics/economy/health-exchanges-go-live-tuesday-are-websites-ready\">are still set to be unveiled Tuesday as planned</a>.</p>\n<p><strong>A government shutdown will not save the government any money</strong>. In fact, a shutdown will cost the government money. <a href=\"http://www.marketplace.org/topics/economy/raising-debt-ceiling/shut-it-down-why-government-shutdown-costs-money\">Shutdowns that lasted about 22 days in the Clinton era cost about $1.5 billion</a>. A shutdown is not expected have a major effect on the October 17 deadline that the Obama Administration has given Congress to raise the nation’s borrowing limit.</p>\n<p><strong>Here is what will happen, according to President Obama, who spoke Monday afternoon:</strong></p>\n<blockquote>If you’re on Social Security, you will keep receiving your checks. If you’re on Medicare, your doctor will still see you. Everyone’s mail will still be delivered. And government operations related to national security or public safety will go on. Our troops will continue to serve with skill, honor, and courage. Air traffic controllers, prison guards, those who are with border control -- our Border Patrol will remain on their posts, but their paychecks will be delayed until the government reopens. NASA will shut down almost entirely, but Mission Control will remain open to support the astronauts serving on the Space Station.</blockquote>\n<p><strong>And here, according to the president, is what would change:</strong></p>\n<blockquote>Office buildings would close.&nbsp; Paychecks would be delayed.&nbsp; Vital services that seniors and veterans, women and children, businesses and our economy depend on would be hamstrung.&nbsp; Business owners would see delays in raising capital, seeking infrastructure permits, or rebuilding after Hurricane Sandy.&nbsp; Veterans who’ve sacrificed for their country will find their support centers unstaffed.&nbsp; Tourists will find every one of America’s national parks and monuments, from Yosemite to the Smithsonian to the Statue of Liberty, immediately closed.&nbsp; And of course, the communities and small businesses that rely on these national treasures for their livelihoods will be out of customers and out of luck.</blockquote>",
+        "guid": "x4d39cdbe-1d80-22a9-ed5b-8cd87414f207",
+        "teaser": "Democrats and Republicans appear unable to reach common ground on a budget before the government shuts down.",
+        "contentencoded": "<p>As the House and Senate continue kicking spending plans back and forth, here is what you need to know:</p>\n<p><strong>A government shutdown does not mean an Obamacare shutdown</strong>. Even though House Republicans are pushing for changes to the Affordable Care Act, it is funded in such a way that it will continue even if there is a partial government shutdown. This means the “exchanges,” where people can search for coverage plans, <a href=\"http://www.marketplace.org/topics/economy/health-exchanges-go-live-tuesday-are-websites-ready\">are still set to be unveiled Tuesday as planned</a>.</p>\n<p><strong>A government shutdown will not save the government any money</strong>. In fact, a shutdown will cost the government money. <a href=\"http://www.marketplace.org/topics/economy/raising-debt-ceiling/shut-it-down-why-government-shutdown-costs-money\">Shutdowns that lasted about 22 days in the Clinton era cost about $1.5 billion</a>. A shutdown is not expected have a major effect on the October 17 deadline that the Obama Administration has given Congress to raise the nation’s borrowing limit.</p>\n<p><strong>Here is what will happen, according to President Obama, who spoke Monday afternoon:</strong></p>\n<blockquote>If you’re on Social Security, you will keep receiving your checks. If you’re on Medicare, your doctor will still see you. Everyone’s mail will still be delivered. And government operations related to national security or public safety will go on. Our troops will continue to serve with skill, honor, and courage. Air traffic controllers, prison guards, those who are with border control -- our Border Patrol will remain on their posts, but their paychecks will be delayed until the government reopens. NASA will shut down almost entirely, but Mission Control will remain open to support the astronauts serving on the Space Station.</blockquote>\n<p><strong>And here, according to the president, is what would change:</strong></p>\n<blockquote>Office buildings would close.&nbsp; Paychecks would be delayed.&nbsp; Vital services that seniors and veterans, women and children, businesses and our economy depend on would be hamstrung.&nbsp; Business owners would see delays in raising capital, seeking infrastructure permits, or rebuilding after Hurricane Sandy.&nbsp; Veterans who’ve sacrificed for their country will find their support centers unstaffed.&nbsp; Tourists will find every one of America’s national parks and monuments, from Yosemite to the Smithsonian to the Statue of Liberty, immediately closed.&nbsp; And of course, the communities and small businesses that rely on these national treasures for their livelihoods will be out of customers and out of luck.</blockquote>",
+        "byline": "Gura, David",
+        "hreflang": "en",
+        "description": "Democrats and Republicans appear unable to reach common ground on a budget before the government shuts down.",
+        "tags": [
+          "APM_TESTING",
+          "PMP:Marketplace_PMP",
+          "4d39cdbe1d8022a9ed5b8cd87414f206",
+          "Marketplace for Monday, September 30, 2013",
+          "Marketplace",
+          "Economy"
+        ],
+        "published": "2013-09-30T19:52:58+00:00",
+        "title": "Why the shutdown won't save money: Fights in 90s cost $1.5B"
+      },
+      "links": {
+        "profile": [
+          {
+            "href": "https://api-sandbox.pmp.io/profiles/story",
+            "title": "APMStory"
+          }
+        ],
+        "distributor": [],
+        "copyright": [
+          {
+            "href": "http://www.publicradio.org/terms",
+            "title": "Copyright (C) 2013 American Public Media Group"
+          }
+        ],
+        "item": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/78e5706a-32dd-ba49-e386-b326945f1396"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df",
+            "title": "Marketplace for Monday, September 30, 2013"
+          }
+        ],
+        "alternate": [
+          {
+            "href": "http://www.marketplace.org/topics/economy/1201-am-will-my-lights-go-government-shutdown-explained",
+            "type": "text/html"
+          }
+        ],
+        "creator": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+          }
+        ],
+        "navigation": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs?guid=x4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
+            "rels": [
+              "self"
+            ],
+            "totalitems": 1,
+            "totalpages": 1,
+            "pagenum": 1
+          }
+        ]
+      },
+      "items": [
+        {
+          "version": "1.0",
+          "href": "https://api-sandbox.pmp.io/docs/78e5706a-32dd-ba49-e386-b326945f1397",
+          "attributes": {
+            "valid": {
+              "from": "2013-09-30T23:01:42+00:00",
+              "to": "3013-09-30T23:01:42+00:00"
+            },
+            "created": "2014-01-30T05:30:34+00:00",
+            "modified": "2014-01-30T05:30:34+00:00",
+            "byline": "Gura, David",
+            "hreflang": "en",
+            "description": "",
+            "tags": [
+              "APM_TESTING",
+              "PMP:Marketplace_PMP",
+              "Marketplace for Monday, September 30, 2013",
+              "Marketplace",
+              "78e5706a32ddba49e386b326945f1396",
+              "Economy"
+            ],
+            "published": "2013-09-30T19:52:58+00:00",
+            "guid": "x78e5706a-32dd-ba49-e386-b326945f1396",
+            "title": "marketplace_segment16_20130930_64.mp3"
+          },
+          "links": {
+            "profile": [
+              {
+                "href": "https://api-sandbox.pmp.io/profiles/audio",
+                "title": "APMAudio"
+              }
+            ],
+            "enclosure": [
+              {
+                "href": "apm-audio:/marketplace/segments/2013/09/30/marketplace_segment16_20130930_64.mp3",
+                "type": "audio/mpeg",
+                "meta": {
+                  "api": {
+                    "href": "http://api.publicradio.org/audio/v2?id=apm-audio:/marketplace/segments/2013/09/30/marketplace_segment16_20130930_64.mp3",
+                    "type": "application/json"
+                  }
+                }
+              }
+            ],
+            "distributor": [],
+            "copyright": [
+              {
+                "href": "http://www.publicradio.org/terms",
+                "title": "Copyright (C) 2013 American Public Media Group"
+              }
+            ],
+            "collection": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+                "title": "Marketplace"
+              },
+              {
+                "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+                "title": "Marketplace"
+              }
+            ],
+            "creator": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+              }
+            ],
+            "item": [],
+            "navigation": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs?guid=x78e5706a-32dd-ba49-e386-b326945f1396",
+                "rels": [
+                  "self"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/api/pmp/ahp_stories.json
+++ b/spec/fixtures/api/pmp/ahp_stories.json
@@ -1,695 +1,2548 @@
 {
-  "version": "1.0",
-  "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=story",
-  "links": {
-    "item": [
-      {
-        "href": "https://api-sandbox.pmp.io/docs/2512a8ec-2a12-7111-d9c1-6e2c3690dbe8"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/4d39cdbe-1d80-22a9-ed5b-8cd87414f206"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/eefd52da-9525-48c7-616d-2dea652b0dc9"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/18ec6d38-0342-7365-f4d5-33c613bff41e"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/870ecf61-b920-f14f-c3ed-17b93c2d7ec6"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/41e9d664-7115-97af-f0ba-c11b4c4821e7"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/e9cb2193-84f4-492d-1314-a6e2ee623eb7"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/fc317f6f-2172-d0ba-e40c-b6cb57b3656f"
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs/fe111285-92c5-f5de-7b34-8a720d5fc750"
-      }
-    ],
-    "navigation": [
-      {
-        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b",
-        "rels": [
-          "self"
-        ],
-        "totalitems": 535,
-        "totalpages": 54,
-        "pagenum": 1
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b&offset=10",
-        "rels": [
-          "next"
-        ],
-        "pagenum": 2
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b",
-        "rels": [
-          "first"
-        ],
-        "pagenum": 1
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b&offset=530",
-        "rels": [
-          "last"
-        ],
-        "pagenum": 54
-      }
-    ],
-    "query": [
-      {
-        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
-        "title": "Query for users",
-        "rels": [
-          "urn:collectiondoc:query:users"
-        ],
-        "href-vars": {
-          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/groups{?limit,offset,tag,collection,text,searchsort,has}",
-        "title": "Query for groups",
-        "rels": [
-          "urn:collectiondoc:query:groups"
-        ],
-        "href-vars": {
-          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/profiles{/guid}",
-        "title": "Access profiles",
-        "rels": [
-          "urn:collectiondoc:hreftpl:profiles"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/profiles{?limit,offset,tag,collection,text,searchsort,has}",
-        "title": "Query for profiles",
-        "rels": [
-          "urn:collectiondoc:query:profiles"
-        ],
-        "href-vars": {
-          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/schemas{/guid}",
-        "title": "Access schemas",
-        "rels": [
-          "urn:collectiondoc:hreftpl:schemas"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
-        "title": "Query for schemas",
-        "rels": [
-          "urn:collectiondoc:query:schemas"
-        ],
-        "href-vars": {
-          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/docs{/guid}{?limit,offset}",
-        "title": "Access documents",
-        "rels": [
-          "urn:collectiondoc:hreftpl:docs"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval",
-          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "offset": "http://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href-template": "https://api-sandbox.pmp.io/docs{?guid,limit,offset,tag,collection,text,searchsort,has,author,distributor,distributorgroup,startdate,enddate,profile,language}",
-        "title": "Query for documents",
-        "rels": [
-          "urn:collectiondoc:query:docs"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Content-Retrieval",
-          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "has": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "author": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "distributor": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "distributorgroup": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "startdate": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "enddate": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "profile": "http://docs.pmp.io/wiki/Content-Retrieval",
-          "language": "http://docs.pmp.io/wiki/Content-Retrieval"
-        },
-        "hints": {
-          "allow": [
-            "GET"
-          ]
-        }
-      },
-      {
-        "href": "https://api-sandbox.pmp.io/guids",
-        "title": "Generate guids",
-        "rels": [
-          "urn:collectiondoc:query:guids"
-        ],
-        "hints": {
-          "allow": [
-            "POST"
-          ],
-          "accept-post": [
-            "application/x-www-form-urlencoded"
-          ]
-        },
-        "type": "application/json"
-      }
-    ],
-    "edit": [
-      {
-        "href-template": "https://publish-sandbox.pmp.io/docs{/guid}",
-        "title": "Document Save",
-        "rels": [
-          "urn:collectiondoc:form:documentsave"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
-        },
-        "hints": {
-          "formats": [
-            "application/vnd.collection.doc+json"
-          ],
-          "allow": [
-            "PUT",
-            "DELETE"
-          ],
-          "docs": "http://docs.pmp.io/wiki/Collection.doc-JSON-Media-Type"
-        }
-      },
-      {
-        "href-template": "https://publish-sandbox.pmp.io/profiles{/guid}",
-        "title": "Profile Save",
-        "rels": [
-          "urn:collectiondoc:form:profilesave"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
-        },
-        "hints": {
-          "formats": [
-            "application/vnd.collection.doc+json"
-          ],
-          "allow": [
-            "PUT",
-            "DELETE"
-          ],
-          "docs": "http://docs.pmp.io/wiki/Profile-profile"
-        }
-      },
-      {
-        "href-template": "https://publish-sandbox.pmp.io/schemas{/guid}",
-        "title": "Schema Save",
-        "rels": [
-          "urn:collectiondoc:form:schemasave"
-        ],
-        "href-vars": {
-          "guid": "xhttp://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
-        },
-        "hints": {
-          "formats": [
-            "application/vnd.collection.doc+json"
-          ],
-          "allow": [
-            "PUT",
-            "DELETE"
-          ],
-          "docs": "http://docs.pmp.io/wiki/Schema-profile"
-        }
-      },
-      {
-        "href": "https://publish-sandbox.pmp.io/files",
-        "title": "Upload a rich media file",
-        "rels": [
-          "urn:collectiondoc:form:mediaupload"
-        ],
-        "href-vars": {
-          "submission": "http://docs.pmp.io/wiki/Media-File-Upload"
-        },
-        "hints": {
-          "allow": [
-            "POST"
-          ],
-          "accept-post": [
-            "multipart/form-data"
-          ]
-        }
-      }
-    ],
-    "auth": [
-      {
-        "href": "https://api-sandbox.pmp.io/auth/access_token",
-        "title": "Issue OAuth2 Token",
-        "rels": [
-          "urn:collectiondoc:form:issuetoken"
-        ],
-        "hints": {
-          "allow": [
-            "POST"
-          ],
-          "docs": "http://docs.pmp.io/wiki/Authentication-Model#token-management"
-        }
-      },
-      {
-        "href": "https://publish-sandbox.pmp.io/auth/access_token",
-        "title": "Revoke OAuth2 Token",
-        "rels": [
-          "urn:collectiondoc:form:revoketoken"
-        ],
-        "hints": {
-          "allow": [
-            "DELETE"
-          ],
-          "docs": "http://docs.pmp.io/wiki/Authentication-Model#revoke-a-token"
-        }
-      }
-    ]
-  },
-  "items": [
-    {
-      "version": "1.0",
-      "href": "https://api-sandbox.pmp.io/docs/2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
-      "attributes": {
-        "valid": {
-          "from": "2013-09-30T20:43:01+00:00",
-          "to": "3013-09-30T20:43:01+00:00"
-        },
-        "created": "2014-01-30T05:30:53+00:00",
-        "modified": "2014-01-30T05:30:53+00:00",
-        "contenttemplated": "<p>This final note today,&nbsp;in which the phrase time is money,&nbsp;is established once again as a truism.</p>\n<p>From the 2013 Drive-Thru Performance Study,&nbsp;by the fast-food trade publication QSR Magazine:&nbsp;Last year, the average McDonald's drive-through customer waited 189.5 seconds for her order. That's a&nbsp;tad more than three minutes.</p>\n<p>It matters, because the big chains do 60-70 percent of their business at the drive-through window.</p>\n<p>The record?&nbsp;Wendy's...back in 2003.&nbsp;116 seconds, or less than two minutes.</p>\n<p>Nobody's been close since.</p>",
-        "guid": "x2512a8ec-2a12-7111-d9c1-6e2c3690dbe9",
-        "teaser": "A new survey looks at the average time spent in the drive-through window.",
-        "contentencoded": "<p>This final note today,&nbsp;in which the phrase time is money,&nbsp;is established once again as a truism.</p>\n<p>From the 2013 Drive-Thru Performance Study,&nbsp;by the fast-food trade publication QSR Magazine:&nbsp;Last year, the average McDonald's drive-through customer waited 189.5 seconds for her order. That's a&nbsp;tad more than three minutes.</p>\n<p>It matters, because the big chains do 60-70 percent of their business at the drive-through window.</p>\n<p>The record?&nbsp;Wendy's...back in 2003.&nbsp;116 seconds, or less than two minutes.</p>\n<p>Nobody's been close since.</p>",
-        "byline": "Ryssdal, Kai",
-        "hreflang": "en",
-        "description": "A new survey looks at the average time spent in the drive-through window.",
-        "tags": [
-          "Final Note",
-          "APM_TESTING",
-          "PMP:Marketplace_PMP",
-          "Marketplace for Monday, September 30, 2013",
-          "2512a8ec2a127111d9c16e2c3690dbe8",
-          "Marketplace",
-          "Business"
-        ],
-        "published": "2013-09-30T20:43:01+00:00",
-        "title": "Serving billions and billions: In less than 3 minutes"
-      },
-      "links": {
-        "profile": [
-          {
-            "href": "https://api-sandbox.pmp.io/profiles/story",
-            "title": "APMStory"
-          }
-        ],
-        "distributor": [],
-        "copyright": [
-          {
-            "href": "http://www.publicradio.org/terms",
-            "title": "Copyright (C) 2013 American Public Media Group"
-          }
-        ],
+    "version": "1.0",
+    "href": "https://api.pmp.io/docs?limit=10&profile=story&collection=4c6e24e5-484f-49e8-be8d-452cfddd6252",
+    "links": {
         "item": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs/300b3409-4631-3f60-bd8f-e15e47b652b5"
-          }
-        ],
-        "collection": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
-            "title": "Marketplace"
-          },
-          {
-            "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
-            "title": "Marketplace"
-          },
-          {
-            "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df",
-            "title": "Marketplace for Monday, September 30, 2013"
-          }
-        ],
-        "alternate": [
-          {
-            "href": "http://www.marketplace.org/topics/business/final-note/serving-billions-and-billions-less-3-minutes",
-            "type": "text/html"
-          }
-        ],
-        "creator": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
-          }
+            {
+                "href": "https://api.pmp.io/docs/bbdd7e4e-bdbc-4927-ab2f-2fe2f708e603"
+            },
+            {
+                "href": "https://api.pmp.io/docs/d202ff38-208b-4b68-b005-ca820fccbabf"
+            },
+            {
+                "href": "https://api.pmp.io/docs/9511115b-75c7-42f4-bbcb-b874ec38da6f"
+            },
+            {
+                "href": "https://api.pmp.io/docs/58377506-f2e5-4fdf-a0bd-bf361b48a7fe"
+            },
+            {
+                "href": "https://api.pmp.io/docs/0b9574e8-4794-4fd3-94c8-887a7b53ec22"
+            },
+            {
+                "href": "https://api.pmp.io/docs/aef667c2-4a0d-420f-9f01-d7b77a2ce6b4"
+            },
+            {
+                "href": "https://api.pmp.io/docs/5be70df9-9fc4-41c0-b554-0dc1765e886b"
+            },
+            {
+                "href": "https://api.pmp.io/docs/159ce579-9a6f-4473-9125-aabd7d45def1"
+            },
+            {
+                "href": "https://api.pmp.io/docs/39d9c72a-e050-4794-8459-d708a103a2f2"
+            },
+            {
+                "href": "https://api.pmp.io/docs/46ec153e-521f-448f-9d79-3f822175500f"
+            }
         ],
         "navigation": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs?guid=x2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
-            "rels": [
-              "self"
-            ],
-            "totalitems": 1,
-            "totalpages": 1,
-            "pagenum": 1
-          }
-        ]
-      },
-      "items": [
-        {
-          "version": "1.0",
-          "href": "https://api-sandbox.pmp.io/docs/300b3409-4631-3f60-bd8f-e15e47b652b6",
-          "attributes": {
-            "valid": {
-              "from": "2013-05-23T23:46:03+00:00",
-              "to": "3013-05-23T23:46:03+00:00"
-            },
-            "created": "2014-01-30T05:30:36+00:00",
-            "modified": "2014-01-30T05:30:36+00:00",
-            "byline": "Mitchell Hartman",
-            "hreflang": "en",
-            "description": "At a McDonald's Drive-Through in Portland, Oregon, the Angus burgers have already been discontinued, though they're still available at other McDonald's in the city. The company has also discontinued the fruit and walnut salad and chicken selects, while adding a new egg-whites McMuffin.",
-            "tags": [
-              "Final Note",
-              "APM_TESTING",
-              "PMP:Marketplace_PMP",
-              "Marketplace for Monday, September 30, 2013",
-              "Marketplace",
-              "Business",
-              "300b340946313f60bd8fe15e47b652b5"
-            ],
-            "published": "2013-09-30T20:43:01+00:00",
-            "guid": "x300b3409-4631-3f60-bd8f-e15e47b652b5",
-            "title": "McDonald's Drive Thru with cancelled Angus burgers 2.jpg"
-          },
-          "links": {
-            "profile": [
-              {
-                "href": "https://api-sandbox.pmp.io/profiles/image",
-                "title": "APMImage"
-              }
-            ],
-            "enclosure": [
-              {
-                "href": "http://www.marketplace.org/sites/default/files/styles/primary-image-610x340/public/McDonald's%20Drive%20Thru%20with%20cancelled%20Angus%20burgers%202.jpg",
-                "type": "image/jpeg",
-                "meta": {
-                  "width": "610",
-                  "crop": "primary",
-                  "height": "340"
-                }
-              },
-              {
-                "href": "http://www.marketplace.org/sites/default/files/styles/square_thumbnail/public/McDonald's%20Drive%20Thru%20with%20cancelled%20Angus%20burgers%202.jpg",
-                "type": "image/jpeg",
-                "meta": {
-                  "width": 180,
-                  "crop": "small",
-                  "height": 180
-                }
-              }
-            ],
-            "distributor": [],
-            "copyright": [
-              {
-                "href": "http://www.publicradio.org/terms",
-                "title": "Copyright (C) 2013 American Public Media Group"
-              }
-            ],
-            "collection": [
-              {
-                "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
-                "title": "Marketplace"
-              },
-              {
-                "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
-                "title": "Marketplace"
-              }
-            ],
-            "creator": [
-              {
-                "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
-              }
-            ],
-            "item": [],
-            "navigation": [
-              {
-                "href": "https://api-sandbox.pmp.io/docs?guid=x300b3409-4631-3f60-bd8f-e15e47b652b5",
+            {
                 "rels": [
-                  "self"
-                ]
-              }
-            ]
-          }
-        }
-      ]
+                    "self"
+                ],
+                "href": "https://api.pmp.io/docs?profile=story&collection=4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                "totalitems": 11,
+                "totalpages": 2,
+                "pagenum": 1
+            },
+            {
+                "rels": [
+                    "next"
+                ],
+                "href": "https://api.pmp.io/docs?profile=story&collection=4c6e24e5-484f-49e8-be8d-452cfddd6252&offset=10",
+                "pagenum": 2
+            },
+            {
+                "rels": [
+                    "first"
+                ],
+                "href": "https://api.pmp.io/docs?profile=story&collection=4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                "pagenum": 1
+            },
+            {
+                "rels": [
+                    "last"
+                ],
+                "href": "https://api.pmp.io/docs?profile=story&collection=4c6e24e5-484f-49e8-be8d-452cfddd6252&offset=10",
+                "pagenum": 2
+            }
+        ],
+        "query": [
+            {
+                "href-template": "https://api.pmp.io/docs/{guid}{?limit,offset,scope}",
+                "title": "Access documents",
+                "rels": [
+                    "urn:collectiondoc:hreftpl:docs"
+                ],
+                "href-vars": {
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/groups/{guid}{?limit,offset,scope}",
+                "title": "Access groups",
+                "rels": [
+                    "urn:collectiondoc:hreftpl:groups"
+                ],
+                "href-vars": {
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/profiles/{guid}{?limit,offset,scope}",
+                "title": "Access profiles",
+                "rels": [
+                    "urn:collectiondoc:hreftpl:profiles"
+                ],
+                "href-vars": {
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/schemas/{guid}{?limit,offset,scope}",
+                "title": "Access schemas",
+                "rels": [
+                    "urn:collectiondoc:hreftpl:schemas"
+                ],
+                "href-vars": {
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/topics/{guid}{?limit,offset,scope}",
+                "title": "Access topics",
+                "rels": [
+                    "urn:collectiondoc:hreftpl:topics"
+                ],
+                "href-vars": {
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/users/{guid}{?limit,offset,scope}",
+                "title": "Access users",
+                "rels": [
+                    "urn:collectiondoc:hreftpl:users"
+                ],
+                "href-vars": {
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/docs{?guid,limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,language,profile,collection,item,has,creator,owner,distributor,distributorgroup,author,location,distance,text}",
+                "title": "Query for documents",
+                "rels": [
+                    "urn:collectiondoc:query:docs"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "language": "http://docs.pmp.io/Querying-the-API#language",
+                    "profile": "http://docs.pmp.io/Querying-the-API#profile",
+                    "collection": "http://docs.pmp.io/Querying-the-API#collection",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "has": "http://docs.pmp.io/Querying-the-API#has",
+                    "creator": "http://docs.pmp.io/Querying-the-API#creator",
+                    "owner": "http://docs.pmp.io/Querying-the-API#owner",
+                    "distributor": "http://docs.pmp.io/Querying-the-API#distributor",
+                    "distributorgroup": "http://docs.pmp.io/Querying-the-API#distributorgroup",
+                    "author": "http://docs.pmp.io/Querying-the-API#author",
+                    "location": "http://docs.pmp.io/Querying-the-API#location",
+                    "distance": "http://docs.pmp.io/Querying-the-API#distance",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/profiles{?guid,limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,collection,item,text}",
+                "title": "Query for profiles",
+                "rels": [
+                    "urn:collectiondoc:query:profiles"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "collection": "http://docs.pmp.io/Querying-the-API#collection",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/schemas{?guid,limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,collection,item,text}",
+                "title": "Query for schemas",
+                "rels": [
+                    "urn:collectiondoc:query:schemas"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "collection": "http://docs.pmp.io/Querying-the-API#collection",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/topics{?guid,limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,collection,item,text}",
+                "title": "Query for topics",
+                "rels": [
+                    "urn:collectiondoc:query:topics"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "collection": "http://docs.pmp.io/Querying-the-API#collection",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/users{?guid,limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,collection,item,location,distance,text}",
+                "title": "Query for users",
+                "rels": [
+                    "urn:collectiondoc:query:users"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "collection": "http://docs.pmp.io/Querying-the-API#collection",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "location": "http://docs.pmp.io/Querying-the-API#location",
+                    "distance": "http://docs.pmp.io/Querying-the-API#distance",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/groups{?guid,limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,collection,item,has,text}",
+                "title": "Query for groups",
+                "rels": [
+                    "urn:collectiondoc:query:groups"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "collection": "http://docs.pmp.io/Querying-the-API#collection",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "has": "http://docs.pmp.io/Querying-the-API#has",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            },
+            {
+                "href-template": "https://api.pmp.io/collection/{guid}/{?limit,offset,searchsort,startdate,enddate,startcreated,valid,writeable,scope,tag,itag,language,profile,item,has,creator,owner,distributor,distributorgroup,author,location,distance,text}",
+                "title": "Query within collection",
+                "rels": [
+                    "urn:collectiondoc:query:collection"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Querying-the-API#guid",
+                    "limit": "http://docs.pmp.io/Querying-the-API#limit",
+                    "offset": "http://docs.pmp.io/Querying-the-API#offset",
+                    "searchsort": "http://docs.pmp.io/Querying-the-API#searchsort",
+                    "startdate": "http://docs.pmp.io/Querying-the-API#startdate",
+                    "enddate": "http://docs.pmp.io/Querying-the-API#enddate",
+                    "startcreated": "http://docs.pmp.io/Querying-the-API#startcreated",
+                    "valid": "http://docs.pmp.io/Querying-the-API#valid",
+                    "writeable": "http://docs.pmp.io/Querying-the-API#writeable",
+                    "scope": "http://docs.pmp.io/Querying-the-API#scope",
+                    "tag": "http://docs.pmp.io/Querying-the-API#tag",
+                    "itag": "http://docs.pmp.io/Querying-the-API#itag",
+                    "language": "http://docs.pmp.io/Querying-the-API#language",
+                    "profile": "http://docs.pmp.io/Querying-the-API#profile",
+                    "item": "http://docs.pmp.io/Querying-the-API#item",
+                    "has": "http://docs.pmp.io/Querying-the-API#has",
+                    "creator": "http://docs.pmp.io/Querying-the-API#creator",
+                    "owner": "http://docs.pmp.io/Querying-the-API#owner",
+                    "distributor": "http://docs.pmp.io/Querying-the-API#distributor",
+                    "distributorgroup": "http://docs.pmp.io/Querying-the-API#distributorgroup",
+                    "author": "http://docs.pmp.io/Querying-the-API#author",
+                    "location": "http://docs.pmp.io/Querying-the-API#location",
+                    "distance": "http://docs.pmp.io/Querying-the-API#distance",
+                    "text": "http://docs.pmp.io/Querying-the-API#text"
+                },
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ]
+                }
+            }
+        ],
+        "edit": [
+            {
+                "href-template": "https://publish.pmp.io/docs/{guid}",
+                "title": "Document Save",
+                "rels": [
+                    "urn:collectiondoc:form:documentsave"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "formats": [
+                        "application/vnd.collection.doc+json"
+                    ],
+                    "allow": [
+                        "PUT"
+                    ],
+                    "docs": "http://docs.pmp.io/Collection.doc-JSON-Media-Type"
+                }
+            },
+            {
+                "href-template": "https://publish.pmp.io/docs/{guid}",
+                "title": "Document Delete",
+                "rels": [
+                    "urn:collectiondoc:form:documentdelete"
+                ],
+                "href-vars": {
+                    "guid": "http://docs.pmp.io/Globaly-Unique-Identifiers-for-PMP-Documents"
+                },
+                "hints": {
+                    "allow": [
+                        "DELETE"
+                    ]
+                }
+            }
+        ],
+        "auth": [
+            {
+                "href": "https://api.pmp.io/auth/credentials",
+                "title": "List OAuth2 Credentials",
+                "rels": [
+                    "urn:collectiondoc:form:listcredentials"
+                ],
+                "hints": {
+                    "allow": [
+                        "GET"
+                    ],
+                    "docs": "http://docs.pmp.io/Authenticating-with-the-API#testing-access"
+                }
+            },
+            {
+                "href": "https://publish.pmp.io/auth/credentials",
+                "title": "Create OAuth2 Credentials",
+                "rels": [
+                    "urn:collectiondoc:form:createcredentials"
+                ],
+                "hints": {
+                    "allow": [
+                        "POST"
+                    ],
+                    "accept-post": [
+                        "application/x-www-form-urlencoded"
+                    ],
+                    "docs": "http://docs.pmp.io/Authenticating-with-the-API#generating-credentials"
+                }
+            },
+            {
+                "href-template": "https://publish.pmp.io/auth/credentials/{client_id}",
+                "title": "Remove OAuth2 Credentials",
+                "rels": [
+                    "urn:collectiondoc:form:removecredentials"
+                ],
+                "hints": {
+                    "allow": [
+                        "DELETE"
+                    ],
+                    "docs": "http://docs.pmp.io/Authenticating-with-the-API#removing-a-credential"
+                }
+            },
+            {
+                "href": "https://api.pmp.io/auth/access_token",
+                "title": "Issue OAuth2 Token",
+                "rels": [
+                    "urn:collectiondoc:form:issuetoken"
+                ],
+                "hints": {
+                    "allow": [
+                        "POST"
+                    ],
+                    "accept-post": [
+                        "application/x-www-form-urlencoded"
+                    ],
+                    "docs": "http://docs.pmp.io/Authentication-Model#token-management"
+                }
+            },
+            {
+                "href": "https://publish.pmp.io/auth/access_token",
+                "title": "Revoke OAuth2 Token",
+                "rels": [
+                    "urn:collectiondoc:form:revoketoken"
+                ],
+                "hints": {
+                    "allow": [
+                        "DELETE"
+                    ],
+                    "docs": "http://docs.pmp.io/Authentication-Model#revoke-a-token"
+                }
+            }
+        ]
     },
-    {
-      "version": "1.0",
-      "href": "https://api-sandbox.pmp.io/docs/4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
-      "attributes": {
-        "valid": {
-          "from": "2013-09-30T19:52:58+00:00",
-          "to": "3013-09-30T19:52:58+00:00"
-        },
-        "created": "2014-01-30T05:30:51+00:00",
-        "modified": "2014-01-30T05:30:51+00:00",
-        "contenttemplated": "<p>As the House and Senate continue kicking spending plans back and forth, here is what you need to know:</p>\n<p><strong>A government shutdown does not mean an Obamacare shutdown</strong>. Even though House Republicans are pushing for changes to the Affordable Care Act, it is funded in such a way that it will continue even if there is a partial government shutdown. This means the “exchanges,” where people can search for coverage plans, <a href=\"http://www.marketplace.org/topics/economy/health-exchanges-go-live-tuesday-are-websites-ready\">are still set to be unveiled Tuesday as planned</a>.</p>\n<p><strong>A government shutdown will not save the government any money</strong>. In fact, a shutdown will cost the government money. <a href=\"http://www.marketplace.org/topics/economy/raising-debt-ceiling/shut-it-down-why-government-shutdown-costs-money\">Shutdowns that lasted about 22 days in the Clinton era cost about $1.5 billion</a>. A shutdown is not expected have a major effect on the October 17 deadline that the Obama Administration has given Congress to raise the nation’s borrowing limit.</p>\n<p><strong>Here is what will happen, according to President Obama, who spoke Monday afternoon:</strong></p>\n<blockquote>If you’re on Social Security, you will keep receiving your checks. If you’re on Medicare, your doctor will still see you. Everyone’s mail will still be delivered. And government operations related to national security or public safety will go on. Our troops will continue to serve with skill, honor, and courage. Air traffic controllers, prison guards, those who are with border control -- our Border Patrol will remain on their posts, but their paychecks will be delayed until the government reopens. NASA will shut down almost entirely, but Mission Control will remain open to support the astronauts serving on the Space Station.</blockquote>\n<p><strong>And here, according to the president, is what would change:</strong></p>\n<blockquote>Office buildings would close.&nbsp; Paychecks would be delayed.&nbsp; Vital services that seniors and veterans, women and children, businesses and our economy depend on would be hamstrung.&nbsp; Business owners would see delays in raising capital, seeking infrastructure permits, or rebuilding after Hurricane Sandy.&nbsp; Veterans who’ve sacrificed for their country will find their support centers unstaffed.&nbsp; Tourists will find every one of America’s national parks and monuments, from Yosemite to the Smithsonian to the Statue of Liberty, immediately closed.&nbsp; And of course, the communities and small businesses that rely on these national treasures for their livelihoods will be out of customers and out of luck.</blockquote>",
-        "guid": "x4d39cdbe-1d80-22a9-ed5b-8cd87414f207",
-        "teaser": "Democrats and Republicans appear unable to reach common ground on a budget before the government shuts down.",
-        "contentencoded": "<p>As the House and Senate continue kicking spending plans back and forth, here is what you need to know:</p>\n<p><strong>A government shutdown does not mean an Obamacare shutdown</strong>. Even though House Republicans are pushing for changes to the Affordable Care Act, it is funded in such a way that it will continue even if there is a partial government shutdown. This means the “exchanges,” where people can search for coverage plans, <a href=\"http://www.marketplace.org/topics/economy/health-exchanges-go-live-tuesday-are-websites-ready\">are still set to be unveiled Tuesday as planned</a>.</p>\n<p><strong>A government shutdown will not save the government any money</strong>. In fact, a shutdown will cost the government money. <a href=\"http://www.marketplace.org/topics/economy/raising-debt-ceiling/shut-it-down-why-government-shutdown-costs-money\">Shutdowns that lasted about 22 days in the Clinton era cost about $1.5 billion</a>. A shutdown is not expected have a major effect on the October 17 deadline that the Obama Administration has given Congress to raise the nation’s borrowing limit.</p>\n<p><strong>Here is what will happen, according to President Obama, who spoke Monday afternoon:</strong></p>\n<blockquote>If you’re on Social Security, you will keep receiving your checks. If you’re on Medicare, your doctor will still see you. Everyone’s mail will still be delivered. And government operations related to national security or public safety will go on. Our troops will continue to serve with skill, honor, and courage. Air traffic controllers, prison guards, those who are with border control -- our Border Patrol will remain on their posts, but their paychecks will be delayed until the government reopens. NASA will shut down almost entirely, but Mission Control will remain open to support the astronauts serving on the Space Station.</blockquote>\n<p><strong>And here, according to the president, is what would change:</strong></p>\n<blockquote>Office buildings would close.&nbsp; Paychecks would be delayed.&nbsp; Vital services that seniors and veterans, women and children, businesses and our economy depend on would be hamstrung.&nbsp; Business owners would see delays in raising capital, seeking infrastructure permits, or rebuilding after Hurricane Sandy.&nbsp; Veterans who’ve sacrificed for their country will find their support centers unstaffed.&nbsp; Tourists will find every one of America’s national parks and monuments, from Yosemite to the Smithsonian to the Statue of Liberty, immediately closed.&nbsp; And of course, the communities and small businesses that rely on these national treasures for their livelihoods will be out of customers and out of luck.</blockquote>",
-        "byline": "Gura, David",
-        "hreflang": "en",
-        "description": "Democrats and Republicans appear unable to reach common ground on a budget before the government shuts down.",
-        "tags": [
-          "APM_TESTING",
-          "PMP:Marketplace_PMP",
-          "4d39cdbe1d8022a9ed5b8cd87414f206",
-          "Marketplace for Monday, September 30, 2013",
-          "Marketplace",
-          "Economy"
-        ],
-        "published": "2013-09-30T19:52:58+00:00",
-        "title": "Why the shutdown won't save money: Fights in 90s cost $1.5B"
-      },
-      "links": {
-        "profile": [
-          {
-            "href": "https://api-sandbox.pmp.io/profiles/story",
-            "title": "APMStory"
-          }
-        ],
-        "distributor": [],
-        "copyright": [
-          {
-            "href": "http://www.publicradio.org/terms",
-            "title": "Copyright (C) 2013 American Public Media Group"
-          }
-        ],
-        "item": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs/78e5706a-32dd-ba49-e386-b326945f1396"
-          }
-        ],
-        "collection": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
-            "title": "Marketplace"
-          },
-          {
-            "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
-            "title": "Marketplace"
-          },
-          {
-            "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df",
-            "title": "Marketplace for Monday, September 30, 2013"
-          }
-        ],
-        "alternate": [
-          {
-            "href": "http://www.marketplace.org/topics/economy/1201-am-will-my-lights-go-government-shutdown-explained",
-            "type": "text/html"
-          }
-        ],
-        "creator": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
-          }
-        ],
-        "navigation": [
-          {
-            "href": "https://api-sandbox.pmp.io/docs?guid=x4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
-            "rels": [
-              "self"
-            ],
-            "totalitems": 1,
-            "totalpages": 1,
-            "pagenum": 1
-          }
-        ]
-      },
-      "items": [
+    "items": [
         {
-          "version": "1.0",
-          "href": "https://api-sandbox.pmp.io/docs/78e5706a-32dd-ba49-e386-b326945f1397",
-          "attributes": {
-            "valid": {
-              "from": "2013-09-30T23:01:42+00:00",
-              "to": "3013-09-30T23:01:42+00:00"
-            },
-            "created": "2014-01-30T05:30:34+00:00",
-            "modified": "2014-01-30T05:30:34+00:00",
-            "byline": "Gura, David",
-            "hreflang": "en",
-            "description": "",
-            "tags": [
-              "APM_TESTING",
-              "PMP:Marketplace_PMP",
-              "Marketplace for Monday, September 30, 2013",
-              "Marketplace",
-              "78e5706a32ddba49e386b326945f1396",
-              "Economy"
-            ],
-            "published": "2013-09-30T19:52:58+00:00",
-            "guid": "x78e5706a-32dd-ba49-e386-b326945f1396",
-            "title": "marketplace_segment16_20130930_64.mp3"
-          },
-          "links": {
-            "profile": [
-              {
-                "href": "https://api-sandbox.pmp.io/profiles/audio",
-                "title": "APMAudio"
-              }
-            ],
-            "enclosure": [
-              {
-                "href": "apm-audio:/marketplace/segments/2013/09/30/marketplace_segment16_20130930_64.mp3",
-                "type": "audio/mpeg",
-                "meta": {
-                  "api": {
-                    "href": "http://api.publicradio.org/audio/v2?id=apm-audio:/marketplace/segments/2013/09/30/marketplace_segment16_20130930_64.mp3",
-                    "type": "application/json"
-                  }
-                }
-              }
-            ],
-            "distributor": [],
-            "copyright": [
-              {
-                "href": "http://www.publicradio.org/terms",
-                "title": "Copyright (C) 2013 American Public Media Group"
-              }
-            ],
-            "collection": [
-              {
-                "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
-                "title": "Marketplace"
-              },
-              {
-                "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
-                "title": "Marketplace"
-              }
-            ],
-            "creator": [
-              {
-                "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
-              }
-            ],
-            "item": [],
-            "navigation": [
-              {
-                "href": "https://api-sandbox.pmp.io/docs?guid=x78e5706a-32dd-ba49-e386-b326945f1396",
-                "rels": [
-                  "self"
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/bbdd7e4e-bdbc-4927-ab2f-2fe2f708e603",
+            "attributes": {
+                "created": "2015-10-27T18:13:23+00:00",
+                "modified": "2015-10-27T18:13:23+00:00",
+                "valid": {
+                    "from": "2015-10-27T18:12:43+00:00",
+                    "to": "3015-10-27T18:12:43+00:00"
+                },
+                "hreflang": "en",
+                "guid": "bbdd7e4e-bdbc-4927-ab2f-2fe2f708e603",
+                "title": "After years of delays, U.S. teams seek to recover WWII remains In India",
+                "teaser": "A U.S. recovery team has returned to a remote part of India to try to retrieve the remains of troops killed in World War II. Family members say a border dispute between India and China has delayed recovery efforts for years.\n ",
+                "description": "It&rsquo;s not unusual to get an odd contact from your past through Classmates.com. But not like the one that reached Bill Verhaegen in 2008.  Verhaegen, a retired chemical equipment salesman, received an email asking if he was the nephew of a Louis F. Verhaegen, a World War II Army flier whose plane disappeared in 1943 during a flight from India to China.  The wreckage of the plane had been found.  &ldquo;When I heard, I was in shock,&rdquo; Verhaegen said from his Aliso Viejo, California home.  Verhaegen&rsquo;s Uncle Louis holds a central place in family lore. Before he vanished into the sky at age 21, Louis&rsquo; family thought he might be headed for a career in professional baseball.  &ldquo;He was tall, he was an athlete,&rdquo; Bill Verhaegen said. &ldquo;Over the years I had heard that he had signed a contract with the Philadelphia Athletics at that time. I have no idea how much truth is in all that, but I guess he was a pretty good left-handed baseball player.&rdquo;  On March 20, 1943, Louis was an assistant radio operator on a B-24 dubbed &ldquo;Pregnant Swan.&rdquo; A crew of 10 was flying it from India to Kunming, China to join the fight against Japan. It never arrived.  Bill Verhaegen&rsquo;s father immediately tried to enlist in the Marines even though he was too young.  &ldquo;The family was affected quite a bit, especially my Dad,&rdquo; Verhaegen said. &ldquo;I&rsquo;m sure at 16 years old or 17 years old, he is thinking he can find him, or have vengeance.&rdquo;  It took 65 years, but in 2008, someone did find his plane -- a mountaineer from Arizona named Clayton Kuhles, who has made a personal mission of finding and identifying lost American aircraft in Asia.  After a two-day trek from the nearest village, Kuhles climbed up the jungled walls of a ravine at the eastern end of the Himalayas and began picking through piles of crumpled and shredded aluminum. Eventually he found what he was looking for: a serial number.  42-40069.  A few months later, Bill Verhaegen got that email from an MIA activist who works with Kuhles.  &ldquo;The first thing I did was call the cemetery where my grandparents are buried to find out if they have room for my uncle if his remains are found.&nbsp; Two of my female cousins already had their DNA done that would help identify his remains.&rdquo;  As clock ticks, recoveries stop   But in the seven years since Kuhles' discovery, there&rsquo;s been no need for that cemetery plot or DNA tests. Not long after the plane was discovered, the government of India kicked out an American recovery team working in the region.  The Indian government gave little explanation, but Indian media linked the decision to a longstanding border dispute between India and China in the remote Indian state known as Arunachal Pradesh.  That meant Louis Verhaegen&rsquo;s plane remained untouched by recovery teams, and they stopped work on another World War II plane -- a B-24 named &quot;Hot As Hell&quot; -- where a recovery had already begun.  The wait has been frustrating for families of 84 men who were aboard those and other planes that Kuhles has found and identified in India.  &ldquo;We lobbied the Indian ambassador to the United States. We sent notes to numerous officials,&rdquo; said Gary Zaetz, a North Carolina activist who locates families of downed fliers after Kuhles finds their planes. It was Zaetz who sent the 2008 email to Verhaegen.  Zaetz&rsquo; own uncle, Irwin &ldquo;Zipper&rdquo; Zaetz, was the navigator of &quot;Hot As Hell.&quot; He says he&rsquo;s working with more than 100 relatives of World War II veterans who are waiting for their loved ones&rsquo; remains to be recovered and returned from Arunachal Pradesh.&nbsp;   But with each year of inaction, Zaetz says that group gets a little smaller, as service members&rsquo; siblings, children, nieces, and nephews grow older or pass away.  Gary&rsquo;s father, Larry &mdash; the brother of the missing flier &mdash; is 91 and not strong enough to talk.  &ldquo;One of the people who was one of our closest colleagues in this effort, a guy named Stephen Chambers, nephew of Sheldon Chambers, my uncle&rsquo;s co-pilot, he passed away,&rdquo; Zaetz said. &ldquo;Because of this moratorium he will never get to see the remains of his uncle.&rdquo;  &ldquo;The clock is very much ticking, absolutely, absolutely,&rdquo; Zaetz said.  A dangerous and disputed region   In all, nearly 600 U.S. aircraft were lost along the route called the Hump, moving supplies and aircraft from India over the mountains and into China.  Unpredictable weather, the towering peaks and rudimentary navigation aids of the time made it startlingly dangerous. The crashes claimed the lives of almost 1,700 troops. All the crashes gave the Hump another nickname: The Aluminum Trail.  The place where the majority of the estimated 416 missing in India are believed to be, Arunachal Pradesh is a crossroads and mixing pot. Strong Burmese and Tibetan influences. Dozens of tribes and languages, a host of religions, including many that worship nature. Rivers, jungle and rocky ridges rising into the Himalayas.  The U.S. sent a recovery team there in 2008.  But the next year, before it could finish, India imposed the unannounced moratorium on recoveries.  China had complained about India allowing U.S. recovery teams into the remote, mountainous territory, which it considers its own.&nbsp;   &ldquo;China is prickly about this particular area because it is occupied by India but claimed by China,&rdquo; said MIT political scientist Taylor Fravel, an expert on Chinese border issues. &ldquo;They have a long border and the entire length of that border is disputed.&rdquo;  But this spring, something changed. India loosened the moratorium &ndash; again with little explanation.&nbsp; And in September, one of the small U.S. recovery teams quietly flew back in.&nbsp; Zaetz has been told that it&rsquo;s gone back to his uncle&rsquo;s plane to try to finish the job there.  The Indian Embassy in Washington didn&rsquo;t respond to requests for comment, and a U.S. State Department spokeswoman declined to talk about any negotiations.&nbsp;   Zaetz says the families aren&rsquo;t sure what to think.  &ldquo;Is this really an end to this moratorium, or is it just PR?&rdquo; he asks. He worries that the Indian government will allow recovery teams to work on one crash site to placate the families and the U.S. government, then again impose the moratorium.  &ldquo;That&rsquo;s unacceptable as far as I&rsquo;m concerned,&rdquo; he said.  Families' long wait continues   Even if India allows the recoveries to continue without interruption, it could take years, or even decades to investigate just the sites Kuhles has already found.  While they wait and hope for their turn, families like the Verhaegens think about how to keep the memory of the men from becoming an echo that fades away as it passes down each generation.  &ldquo;We talked about how this is handed down, how it affects this second set of cousins who didn&rsquo;t have benefit of everybody talking about my Uncle Louis all the time,&rdquo; said Bill Verhaegen.  So, he talks to his own son. Maybe Verhaegen can&rsquo;t bring uncle Louis to life as clearly and powerfully as his own aunts and uncles did for him. But he can pass down some things.  &ldquo;I have one of my uncle&rsquo;s flight suits, the lightweight flight suits, and I actually had it cleaned and I had my son put that on,&rdquo; Verhaegen said.  &ldquo;My son is 15 years old and he&rsquo;s 5-foot-10 and it looks like it fits him perfectly. So when they talked about how tall my uncle was, I was a little surprised how the suit fit my son so well.&rdquo;  Some of the men who went off to World War II and didn&rsquo;t come back will always seem a little taller and bit more handsome. And maybe even a little better at baseball.  At least, for as long as someone keeps remembering.  This story is part of the American Homefront Project - a joint effort of WUNC, KPCC, and KUOW - reporting on American military life and veterans.   ",
+                "contentencoded": "It&rsquo;s not unusual to get an odd contact from your past through Classmates.com. But not like the one that reached Bill Verhaegen in 2008.<br /> <br /> Verhaegen, a retired chemical equipment salesman, received an email asking if he was the nephew of a Louis F. Verhaegen, a World War II Army flier whose plane disappeared in 1943 during a flight from India to China.<br /> <br /> The wreckage of the plane had been found.<br /> <br /> &ldquo;When I heard, I was in shock,&rdquo; Verhaegen said from his Aliso Viejo, California home.<br /> <br /> Verhaegen&rsquo;s Uncle Louis holds a central place in family lore. Before he vanished into the sky at age 21, Louis&rsquo; family thought he might be headed for a career in professional baseball.<br /> <br /> &ldquo;He was tall, he was an athlete,&rdquo; Bill Verhaegen said. &ldquo;Over the years I had heard that he had signed a contract with the Philadelphia Athletics at that time. I have no idea how much truth is in all that, but I guess he was a pretty good left-handed baseball player.&rdquo;<br /> <br /> On March 20, 1943, Louis was an assistant radio operator on a B-24 dubbed &ldquo;Pregnant Swan.&rdquo; A crew of 10 was flying it from India to Kunming, China to join the fight against Japan. It never arrived.<br /> <br /> Bill Verhaegen&rsquo;s father immediately tried to enlist in the Marines even though he was too young.<br /> <br /> &ldquo;The family was affected quite a bit, especially my Dad,&rdquo; Verhaegen said. &ldquo;I&rsquo;m sure at 16 years old or 17 years old, he is thinking he can find him, or have vengeance.&rdquo;<br /> <br /> It took 65 years, but in 2008, someone did find his plane -- a mountaineer from Arizona named Clayton Kuhles, who has made a personal mission of finding and identifying lost American aircraft in Asia.<br /> <br /> After a two-day trek from the nearest village, Kuhles climbed up the jungled walls of a ravine at the eastern end of the Himalayas and began picking through piles of crumpled and shredded aluminum. Eventually he found what he was looking for: a serial number.<br /> <br /> 42-40069.<br /> <br /> A few months later, Bill Verhaegen got that email from an MIA activist who works with Kuhles.<br /> <br /> &ldquo;The first thing I did was call the cemetery where my grandparents are buried to find out if they have room for my uncle if his remains are found.&nbsp; Two of my female cousins already had their DNA done that would help identify his remains.&rdquo;<br /> <br /> <strong>As clock ticks, recoveries stop</strong> <br /> <br /> But in the seven years since Kuhles' discovery, there&rsquo;s been no need for that cemetery plot or DNA tests. Not long after the plane was discovered, the government of India kicked out an American recovery team working in the region.<br /> <br /> The Indian government gave little explanation, but Indian media linked the decision to a longstanding border dispute between India and China in the remote Indian state known as Arunachal Pradesh.<br /> <br /> That meant Louis Verhaegen&rsquo;s plane remained untouched by recovery teams, and they stopped work on another World War II plane -- a B-24 named &quot;Hot As Hell&quot; -- where a recovery had already begun.<br /> <br /> The wait has been frustrating for families of 84 men who were aboard those and other planes that Kuhles has found and identified in India.<br /> <br /> &ldquo;We lobbied the Indian ambassador to the United States. We sent notes to numerous officials,&rdquo; said Gary Zaetz, a North Carolina activist who locates families of downed fliers after Kuhles finds their planes. It was Zaetz who sent the 2008 email to Verhaegen.<br /> <br /> Zaetz&rsquo; own uncle, Irwin &ldquo;Zipper&rdquo; Zaetz, was the navigator of &quot;Hot As Hell.&quot; He says he&rsquo;s working with more than 100 relatives of World War II veterans who are waiting for their loved ones&rsquo; remains to be recovered and returned from Arunachal Pradesh.&nbsp; <br /> <br /> But with each year of inaction, Zaetz says that group gets a little smaller, as service members&rsquo; siblings, children, nieces, and nephews grow older or pass away.<br /> <br /> Gary&rsquo;s father, Larry &mdash; the brother of the missing flier &mdash; is 91 and not strong enough to talk.<br /> <br /> &ldquo;One of the people who was one of our closest colleagues in this effort, a guy named Stephen Chambers, nephew of Sheldon Chambers, my uncle&rsquo;s co-pilot, he passed away,&rdquo; Zaetz said. &ldquo;Because of this moratorium he will never get to see the remains of his uncle.&rdquo;<br /> <br /> &ldquo;The clock is very much ticking, absolutely, absolutely,&rdquo; Zaetz said.<br /> <br /> <strong>A dangerous and disputed region</strong> <br /> <br /> In all, nearly 600 U.S. aircraft were lost along the route called the Hump, moving supplies and aircraft from India over the mountains and into China.<br /> <br /> Unpredictable weather, the towering peaks and rudimentary navigation aids of the time made it startlingly dangerous. The crashes claimed the lives of almost 1,700 troops. All the crashes gave the Hump another nickname: The Aluminum Trail.<br /> <br /> The place where the majority of the estimated 416 missing in India are believed to be, Arunachal Pradesh is a crossroads and mixing pot. Strong Burmese and Tibetan influences. Dozens of tribes and languages, a host of religions, including many that worship nature. Rivers, jungle and rocky ridges rising into the Himalayas.<br /> <br /> The U.S. sent a recovery team there in 2008.<br /> <br /> But the next year, before it could finish, India imposed the unannounced moratorium on recoveries.<br /> <br /> China had complained about India allowing U.S. recovery teams into the remote, mountainous territory, which it considers its own.&nbsp; <br /> <br /> &ldquo;China is prickly about this particular area because it is occupied by India but claimed by China,&rdquo; said MIT political scientist Taylor Fravel, an expert on Chinese border issues. &ldquo;They have a long border and the entire length of that border is disputed.&rdquo;<br /> <br /> But this spring, something changed. India loosened the moratorium &ndash; again with little explanation.&nbsp; And in September, one of the small U.S. recovery teams quietly flew back in.&nbsp; Zaetz has been told that it&rsquo;s gone back to his uncle&rsquo;s plane to try to finish the job there.<br /> <br /> The Indian Embassy in Washington didn&rsquo;t respond to requests for comment, and a U.S. State Department spokeswoman declined to talk about any negotiations.&nbsp; <br /> <br /> Zaetz says the families aren&rsquo;t sure what to think.<br /> <br /> &ldquo;Is this really an end to this moratorium, or is it just PR?&rdquo; he asks. He worries that the Indian government will allow recovery teams to work on one crash site to placate the families and the U.S. government, then again impose the moratorium.<br /> <br /> &ldquo;That&rsquo;s unacceptable as far as I&rsquo;m concerned,&rdquo; he said.<br /> <strong><br /> Families' long wait continues</strong> <br /> <br /> Even if India allows the recoveries to continue without interruption, it could take years, or even decades to investigate just the sites Kuhles has already found.<br /> <br /> While they wait and hope for their turn, families like the Verhaegens think about how to keep the memory of the men from becoming an echo that fades away as it passes down each generation.<br /> <br /> &ldquo;We talked about how this is handed down, how it affects this second set of cousins who didn&rsquo;t have benefit of everybody talking about my Uncle Louis all the time,&rdquo; said Bill Verhaegen.<br /> <br /> So, he talks to his own son. Maybe Verhaegen can&rsquo;t bring uncle Louis to life as clearly and powerfully as his own aunts and uncles did for him. But he can pass down some things.<br /> <br /> &ldquo;I have one of my uncle&rsquo;s flight suits, the lightweight flight suits, and I actually had it cleaned and I had my son put that on,&rdquo; Verhaegen said.<br /> <br /> &ldquo;My son is 15 years old and he&rsquo;s 5-foot-10 and it looks like it fits him perfectly. So when they talked about how tall my uncle was, I was a little surprised how the suit fit my son so well.&rdquo;<br /> <br /> Some of the men who went off to World War II and didn&rsquo;t come back will always seem a little taller and bit more handsome. And maybe even a little better at baseball.<br /> <br /> At least, for as long as someone keeps remembering.<br /> <br /> <em>This story is part of the American Homefront Project - a joint effort of WUNC, KPCC, and KUOW - reporting on American military life and veterans. </em> <br /> <br />",
+                "byline": "American Homefront Project",
+                "published": "2015-10-27T18:12:43+00:00",
+                "tags": [
+                    "International",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-163273"
                 ]
-              }
-            ]
-          }
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/81b8fcb3-b7fd-4d62-900f-164ef9848702",
+                        "title": "Peter Janse with the Joint POW/MIA Accounting Command, examines one of the engine of the B-24 Hot as Hell in Arunachal Pradesh, India in 2008.",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/d7be1b53-12aa-4b7e-8e82-46a0d94fd1e8",
+                        "title": "India MIA recoveries",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/163273"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/bbdd7e4e-bdbc-4927-ab2f-2fe2f708e603",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/81b8fcb3-b7fd-4d62-900f-164ef9848702",
+                    "attributes": {
+                        "created": "2015-10-27T18:13:21+00:00",
+                        "modified": "2015-10-27T18:13:21+00:00",
+                        "valid": {
+                            "from": "2015-10-27T18:13:21+00:00",
+                            "to": "3015-10-27T18:13:21+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "81b8fcb3-b7fd-4d62-900f-164ef9848702",
+                        "title": "Peter Janse with the Joint POW/MIA Accounting Command, examines one of the engine of the B-24 Hot as Hell in Arunachal Pradesh, India in 2008.",
+                        "byline": "JPAC/JESSE M. SHIPPS",
+                        "itags": [
+                            "prx:story_images-382121"
+                        ],
+                        "published": "2015-10-27T18:13:21+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/cbe5af85038ef9aeb3b8c7080a326914/0/web/story_image/382121/medium/dt.common.streams.StreamServer.cls.jpeg",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/81b8fcb3-b7fd-4d62-900f-164ef9848702"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/d7be1b53-12aa-4b7e-8e82-46a0d94fd1e8",
+                    "attributes": {
+                        "created": "2015-10-27T18:13:22+00:00",
+                        "modified": "2015-10-27T18:13:22+00:00",
+                        "valid": {
+                            "from": "2015-10-27T18:13:22+00:00",
+                            "to": "3015-10-27T18:13:22+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "d7be1b53-12aa-4b7e-8e82-46a0d94fd1e8",
+                        "title": "India MIA recoveries",
+                        "itags": [
+                            "prx:audio_files-996451"
+                        ],
+                        "published": "2015-10-27T18:13:22+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/632d06bc4a43d7623e87e24c011b50f5/0/web/audio_file/996451/broadcast/India_MIA_AHP_version.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 403,
+                                    "size": 6443484
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/d7be1b53-12aa-4b7e-8e82-46a0d94fd1e8"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/d202ff38-208b-4b68-b005-ca820fccbabf",
+            "attributes": {
+                "created": "2015-10-12T17:29:48+00:00",
+                "modified": "2015-10-12T17:29:48+00:00",
+                "valid": {
+                    "from": "2015-10-12T17:29:11+00:00",
+                    "to": "3015-10-12T17:29:11+00:00"
+                },
+                "hreflang": "en",
+                "guid": "d202ff38-208b-4b68-b005-ca820fccbabf",
+                "title": "Military Can't Accept This Transgender Soldier As A Woman – Yet",
+                "teaser": "The Pentagon is getting ready to craft more inclusive policies for service members who identify as transgender. But for those troops who are already openly serving the situation is complicated.",
+                "description": "Capt. Jennifer Peace walks into the room, a tall, thin woman in crisp uniform, with minimal makeup and trim brown hair. \nBut when soldiers call her ma&rsquo;am, she has orders to correct them. They must call her sir.\n Capt. Peace, an intelligence officer stationed at Joint Base Lewis-McChord south of Seattle, is transgender. And although it&rsquo;s been four years since the ban on homosexuality in the ranks was lifted, being trans is still a problem in the military.\n That&rsquo;s about to change. But until the Defense Department crafts formal policies, transgender service members are in a complicated and sometimes frustrating position on how to handle bathrooms, bunking, pronouns &ndash; and haircuts.\n Peace&rsquo;s hair sweeps neatly across her brow line and falls just below her ears. That&rsquo;s a problem, because according to the U.S. Army, Jennifer Peace is a man. And her hair is too long to conform to the standards set for men. She&rsquo;s been ordered to get it cut.\n Fixing that part of the military&rsquo;s policy seems straightforward. Less clear is how open transgender service will affect combat roles, which aren&rsquo;t available to women right now.\n Peace deployed to Iraq in 2008 and Afghanistan in 2012 as a man. And though her evaluations were good, she struggled with the way her body looked and with depression. She said it was in Afghanistan that she finally put a name to her angst.\n So nearly two years ago with her wife&rsquo;s support, Peace started medically transitioning from male to female. She&rsquo;s one of an estimated 15,000 transgender troops serving in the Armed Forces and reserves, according UCLA&rsquo;s Williams Institute, which conducts research on sexual orientation and gender policy.\n 'Scared The Entire Time'\n Peace&rsquo;s decision to transition had potentially devastating consequences for her career and for her family &ndash; she and her wife, Debbie, have been married for 11 years. They live in Spanaway, Wash., with their three children, and Peace said they&rsquo;ve racked up $55,000 in debt for her surgeries.\n &ldquo;I was scared the entire time,&rdquo; Peace said. &ldquo;We had so many conversations about what are we to do if I get kicked out? I've got three kids and a mortgage like everyone else. The Army is what I knew. What would I do if was gone tomorrow?&quot;\n That didn&rsquo;t happen. And under an order from Defense Secretary Ashton Carter, a senior Pentagon official must review involuntary discharges for transgender service members.\n Carter made it clear in a speech for LGBT pride month at the Pentagon that diversity in the ranks is critical to the mission.\n &ldquo;Because we need to be a meritocracy,&rdquo; Carter said. &ldquo;We have to focus relentlessly on our mission, which means the thing that matters most about a person is what they can contribute to national defense.&rdquo;  &nbsp;Calling Her 'Sir'\n But first there are the haircuts and the pronouns.\n Even though Peace has legally changed her name, her soldiers are under orders to address her as &ldquo;sir.&rdquo; When they didn&rsquo;t do that at first, she said, both she and her soldiers were reprimanded by command.\n&ldquo;My soldiers were called in and they said, &lsquo;What are you calling Capt. Peace? What were you told to call Capt. Peace?&rsquo;&quot; she said. &ldquo;I was called in and my direct supervisor said, &quot;Hey, Capt. Peace. I need you start correcting people's pronouns.&rsquo;&rdquo;\n An Army spokesman said current policy is to treat soldiers for all purposes by the gender they held when they entered the service.\n Such issues will likely be addressed by a working group formed by Secretary Carter &ndash; as will more complex problems, like whether transgender troops will be excluded from any military jobs.\n There's a widespread recognition that current policies don't work. And a strong intent to set the right policies.\n These aren&rsquo;t insurmountable issues, said Aaron Belkin, director of the Palm Center, an independent research institute that focuses on gender, sexuality and the military. Belkin said British, Australian and Canadian forces already have developed inclusive policies for transgender personnel.\n &ldquo;In all of those experiences, sure, culture changes a bit because the troops aren't used to serving with openly transgender personnel, but the implementation issues are not difficult to solve,&rdquo; Belkin said.\n The frustration for transgender troops is the time it&rsquo;s taking. Be patient, counsels Sue Fulton, a former Army captain who now is president of SPARTA, a nonprofit that supports LGBT military veterans and their families.\n &ldquo;There's a widespread recognition that current policies don't work. And a strong intent to set the right policies,&rdquo; Fulton said. &ldquo;To make sure they're doing the right thing is going to take time. &ldquo;\n And, noted Fulton, part of the first class of women to graduate from West Point: &ldquo;Being first is hard.&rdquo;\n While Jennifer Peace admits she&rsquo;s impatient, she&rsquo;s also hopeful that soon the focus will be on her job performance, not her gender.\n &ldquo;I think by this time next year, we&rsquo;ll be talking about how well the implementation has gone,&rdquo; she said. ",
+                "contentencoded": "<div>Capt. Jennifer Peace walks into the room, a tall, thin woman in crisp uniform, with minimal makeup and trim brown hair.<br /> <br /></div>\n<div>But when soldiers call her ma&rsquo;am, she has orders to correct them. They must call her sir.</div>\n<div><br /> Capt. Peace, an intelligence officer stationed at Joint Base Lewis-McChord south of Seattle, is transgender. And although it&rsquo;s been four years since the ban on homosexuality in the ranks was lifted, being trans is still a problem in the military.</div>\n<div><br /> That&rsquo;s about to change. But until the Defense Department crafts formal policies, transgender service members are in a complicated and sometimes frustrating position on how to handle bathrooms, bunking, pronouns &ndash; and haircuts.</div>\n<div><br /> Peace&rsquo;s hair sweeps neatly across her brow line and falls just below her ears. That&rsquo;s a problem, because according to the U.S. Army, Jennifer Peace is a man. And her hair is too long to conform to the standards set for men. She&rsquo;s been ordered to get it cut.</div>\n<div><br /> Fixing that part of the military&rsquo;s policy seems straightforward. Less clear is how open transgender service will affect combat roles, which aren&rsquo;t available to women right now.</div>\n<div><br /> Peace deployed to Iraq in 2008 and Afghanistan in 2012 as a man. And though her evaluations were good, she struggled with the way her body looked and with depression. She said it was in Afghanistan that she finally put a name to her angst.</div>\n<div><br /> So nearly two years ago with her wife&rsquo;s support, Peace started medically transitioning from male to female. She&rsquo;s one of an estimated 15,000 transgender troops serving in the Armed Forces and reserves, according UCLA&rsquo;s Williams Institute, which conducts research on sexual orientation and gender policy.</div>\n<div><br /> 'Scared The Entire Time'</div>\n<div><br /> Peace&rsquo;s decision to transition had potentially devastating consequences for her career and for her family &ndash; she and her wife, Debbie, have been married for 11 years. They live in Spanaway, Wash., with their three children, and Peace said they&rsquo;ve racked up $55,000 in debt for her surgeries.</div>\n<div><br /> &ldquo;I was scared the entire time,&rdquo; Peace said. &ldquo;We had so many conversations about what are we to do if I get kicked out? I've got three kids and a mortgage like everyone else. The Army is what I knew. What would I do if was gone tomorrow?&quot;</div>\n<div><br /> That didn&rsquo;t happen. And under an order from Defense Secretary Ashton Carter, a senior Pentagon official must review involuntary discharges for transgender service members.</div>\n<div><br /> Carter made it clear in a speech for LGBT pride month at the Pentagon that diversity in the ranks is critical to the mission.</div>\n<div><br /> &ldquo;Because we need to be a meritocracy,&rdquo; Carter said. &ldquo;We have to focus relentlessly on our mission, which means the thing that matters most about a person is what they can contribute to national defense.&rdquo;<br /> <br /> &nbsp;Calling Her 'Sir'</div>\n<div><br /> But first there are the haircuts and the pronouns.</div>\n<div><br /> Even though Peace has legally changed her name, her soldiers are under orders to address her as &ldquo;sir.&rdquo; When they didn&rsquo;t do that at first, she said, both she and her soldiers were reprimanded by command.</div>\n<div>&ldquo;My soldiers were called in and they said, &lsquo;What are you calling Capt. Peace? What were you told to call Capt. Peace?&rsquo;&quot; she said. &ldquo;I was called in and my direct supervisor said, &quot;Hey, Capt. Peace. I need you start correcting people's pronouns.&rsquo;&rdquo;</div>\n<div><br /> An Army spokesman said current policy is to treat soldiers for all purposes by the gender they held when they entered the service.</div>\n<div><br /> Such issues will likely be addressed by a working group formed by Secretary Carter &ndash; as will more complex problems, like whether transgender troops will be excluded from any military jobs.</div>\n<div><br /> There's a widespread recognition that current policies don't work. And a strong intent to set the right policies.</div>\n<div><br /> These aren&rsquo;t insurmountable issues, said Aaron Belkin, director of the Palm Center, an independent research institute that focuses on gender, sexuality and the military. Belkin said British, Australian and Canadian forces already have developed inclusive policies for transgender personnel.</div>\n<div><br /> &ldquo;In all of those experiences, sure, culture changes a bit because the troops aren't used to serving with openly transgender personnel, but the implementation issues are not difficult to solve,&rdquo; Belkin said.</div>\n<div><br /> The frustration for transgender troops is the time it&rsquo;s taking. Be patient, counsels Sue Fulton, a former Army captain who now is president of SPARTA, a nonprofit that supports LGBT military veterans and their families.</div>\n<div><br /> &ldquo;There's a widespread recognition that current policies don't work. And a strong intent to set the right policies,&rdquo; Fulton said. &ldquo;To make sure they're doing the right thing is going to take time. &ldquo;</div>\n<div><br /> And, noted Fulton, part of the first class of women to graduate from West Point: &ldquo;Being first is hard.&rdquo;</div>\n<div><br /> While Jennifer Peace admits she&rsquo;s impatient, she&rsquo;s also hopeful that soon the focus will be on her job performance, not her gender.</div>\n<div><br /> &ldquo;I think by this time next year, we&rsquo;ll be talking about how well the implementation has gone,&rdquo; she said. <br /></div>",
+                "byline": "American Homefront Project",
+                "published": "2015-10-12T17:29:11+00:00",
+                "tags": [
+                    "Gay and Lesbian",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-161942"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/19e3bf7e-8da4-44e0-8fdf-c4521a659227",
+                        "title": "From left: Deborah Peace and Capt. Jennifer Peace with their youngest child.",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/033ea15c-acc8-4577-9175-6cb631d41916",
+                        "title": "Transgender troops",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/161942"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/d202ff38-208b-4b68-b005-ca820fccbabf",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/19e3bf7e-8da4-44e0-8fdf-c4521a659227",
+                    "attributes": {
+                        "created": "2015-10-12T17:29:46+00:00",
+                        "modified": "2015-10-12T17:29:46+00:00",
+                        "valid": {
+                            "from": "2015-10-12T17:29:46+00:00",
+                            "to": "3015-10-12T17:29:46+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "19e3bf7e-8da4-44e0-8fdf-c4521a659227",
+                        "title": "From left: Deborah Peace and Capt. Jennifer Peace with their youngest child.",
+                        "byline": "Patricia Murphy/KUOW",
+                        "itags": [
+                            "prx:story_images-379317"
+                        ],
+                        "published": "2015-10-12T17:29:46+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/09b8fd771ecfd9870279f66ddd6557f8/0/web/story_image/379317/medium/IMG_1170.JPG",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/19e3bf7e-8da4-44e0-8fdf-c4521a659227"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/033ea15c-acc8-4577-9175-6cb631d41916",
+                    "attributes": {
+                        "created": "2015-10-12T17:29:47+00:00",
+                        "modified": "2015-10-12T17:29:47+00:00",
+                        "valid": {
+                            "from": "2015-10-12T17:29:47+00:00",
+                            "to": "3015-10-12T17:29:47+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "033ea15c-acc8-4577-9175-6cb631d41916",
+                        "title": "Transgender troops",
+                        "itags": [
+                            "prx:audio_files-986449"
+                        ],
+                        "published": "2015-10-12T17:29:47+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/eff9e38e65ebf486aa5257cddcb5d457/0/web/audio_file/986449/broadcast/npm100915_Trans_soldiers.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 223,
+                                    "size": 7140085
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/033ea15c-acc8-4577-9175-6cb631d41916"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/9511115b-75c7-42f4-bbcb-b874ec38da6f",
+            "attributes": {
+                "created": "2015-09-04T15:20:01+00:00",
+                "modified": "2015-09-05T02:02:37+00:00",
+                "valid": {
+                    "from": "2015-09-05T02:02:07+00:00",
+                    "to": "3015-09-05T02:02:07+00:00"
+                },
+                "hreflang": "en",
+                "guid": "9511115b-75c7-42f4-bbcb-b874ec38da6f",
+                "title": "Veteran Housing Vouchers Scorned by Landlords ",
+                "teaser": "A federal program provides housing vouchers to help veterans pay their rent. But in cities with expensive housing markets, many landlords won't accept them.",
+                "description": "The building manager's office was closed, but&nbsp;Veronica Schenkelberg and Adrian Carrillo decided to wait.\nAll  day, they'd been hitting buzzers and knocking on doors, looking for an  apartment for Carrillo, and this building showed promise--it&nbsp;had an  apartment available, and from what Carrillo could gather online, it took  Section 8 housing vouchers.\nAfter 35 minutes, Cindy Morrison  arrived to unlock the door and deliver the same statement the two had  been hearing all day:&nbsp; The building doesn't take federal rent assistance  vouchers.\n&quot;Not even for veterans?&quot; Carrillo asked.\n&quot;Not for anybody,&quot; Morrison said.\nAnd  so it goes in Los Angeles, which is home to one of the hottest rental  markets in the country, and also the nation's largest population of  homeless veterans. For those reasons, L.A. has become the kingpin of the  Obama administration's pledge to end veteran homelessness by the end of  2015.\nOne way the government hopes to do that is by issuing  vouchers through the Veterans Affairs Supportive Housing (VASH) program.  The voucher, which is much like a federal Section 8 voucher, helps  veterans pay their rent. Los Angeles received over 800 new Veterans  Affairs Supportive Housing (VASH) vouchers in 2015. And there are close  to 4,000 active leases through VASH right now in the L.A. area.\nBut  hundreds of veterans, such as Carrillo, have VASH vouchers but cannot  find a place to use them. Many landlords say the vouchers don't pay  enough to make it worth their while to accept them. Some fear that doing  so would subject them to burdensome government requirements, while  others express general reservations about renting to veterans.\n\n  &quot;If  I would've known I was in this predicament, I would've never ever moved  out here,&quot; Carrillo said. &quot;I wake up to regret every single day.&quot;\n\nCarrillo  served six&nbsp;years in the U.S. Army, including a deployment to  Afghanistan. After being discharged, he carved out a comfortable life in  Fayetteville, just outside North Carolina&rsquo;s massive Fort Bragg. A  combination of medical conditions left him with a 100% service-connected  medical disability, which pays him about $3,000 each month.\nThat  was enough to rent a nice house he, his fiancee, and their 5-year-old  daughter Adrea could live in. With his rent at $650 per month he had  enough left over to save for his daughter&rsquo;s future too.\nThen,  about a year ago, his mother, who lives in Whittier, underwent an  emergency brain operation, and he needed to take care of her as she  recovered.\nThus began Adrian Carrillo&rsquo;s rough entry into Southern California&rsquo;s rental housing market--and ultimately, homelessness.\n&quot;California is expensive,&quot; he said.\nAnd VASH seemed like a lifesaver.\nThe  voucher would pay a chunk of Carrillo's rent for him. To help him find a  place that'd take it, the V.A. assigned him a caseworker.\nThat&rsquo;s when he met Veronica Schenkelberg.\nA  licensed social worker, Schenkelberg walked Carrillo through the  services available to him: medical care, counseling, job training, and  job placement assistance. He was approved for a 2-bedroom apartment and  handed a voucher worth about $1,700.\n&quot;We do lease-up the  veterans,&quot; Schenkelberg said. &quot;It takes a little longer because the  market is so tight, but we do. We do find housing eventually. It just  takes a little bit of time.&quot;\nPart of her job is selling landlords  on the program. But Section 8, an anti-poverty program, has a stigma in  the landlord community, said Charles Lazar, who owns five apartment  buildings in Los Angeles.\nHe used to accept Section 8 tenants but  stopped doing so long ago. He feels that some vets may create problems  for his other tenants.\n&quot;What happens if someone does have mental  issues that aren&rsquo;t being addressed?&quot; he said. &quot;When you have someone  screaming in the middle of the night and you&rsquo;ve got people waking up and  kids that are small and they are scared, then you have to deal with it.  What are you going to do?&quot;\nVASH vouchers come with supportive  services and a case worker. Each vet also has a support network tasked  with responding to issues around the clock.\nEd Cabrera, a spokesman for the U.S. Department of Housing and Urban Development, said he encounters Lazar's argument a lot.\n&quot;There  are a lot of stereotypes out there that affect veterans who&rsquo;ve returned  from combat or current theaters, he said. &quot; So a lot of education needs  to happen.&quot;\nFor Carrillo, landlord education won't come soon enough.\nWalking away from his fourth apartment complex of the day, he looked worn out.\nThe  landlord there told Carrillo he did indeed have an apartment  available--a 2-bedroom, which&nbsp;at $1,600 per month was well within the  dollar value of Carrillo&rsquo;s voucher--but he wasn't interested in the  voucher program.\n&quot;Man, it just tears you up,&quot; Carrillo said.\nBeing homeless was clearly taking its toll.\n&quot;If it was just me and Lori, that&rsquo;s one thing,&quot; Carrillo said, referring to his fiancee. &quot;We can hang in there.\nBut  it&rsquo;s very very painful when your daughter wakes up crying and she says  &lsquo;this is not our house, Daddy. I want to go back to North Carolina. I  want to go back to the old house.&rsquo;&quot;\nGetting back into his car,  Carrillo said he was done looking for housing in L.A. He's planning to  leave Southern California and head to Texas, where the family just might  be able to find an affordable, decent home.",
+                "contentencoded": "<p>The building manager's office was closed, but&nbsp;Veronica Schenkelberg and Adrian Carrillo decided to wait.</p>\n<p>All  day, they'd been hitting buzzers and knocking on doors, looking for an  apartment for Carrillo, and this building showed promise--it&nbsp;had an  apartment available, and from what Carrillo could gather online, it took  Section 8 housing vouchers.</p>\n<p>After 35 minutes, Cindy Morrison  arrived to unlock the door and deliver the same statement the two had  been hearing all day:&nbsp; The building doesn't take federal rent assistance  vouchers.</p>\n<p>&quot;Not even for veterans?&quot; Carrillo asked.</p>\n<p>&quot;Not for anybody,&quot; Morrison said.</p>\n<p>And  so it goes in Los Angeles, which is home to one of the hottest rental  markets in the country, and also the nation's largest population of  homeless veterans. For those reasons, L.A. has become the kingpin of the  Obama administration's pledge to end veteran homelessness by the end of  2015.</p>\n<p>One way the government hopes to do that is by issuing  vouchers through the Veterans Affairs Supportive Housing (VASH) program.  The voucher, which is much like a federal Section 8 voucher, helps  veterans pay their rent. Los Angeles received over 800 new Veterans  Affairs Supportive Housing (VASH) vouchers in 2015. And there are close  to 4,000 active leases through VASH right now in the L.A. area.</p>\n<p>But  hundreds of veterans, such as Carrillo, have VASH vouchers but cannot  find a place to use them. Many landlords say the vouchers don't pay  enough to make it worth their while to accept them. Some fear that doing  so would subject them to burdensome government requirements, while  others express general reservations about renting to veterans.</p>\n<div class=\"wysiwyg-asset-image-wrapper inset\">\n<div class=\"wysiwyg-asset-image\"><a class=\"popup\" href=\"http://mediad.publicbroadcasting.net/p/wunc2/files/styles/x_large/public/201508/Carrillo-4_0.jpeg\" class=\"popup\"> </a> &quot;If  I would've known I was in this predicament, I would've never ever moved  out here,&quot; Carrillo said. &quot;I wake up to regret every single day.&quot;</div>\n</div>\n<p>Carrillo  served six&nbsp;years in the U.S. Army, including a deployment to  Afghanistan. After being discharged, he carved out a comfortable life in  Fayetteville, just outside North Carolina&rsquo;s massive Fort Bragg. A  combination of medical conditions left him with a 100% service-connected  medical disability, which pays him about $3,000 each month.</p>\n<p>That  was enough to rent a nice house he, his fiancee, and their 5-year-old  daughter Adrea could live in. With his rent at $650 per month he had  enough left over to save for his daughter&rsquo;s future too.</p>\n<p>Then,  about a year ago, his mother, who lives in Whittier, underwent an  emergency brain operation, and he needed to take care of her as she  recovered.</p>\n<p>Thus began Adrian Carrillo&rsquo;s rough entry into Southern California&rsquo;s rental housing market--and ultimately, homelessness.</p>\n<p>&quot;California is expensive,&quot; he said.</p>\n<p>And VASH seemed like a lifesaver.</p>\n<p>The  voucher would pay a chunk of Carrillo's rent for him. To help him find a  place that'd take it, the V.A. assigned him a caseworker.</p>\n<p>That&rsquo;s when he met Veronica Schenkelberg.</p>\n<p>A  licensed social worker, Schenkelberg walked Carrillo through the  services available to him: medical care, counseling, job training, and  job placement assistance. He was approved for a 2-bedroom apartment and  handed a voucher worth about $1,700.</p>\n<p>&quot;We do lease-up the  veterans,&quot; Schenkelberg said. &quot;It takes a little longer because the  market is so tight, but we do. We do find housing eventually. It just  takes a little bit of time.&quot;</p>\n<p>Part of her job is selling landlords  on the program. But Section 8, an anti-poverty program, has a stigma in  the landlord community, said Charles Lazar, who owns five apartment  buildings in Los Angeles.</p>\n<p>He used to accept Section 8 tenants but  stopped doing so long ago. He feels that some vets may create problems  for his other tenants.</p>\n<p>&quot;What happens if someone does have mental  issues that aren&rsquo;t being addressed?&quot; he said. &quot;When you have someone  screaming in the middle of the night and you&rsquo;ve got people waking up and  kids that are small and they are scared, then you have to deal with it.  What are you going to do?&quot;</p>\n<p>VASH vouchers come with supportive  services and a case worker. Each vet also has a support network tasked  with responding to issues around the clock.</p>\n<p>Ed Cabrera, a spokesman for the U.S. Department of Housing and Urban Development, said he encounters Lazar's argument a lot.</p>\n<p>&quot;There  are a lot of stereotypes out there that affect veterans who&rsquo;ve returned  from combat or current theaters, he said. &quot; So a lot of education needs  to happen.&quot;</p>\n<p>For Carrillo, landlord education won't come soon enough.</p>\n<p>Walking away from his fourth apartment complex of the day, he looked worn out.</p>\n<p>The  landlord there told Carrillo he did indeed have an apartment  available--a 2-bedroom, which&nbsp;at $1,600 per month was well within the  dollar value of Carrillo&rsquo;s voucher--but he wasn't interested in the  voucher program.</p>\n<p>&quot;Man, it just tears you up,&quot; Carrillo said.</p>\n<p>Being homeless was clearly taking its toll.</p>\n<p>&quot;If it was just me and Lori, that&rsquo;s one thing,&quot; Carrillo said, referring to his fiancee. &quot;We can hang in there.</p>\n<p>But  it&rsquo;s very very painful when your daughter wakes up crying and she says  &lsquo;this is not our house, Daddy. I want to go back to North Carolina. I  want to go back to the old house.&rsquo;&quot;</p>\nGetting back into his car,  Carrillo said he was done looking for housing in L.A. He's planning to  leave Southern California and head to Texas, where the family just might  be able to find an affordable, decent home.",
+                "byline": "American Homefront Project",
+                "published": "2015-09-05T02:02:07+00:00",
+                "tags": [
+                    "Hard Feature",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-159273"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/9972efbf-d1e6-4a39-9361-3b9cf9b95b41",
+                        "title": "Former paratrooper Adrian Carrillo with his five year old daughter Adrea. Carrillo has spent months searching for affordable housing in Southern California.",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/033f3c83-fa2b-426b-969d-4e040c400ec1",
+                        "title": "VASH for AHP",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/159273"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/9511115b-75c7-42f4-bbcb-b874ec38da6f",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/9972efbf-d1e6-4a39-9361-3b9cf9b95b41",
+                    "attributes": {
+                        "created": "2015-09-04T15:20:00+00:00",
+                        "modified": "2015-09-04T15:20:00+00:00",
+                        "valid": {
+                            "from": "2015-09-04T15:20:00+00:00",
+                            "to": "3015-09-04T15:20:00+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "9972efbf-d1e6-4a39-9361-3b9cf9b95b41",
+                        "title": "Former paratrooper Adrian Carrillo with his five year old daughter Adrea. Carrillo has spent months searching for affordable housing in Southern California.",
+                        "byline": "",
+                        "itags": [
+                            "prx:story_images-373605"
+                        ],
+                        "published": "2015-09-04T15:20:00+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/76a6ab5607a9ceb8dad06d773bb06c54/0/web/story_image/373605/medium/Carrillo-4.jpeg",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/9972efbf-d1e6-4a39-9361-3b9cf9b95b41"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/033f3c83-fa2b-426b-969d-4e040c400ec1",
+                    "attributes": {
+                        "created": "2015-09-04T15:20:01+00:00",
+                        "modified": "2015-09-04T15:20:01+00:00",
+                        "valid": {
+                            "from": "2015-09-04T15:20:01+00:00",
+                            "to": "3015-09-04T15:20:01+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "033f3c83-fa2b-426b-969d-4e040c400ec1",
+                        "title": "VASH for AHP",
+                        "itags": [
+                            "prx:audio_files-963098"
+                        ],
+                        "published": "2015-09-04T15:20:01+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/3f7012f10c5902d7ff34f06ce9dd9077/0/web/audio_file/963098/broadcast/VASH_for_AHP.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 229,
+                                    "size": 3663345
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/033f3c83-fa2b-426b-969d-4e040c400ec1"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/58377506-f2e5-4fdf-a0bd-bf361b48a7fe",
+            "attributes": {
+                "created": "2015-09-01T23:10:47+00:00",
+                "modified": "2015-09-01T23:10:47+00:00",
+                "valid": {
+                    "from": "2015-09-01T23:10:16+00:00",
+                    "to": "3015-09-01T23:10:16+00:00"
+                },
+                "hreflang": "en",
+                "guid": "58377506-f2e5-4fdf-a0bd-bf361b48a7fe",
+                "title": "70 years later, VJ Day still a vivid memory for veterans",
+                "teaser": "On the 70th anniversary of VJ Day, veterans remember the official end of World War II.",
+                "description": "On the 70th anniversary of VJ Day, veterans remember the official end of World War II.",
+                "contentencoded": "On the 70th anniversary of VJ Day, veterans remember the official end of World War II.",
+                "byline": "American Homefront Project",
+                "published": "2015-09-01T23:10:16+00:00",
+                "tags": [
+                    "Hard Feature",
+                    "Historical",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-159066"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/499f4f60-d1a6-46e7-a86a-5847d9f7172c",
+                        "title": "Henry Chamberlain looks over mementos from his army service. Chamberlain spent more than three years as a Japanese prisoner of war during WWII.",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/2818e06f-70c2-4631-9331-149e45cb75ff",
+                        "title": "npm090215 VJ Day",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/159066"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/58377506-f2e5-4fdf-a0bd-bf361b48a7fe",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/499f4f60-d1a6-46e7-a86a-5847d9f7172c",
+                    "attributes": {
+                        "created": "2015-09-01T23:10:45+00:00",
+                        "modified": "2015-09-01T23:10:46+00:00",
+                        "valid": {
+                            "from": "2015-09-01T23:10:45+00:00",
+                            "to": "3015-09-01T23:10:45+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "499f4f60-d1a6-46e7-a86a-5847d9f7172c",
+                        "title": "Henry Chamberlain looks over mementos from his army service. Chamberlain spent more than three years as a Japanese prisoner of war during WWII.",
+                        "byline": "Patricia Murphy/KUOW",
+                        "itags": [
+                            "prx:story_images-373021"
+                        ],
+                        "published": "2015-09-01T23:10:45+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/bdbd97b9c45543bd7d301f11f92ff03f/0/web/story_image/373021/medium/IMG_1123.JPG",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/499f4f60-d1a6-46e7-a86a-5847d9f7172c"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/2818e06f-70c2-4631-9331-149e45cb75ff",
+                    "attributes": {
+                        "created": "2015-09-01T23:10:46+00:00",
+                        "modified": "2015-09-01T23:10:46+00:00",
+                        "valid": {
+                            "from": "2015-09-01T23:10:46+00:00",
+                            "to": "3015-09-01T23:10:46+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "2818e06f-70c2-4631-9331-149e45cb75ff",
+                        "title": "npm090215 VJ Day",
+                        "itags": [
+                            "prx:audio_files-961532"
+                        ],
+                        "published": "2015-09-01T23:10:46+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/12940efff86ff31030be1116afb331c6/0/web/audio_file/961532/broadcast/npm090215_VJ_Day.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 237,
+                                    "size": 7594325
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/2818e06f-70c2-4631-9331-149e45cb75ff"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/0b9574e8-4794-4fd3-94c8-887a7b53ec22",
+            "attributes": {
+                "created": "2015-08-27T19:55:19+00:00",
+                "modified": "2015-08-27T19:55:19+00:00",
+                "valid": {
+                    "from": "2015-08-27T19:54:48+00:00",
+                    "to": "3015-08-27T19:54:48+00:00"
+                },
+                "hreflang": "en",
+                "guid": "0b9574e8-4794-4fd3-94c8-887a7b53ec22",
+                "title": "Do 22 Veterans A Day Commit Suicide? ",
+                "teaser": "Veterans advocates, protesters, and even President Obama have cited the statistic that 22 veterans a day kill themselves. But the reality is complex, and the number can be misleading.",
+                "description": "A single, deeply-troubling number is shaping the way we think about U.S. veterans: 22.\nAs in: there are 22 veterans a day who commit suicide. That&rsquo;s what a VA study announced in 2013.\nThat simple, easy-to-grasp, and -- in this context -- terrible number has become a rallying cry for veterans groups and activists. But the reality behind it, and what it&rsquo;s doing to the way we think about younger veterans, isn&rsquo;t simple.\n&ldquo;That number, if we talk about it out of context, is questionable,&rdquo; said Keith Jennings, an Iraq war veteran and clinical psychologist who acts as chief science advisor for a Durham, N.C. group called StopSoldierSuicide.org .\n&ldquo;There&rsquo;s a big plus-or-minus and uncertainty and variability behind that,&rdquo; Jennings said.\nA commonly used, but imprecise, number\nAlmost weekly, there are walks, swims and runs dedicated to raising awareness of the 22 statistic. In some cities, there have been street-corner rallies on the 22nd of each month. People in California and Texas held 22-kilometer marches, both led by shirtless Marines in shorts carrying packs that weighed 22 kilograms.\nThere have been lots of news stories this summer about Marine Corps veteran Toby Flaget, who has been walking from Oregon to New Jersey wearing a t-shirt that says, &ldquo;22 is 22 too many.&rdquo;\n&ldquo;People don&rsquo;t want to talk about it, but it&rsquo;s a real problem.&rdquo; Flaget told television station WQAD during a stop in Clinton, Iowa.&nbsp;\nAnd the statistic has inspired more than just physical challenges. It has helped draw more resources for suicide research and prevention.\nIt was frequently cited by supporters of a bill to improve mental health care for veterans that President Barack Obama signed into law early this year .\nThat bill is called the Clay Hunt Suicide Prevention for American Veterans Act , and it&rsquo;s named for a young veteran of the Iraq and Afghanistan wars who killed himself.\nBut as it turns out, 22-a-day has little to do with veterans of those wars.\nThe study that came up with the figure was released in 2012 by the Department of Veterans Affairs Mental Health Services Suicide Prevention Program. While it estimated that 22 veterans died from suicide each day in 2010, it also mentioned some big caveats.\nThey include the study&rsquo;s reliance on death certificates to ascertain who was a veteran. States vary in the way they determine a dead person&rsquo;s veteran status, and the data isn&rsquo;t precise.\nAlso, the data was from just 21 states and didn&rsquo;t include some with large veteran populations. And more than two-thirds of the people in the study who killed themselves were at least 50 years old.\n&ldquo;It is recommended that the estimated number of Veterans be interpreted with caution due to the use of data from a sample of states and existing evidence of uncertainty in Veteran identifiers on U.S. death certificates,&rdquo; wrote the study&rsquo;s authors.\nJennings called the study a Herculean effort by great researchers who were clear about its shortcomings.\n&quot;This number has some variability within it,&quot; Jennings said. &quot;There's some uncertainty in it, and when you talk about this number, it needs to be talked about in context.&rdquo;\nBut too many people aren&rsquo;t using that context, he said.&nbsp;\n&ldquo;When we talk 22 deaths a day, we as Americans think that number, 22, I can hang my hat on it, because it&rsquo;s a hard number. But it&rsquo;s not.&rdquo;\nIt&rsquo;s impossible to know if 22 undercounts or over counts veteran suicides, Jennings said, but it&rsquo;s obvious that mainly it refers to people who didn&rsquo;t serve in Afghanistan or Iraq.\n&ldquo;And a lot of times, when we talk about that 22 veterans per day, that gets kind of subsumed in this larger conversation or a conversation specific to the current cohort of military service members and veterans, but that is not accurate.&rdquo;\nPsychiatrist Bruce Capehart also raises concerns about the 22-a-day meme. Capehart heads the mental health program for Afghanistan and Iraq veterans at the Durham VA Medical Center. He recently spoke to a North Carolina task force about the complexities of suicide research and the problems with the 22-a-day figure.\nCapehart doesn&rsquo;t dispute the idea of 22 people a day dying, but said it&rsquo;s unlikely all are veterans.\nInstead, he said, based on other research, many of those counted as veterans likely served in reserve units, or were on active duty when they died.\nSuicide research complex, challenging\nCaveats and imprecision aren&rsquo;t unusual in research, particularly on suicide, which poses big challenges as a study topic.\nCapehart notes that some suicides are recorded on death certificates as accidents, making it impossible to conduct a reliable count of people who take their own lives. And researchers say studies are hard to do with precision because suicides are relatively rare.\n&ldquo;The numbers that happen with suicide are much less than you would get with something like, say, a cold or the flu,&rdquo; said Department of Defense epidemiologist and statistician Derek Smolenski . &ldquo;For statistics to be robust and to give you good comparisons and very precise values, you need to have a certain number of people that are falling into the study.&rdquo;\nSmolenski, a civilian who works at Joint Base Lewis-McChord in Washington State, was among the authors of two large suicide studies published this year. One found that veterans who served during the Afghanistan and Iraq wars commit suicide at a rate of about one a day. The other concluded that Americans deployed to those wars were actually less  likely to kill themselves than those who served but didn&rsquo;t go to war.\nSmolenski&rsquo;s research also carries caveats. Among them: it followed Afghanistan and Iraq veterans from their time of discharge until 2009, and its conclusions can&rsquo;t necessarily be generalized to other time periods.\nWhich offers a hint into the complexities of suicide research. One plausible theory, say suicide experts, is that combat may not be a serious risk factor for suicide. That could mean the higher rates among older veterans might have little to do with their military service, and instead are tied more to some other demographic trait that they share.\nOr, it could be that combat actually does increase risk, but does so later in life.\nSmolenski said the studies he was involved with shouldn&rsquo;t be compared directly with the 22 research.\nBut, like many suicide researchers, he says he&rsquo;s become used to seeing results misinterpreted.\n&ldquo;I&rsquo;m at the point where I shrug it off,&rdquo; he said. &ldquo;The popular media will latch onto whatever number they want to and go forth from there.&rdquo;\nA corrosive narrative?\nMisinterpreting data, though, could have serious consequences.\nCapehart says reliable data on veteran suicide is important for several reasons, including it helps agencies that fund research and prevention decide where to spend their money.\n&ldquo;That helps us focus what should our efforts be as far as outreach, education, prevention and treatment, because most suicides are related to an underlying mental health condition,&rdquo; Capehart said. &ldquo;But we have to know who those people are that need those treatments before we can offer it to them and help them become engaged in care.&rdquo;\nBeyond precision with data, there&rsquo;s another more subtle issue about the figure of 22 suicides a day.\nWhile it has been a valuable tool for drawing more attention to veterans&rsquo; issues, some who work with Iraq and Afghanistan veterans worry that it contributes to a corrosive stereotype.\n&ldquo;There&rsquo;s a narrative that goes something like: American enlists, American goes to war, American comes back and is diagnosed with a mental health condition or is broken, and because they have PTSD, they ultimately kill themselves,&rdquo; Jennings said. &nbsp;&ldquo;But that&rsquo;s a false narrative.&rdquo;\nAnd it&rsquo;s not the first inaccurate narrative that Americans have built around a generation of veterans.\nJennings, the son of a Vietnam veteran, grew up surrounded by successful, well-adjusted veterans of that war. Even so, he says, when he thinks about Vietnam vets, his mind reflexively conjures up the cartoonish stereotype of a man on a street corner, begging from a wheelchair with a POW-MIA flag.\nThis kind of narrative is powerful stuff. And some scientists and veterans advocates fear all the talk of 22 deaths a day, without the caveats, may actually be leading more young veterans to kill themselves.\n&ldquo;That is the thing that scares me about being very overt and talking about it,&rdquo; said Ilario Pantano , North Carolina&rsquo;s Director of Veterans Affairs. &ldquo;Does it legitimize it as a course of action?&rdquo;\nPantano, also an Iraq combat veteran, says the stereotype can make life harder even for vets who aren&rsquo;t struggling with mental health problems.\n&ldquo;Potentially it causes an employer to be reluctant to hire a veteran or somebody to be uncomfortable to be in a relationship with a veteran,&rdquo; he said. &ldquo;And then that can lead to a negative spiral downstream just because there&rsquo;s some perception that there&rsquo;s some fragility or danger associated with that person.\nResearch on military suicides has increased in recent years. And the VA, Department of Defense, and Centers for Disease Control and Prevention are sharing data to make studies more precise, said Jackie Maffucci, research director for the Iraq and Afghanistan Veterans of America .\nMaffucci&rsquo;s group campaigned to get the Clay Hunt bill passed, and used the 22 statistic while doing so, she said. But it tried to be clear about the nature of that number.\n&ldquo;We tried our best to balance the conversation, in a sense that we never wanted to give the impression that it was 22 post-9/11 veterans because that is just not true,&rdquo; she said.&nbsp; &nbsp;\n&ldquo;I do think (22) is very important for educational purposes,&rdquo; Maffucci said. &ldquo;It&rsquo;s very important to start the conversation, and it&rsquo;s a conversation that needs to be had about the challenges within the veteran community, and some of the challenges that are arising with mental health care, with suicide prevention specifically. But certainly there are intricacies to that number.&rdquo;&rsquo;\nMaffucci said her group&rsquo;s members consistently say in surveys that suicide and mental health are the issues that most concern them. And though 22-a-day isn&rsquo;t close to the real number of Iraq and Afghanistan vets who kill themselves, part of the complex reality is that some still do, and at higher rates than the general population.\nIt&rsquo;s also true that significant numbers of young veterans suffer problems such as PTSD and traumatic brain injury.\nBoth Jennings and Pantano know men who served under them in Iraq and killed themselves after coming home. Pantano keeps the photo of one in his office, and he has made suicide prevention and mental health issues priorities for his department.\n&ldquo;What I will tell you is, one is too many,&rdquo; Pantano said. &ldquo;One a day is too many.&rdquo;\nBut Jennings says people should remember the complex truth about suicide when they meet a young combat vet or hear that 22 statistic.\n&ldquo;What gets lost in the conversation is the majority &mdash; actually you can say the vast majority of folks &mdash; do okay,&rdquo; he said. &ldquo;The vast majority of our veterans do okay.&rdquo;",
+                "contentencoded": "<p>A single, deeply-troubling number is shaping the way we think about U.S. veterans: 22.</p>\n<p>As in: there are 22 veterans a day who commit suicide. That&rsquo;s what a <a href=\"http://www.va.gov/opa/docs/suicide-data-report-2012-final.pdf\" target=\"_blank\">VA study</a> announced in 2013.</p>\n<p>That simple, easy-to-grasp, and -- in this context -- terrible number has become a rallying cry for veterans groups and activists. But the reality behind it, and what it&rsquo;s doing to the way we think about younger veterans, isn&rsquo;t simple.</p>\n<p>&ldquo;That number, if we talk about it out of context, is questionable,&rdquo; said Keith Jennings, an Iraq war veteran and clinical psychologist who acts as chief science advisor for a Durham, N.C. group called <a href=\"http://www.stopsoldiersuicide.org/\" target=\"_blank\">StopSoldierSuicide.org</a> .</p>\n<p>&ldquo;There&rsquo;s a big plus-or-minus and uncertainty and variability behind that,&rdquo; Jennings said.</p>\n<p><strong>A commonly used, but imprecise, number</strong></p>\n<p>Almost weekly, there are walks, swims and runs dedicated to raising awareness of the 22 statistic. In some cities, there have been street-corner rallies on the 22nd of each month. People in California and Texas held 22-kilometer marches, both <a href=\"http://www.usatoday.com/story/news/nation/2015/07/25/marines-march-silkies-raise-suicide-awarness/30664319/\" target=\"_blank\">led by shirtless Marines in shorts</a> carrying packs that weighed 22 kilograms.</p>\n<p>There have been lots of news stories this summer about Marine Corps veteran Toby Flaget, who has been walking from Oregon to New Jersey wearing a t-shirt that says, &ldquo;22 is 22 too many.&rdquo;</p>\n<p>&ldquo;People don&rsquo;t want to talk about it, but it&rsquo;s a real problem.&rdquo; Flaget <a href=\"http://wqad.com/2015/07/15/marine-walking-across-the-country-to-raise-awareness-about-veteran-suicide/\" target=\"_blank\">told television station WQAD</a> during a stop in Clinton, Iowa.&nbsp;</p>\n<p>And the statistic has inspired more than just physical challenges. It has helped draw more resources for suicide research and prevention.</p>\n<p>It was frequently cited by supporters of a bill to improve mental health care for veterans that <a href=\"https://www.whitehouse.gov/blog/2015/02/12/clay-hunt-act-what-president-just-signed\" target=\"_blank\">President Barack Obama signed into law early this year</a> .</p>\n<p>That bill is called the <a href=\"http://iava.org/savact/\" target=\"_blank\">Clay Hunt Suicide Prevention for American Veterans Act</a> , and it&rsquo;s named for a young veteran of the Iraq and Afghanistan wars who killed himself.</p>\n<p>But as it turns out, 22-a-day has little to do with veterans of those wars.</p>\n<p>The <a href=\"http://www.va.gov/opa/docs/suicide-data-report-2012-final.pdf\" target=\"_blank\">study that came up with the figure</a> was released in 2012 by the Department of Veterans Affairs Mental Health Services Suicide Prevention Program. While it estimated that 22 veterans died from suicide each day in 2010, it also mentioned some big caveats.</p>\n<p>They include the study&rsquo;s reliance on death certificates to ascertain who was a veteran. States vary in the way they determine a dead person&rsquo;s veteran status, and the data isn&rsquo;t precise.</p>\n<p>Also, the data was from just 21 states and didn&rsquo;t include some with large veteran populations. And more than two-thirds of the people in the study who killed themselves were at least 50 years old.</p>\n<p>&ldquo;It is recommended that the estimated number of Veterans be interpreted with caution due to the use of data from a sample of states and existing evidence of uncertainty in Veteran identifiers on U.S. death certificates,&rdquo; wrote the study&rsquo;s authors.</p>\n<p>Jennings called the study a Herculean effort by great researchers who were clear about its shortcomings.</p>\n<p>&quot;This number has some variability within it,&quot; Jennings said. &quot;There's some uncertainty in it, and when you talk about this number, it needs to be talked about in context.&rdquo;</p>\n<p>But too many people aren&rsquo;t using that context, he said.&nbsp;</p>\n<p>&ldquo;When we talk 22 deaths a day, we as Americans think that number, 22, I can hang my hat on it, because it&rsquo;s a hard number. But it&rsquo;s not.&rdquo;</p>\n<p>It&rsquo;s impossible to know if 22 undercounts or over counts veteran suicides, Jennings said, but it&rsquo;s obvious that mainly it refers to people who didn&rsquo;t serve in Afghanistan or Iraq.</p>\n<p>&ldquo;And a lot of times, when we talk about that 22 veterans per day, that gets kind of subsumed in this larger conversation or a conversation specific to the current cohort of military service members and veterans, but that is not accurate.&rdquo;</p>\n<p><a href=\"http://psychiatry.duke.edu/faculty/details/0115546\">Psychiatrist Bruce Capehart</a> also raises concerns about the 22-a-day meme. Capehart heads the mental health program for Afghanistan and Iraq veterans at the Durham VA Medical Center. He recently spoke to a North Carolina task force about the complexities of suicide research and the problems with the 22-a-day figure.</p>\n<p>Capehart doesn&rsquo;t dispute the idea of 22 people a day dying, but said it&rsquo;s unlikely all are veterans.</p>\n<p>Instead, he said, based on other research, many of those counted as veterans likely served in reserve units, or were on active duty when they died.</p>\n<p><strong>Suicide research complex, challenging</strong></p>\n<p>Caveats and imprecision aren&rsquo;t unusual in research, particularly on suicide, which poses big challenges as a study topic.</p>\n<p>Capehart notes that some suicides are recorded on death certificates as accidents, making it impossible to conduct a reliable count of people who take their own lives. And researchers say studies are hard to do with precision because suicides are relatively rare.</p>\n<p>&ldquo;The numbers that happen with suicide are much less than you would get with something like, say, a cold or the flu,&rdquo; said Department of Defense epidemiologist and statistician <a href=\"https://www.linkedin.com/pub/derek-smolenski/9a/5a0/152\" target=\"_blank\">Derek Smolenski</a> . &ldquo;For statistics to be robust and to give you good comparisons and very precise values, you need to have a certain number of people that are falling into the study.&rdquo;</p>\n<p>Smolenski, a civilian who works at Joint Base Lewis-McChord in Washington State, was among the authors of two large suicide studies published this year. <a href=\"http://www.annalsofepidemiology.org/article/S1047-2797%2814%2900525-0/fulltext\" target=\"_blank\">One found</a> that veterans who served during the Afghanistan and Iraq wars commit suicide at a rate of about one a day. The <a href=\"http://archpsyc.jamanetwork.com/article.aspx?articleid=2211891\" target=\"_blank\">other concluded</a> that Americans deployed to those wars were actually <em>less </em> likely to kill themselves than those who served but didn&rsquo;t go to war.</p>\n<p>Smolenski&rsquo;s research also carries caveats. Among them: it followed Afghanistan and Iraq veterans from their time of discharge until 2009, and its conclusions can&rsquo;t necessarily be generalized to other time periods.</p>\n<p>Which offers a hint into the complexities of suicide research. One plausible theory, say suicide experts, is that combat may not be a serious risk factor for suicide. That could mean the higher rates among older veterans might have little to do with their military service, and instead are tied more to some other demographic trait that they share.</p>\n<p>Or, it could be that combat actually does increase risk, but does so later in life.</p>\n<p>Smolenski said the studies he was involved with shouldn&rsquo;t be compared directly with the 22 research.</p>\n<p>But, like many suicide researchers, he says he&rsquo;s become used to seeing results misinterpreted.</p>\n<p>&ldquo;I&rsquo;m at the point where I shrug it off,&rdquo; he said. &ldquo;The popular media will latch onto whatever number they want to and go forth from there.&rdquo;</p>\n<p><strong>A corrosive narrative?</strong></p>\n<p>Misinterpreting data, though, could have serious consequences.</p>\n<p>Capehart says reliable data on veteran suicide is important for several reasons, including it helps agencies that fund research and prevention decide where to spend their money.</p>\n<p>&ldquo;That helps us focus what should our efforts be as far as outreach, education, prevention and treatment, because most suicides are related to an underlying mental health condition,&rdquo; Capehart said. &ldquo;But we have to know who those people are that need those treatments before we can offer it to them and help them become engaged in care.&rdquo;</p>\n<p>Beyond precision with data, there&rsquo;s another more subtle issue about the figure of 22 suicides a day.</p>\n<p>While it has been a valuable tool for drawing more attention to veterans&rsquo; issues, some who work with Iraq and Afghanistan veterans worry that it contributes to a corrosive stereotype.</p>\n<p>&ldquo;There&rsquo;s a narrative that goes something like: American enlists, American goes to war, American comes back and is diagnosed with a mental health condition or is broken, and because they have PTSD, they ultimately kill themselves,&rdquo; Jennings said. &nbsp;&ldquo;But that&rsquo;s a false narrative.&rdquo;</p>\n<p>And it&rsquo;s not the first inaccurate narrative that Americans have built around a generation of veterans.</p>\n<p>Jennings, the son of a Vietnam veteran, grew up surrounded by successful, well-adjusted veterans of that war. Even so, he says, when he thinks about Vietnam vets, his mind reflexively conjures up the cartoonish stereotype of a man on a street corner, begging from a wheelchair with a POW-MIA flag.</p>\n<p>This kind of narrative is powerful stuff. And some scientists and veterans advocates fear all the talk of 22 deaths a day, without the caveats, may actually be leading more young veterans to kill themselves.</p>\n<p>&ldquo;That is the thing that scares me about being very overt and talking about it,&rdquo; said <a href=\"https://www.nccommerce.com/about-our-department/boards-commissions/nc-military-affairs-commission/commission-members?udt_9771_param_detail=29475\" target=\"_blank\">Ilario Pantano</a> , North Carolina&rsquo;s Director of Veterans Affairs. &ldquo;Does it legitimize it as a course of action?&rdquo;</p>\n<p>Pantano, also an Iraq combat veteran, says the stereotype can make life harder even for vets who aren&rsquo;t struggling with mental health problems.</p>\n<p>&ldquo;Potentially it causes an employer to be reluctant to hire a veteran or somebody to be uncomfortable to be in a relationship with a veteran,&rdquo; he said. &ldquo;And then that can lead to a negative spiral downstream just because there&rsquo;s some perception that there&rsquo;s some fragility or danger associated with that person.</p>\n<p>Research on military suicides has increased in recent years. And the VA, Department of Defense, and Centers for Disease Control and Prevention are sharing data to make studies more precise, said Jackie Maffucci, research director for the <a href=\"http://iava.org/\" target=\"_blank\">Iraq and Afghanistan Veterans of America</a> .</p>\n<p>Maffucci&rsquo;s group campaigned to get the Clay Hunt bill passed, and used the 22 statistic while doing so, she said. But it tried to be clear about the nature of that number.</p>\n<p>&ldquo;We tried our best to balance the conversation, in a sense that we never wanted to give the impression that it was 22 post-9/11 veterans because that is just not true,&rdquo; she said.&nbsp; &nbsp;</p>\n<p>&ldquo;I do think (22) is very important for educational purposes,&rdquo; Maffucci said. &ldquo;It&rsquo;s very important to start the conversation, and it&rsquo;s a conversation that needs to be had about the challenges within the veteran community, and some of the challenges that are arising with mental health care, with suicide prevention specifically. But certainly there are intricacies to that number.&rdquo;&rsquo;</p>\n<p>Maffucci said her group&rsquo;s members consistently say in surveys that suicide and mental health are the issues that most concern them. And though 22-a-day isn&rsquo;t close to the real number of Iraq and Afghanistan vets who kill themselves, part of the complex reality is that some still do, and at higher rates than the general population.</p>\n<p>It&rsquo;s also true that significant numbers of young veterans suffer problems such as PTSD and traumatic brain injury.</p>\n<p>Both Jennings and Pantano know men who served under them in Iraq and killed themselves after coming home. Pantano keeps the photo of one in his office, and he has made suicide prevention and mental health issues priorities for his department.</p>\n<p>&ldquo;What I will tell you is, one is too many,&rdquo; Pantano said. &ldquo;One a day is too many.&rdquo;</p>\n<p>But Jennings says people should remember the complex truth about suicide when they meet a young combat vet or hear that 22 statistic.</p>\n<p>&ldquo;What gets lost in the conversation is the majority &mdash; actually you can say the vast majority of folks &mdash; do okay,&rdquo; he said. &ldquo;The vast majority of our veterans do okay.&rdquo;</p>",
+                "byline": "American Homefront Project",
+                "published": "2015-08-27T19:54:48+00:00",
+                "tags": [
+                    "Hard Feature",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-158539"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/dab955bb-778a-4d88-b211-e6ad8239f2f9",
+                        "title": "Veterans and their spouses gathered in Huntsville, Alabama in April as part of a movement called '22 Too Many.'",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/17fde6a0-0d7c-4526-9977-d8fa96834c9a",
+                        "title": "Veteran suicide statistics",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/158539"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/0b9574e8-4794-4fd3-94c8-887a7b53ec22",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/dab955bb-778a-4d88-b211-e6ad8239f2f9",
+                    "attributes": {
+                        "created": "2015-08-27T19:55:17+00:00",
+                        "modified": "2015-08-27T19:55:17+00:00",
+                        "valid": {
+                            "from": "2015-08-27T19:55:17+00:00",
+                            "to": "3015-08-27T19:55:17+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "dab955bb-778a-4d88-b211-e6ad8239f2f9",
+                        "title": "Veterans and their spouses gathered in Huntsville, Alabama in April as part of a movement called '22 Too Many.'",
+                        "byline": "The Huntsville Times/Steve Doyle",
+                        "itags": [
+                            "prx:story_images-372053"
+                        ],
+                        "published": "2015-08-27T19:55:17+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/84cd01375275fc20877e887d4bec924d/0/web/story_image/372053/medium/Alabama_suicide_protest.JPG",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/dab955bb-778a-4d88-b211-e6ad8239f2f9"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/17fde6a0-0d7c-4526-9977-d8fa96834c9a",
+                    "attributes": {
+                        "created": "2015-08-27T19:55:18+00:00",
+                        "modified": "2015-08-27T19:55:18+00:00",
+                        "valid": {
+                            "from": "2015-08-27T19:55:18+00:00",
+                            "to": "3015-08-27T19:55:18+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "17fde6a0-0d7c-4526-9977-d8fa96834c9a",
+                        "title": "Veteran suicide statistics",
+                        "itags": [
+                            "prx:audio_files-957577"
+                        ],
+                        "published": "2015-08-27T19:55:18+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/8aa018f21cb480d627d941b82ed7907b/0/web/audio_file/957577/broadcast/Veteran_suicide_PRX.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 425,
+                                    "size": 13595470
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/17fde6a0-0d7c-4526-9977-d8fa96834c9a"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/aef667c2-4a0d-420f-9f01-d7b77a2ce6b4",
+            "attributes": {
+                "created": "2015-08-11T05:13:34+00:00",
+                "modified": "2015-08-13T20:19:25+00:00",
+                "valid": {
+                    "from": "2015-08-13T20:18:50+00:00",
+                    "to": "3015-08-13T20:18:50+00:00"
+                },
+                "hreflang": "en",
+                "guid": "aef667c2-4a0d-420f-9f01-d7b77a2ce6b4",
+                "title": "A Pod Of Their Own: Washington State Prison Keeps Veterans Together",
+                "teaser": "Military veterans have their own hospitals, their own cemeteries, and now – in a handful of states – their own prison units.\n\nIn Washington State, California, Virginia, and elsewhere, veterans who commit crimes can be assigned to special prisons that house incarcerated veterans together.\n\nCorrections officials say their shared experience makes it easier for the inmates to adapt to life behind bars.  But it's unclear if it helps them once they leave prison.",
+                "description": "\nEvery morning the flags at Stafford Creek Corrections Center in Aberdeen, Washington, are raised in a color guard ceremony.\nThe 10 men who do the job are inmates and veterans. \nThe ceremony ends with a salute, although the solemnity and reverence can seem strange in this setting.\nThe color guard, still in formation, walks along the concertina wire past the guard shack back to their housing unit, which they call their pod.\nWashington is among a handful of states that have started such programs to house incarcerated veterans together.\nCorrectional unit supervisor Tera McElravy said the two-year-old program doesn&rsquo;t aim to recreate the military. Rather it enables the state Department of Corrections to use the inmates&rsquo; shared life experiences to help with rehabilitation and transition. &nbsp;\n&ldquo;We want to recapture that positive stuff that they learned in the military and them have them apply it to civilian life,&rdquo; McElravy said.\nThe 90 or so men move about their unit freely. The walls are painted with armed forces insignia and flags.\nThe program is attractive to prison officials largely because it doesn't cost extra money. Inmates with non-violent behavior while in prison are eligible; they work with the State Department of Veterans Affairs to sign up for VA benefits, services and job training.\nInmate Michael Kent began serving time for robbery in 2011 and came to the vets pod a year and a half ago.\n&ldquo;When I came to the pod, people greeted me. I was like, &lsquo;Whoa, something is different here,&rsquo;&rdquo; Kent said. A common background helped to foster a sense of responsibility.\n&ldquo;There wasn&rsquo;t all the politics. There wasn't all the other garbage to be involved in,&rdquo; he said. &ldquo;All they were trying to do is help each other out. &ldquo;\nAt Kent&rsquo;s feet was Snickers, a chocolate-colored dog, whose tail beats a steady thump on the tile floor. Kent is training Snickers as a service dog for a wounded veteran. It&rsquo;s one of a few community service programs inmates can participate in.\nThere are skeptics who question the effectiveness of inmate-veteran programs in Oregon, Florida and Colorado.\nAmong them is William Brown, a criminal justice professor at Western Oregon University. He&rsquo;s also a veteran.\nBrown said it makes sense that housing veterans together works well in prison. He said they're used to participating in what&rsquo;s known as a total institution &ndash; or a closed, formally structured way of living.\n&ldquo;They&rsquo;ve already adapted to the basic indispensable factors of the military total institution: obedience, discipline, survival and sacrifice,&rdquo; Brown said.\nBrown said the test of a program's success depends on what happens after the inmates are released. &ldquo;Eventually you're going to have to put them into the civilian culture. How are they going to navigate there?&rdquo;\nEven within this prison, inmates who are veterans face special challenges. Kent has experienced pushback from guards who were in the military. He has been called out by fellow Army Rangers while working out at the prison gym and jeered while serving on the color guard.\n&ldquo;It&rsquo;s almost like, &lsquo;What right do you think you have to touch the flag? You broke the law. You let people down,&rsquo;&rdquo; Kent said.\nThat&rsquo;s something he and others in this unit know they will need to deal with on the outside. Not only being an ex-con, but being perceived as a failed veteran.\n&ldquo;That may be true, but that doesn&rsquo;t mean that we can&rsquo;t find it within ourselves to redeem that &ndash; to reach back,&rdquo; Kent said.\nSo far eight offenders have been released from the veterans&rsquo; pods in Washington. One is back in prison.\nMcElravy, the unit supervisor, said the program is a work in progress, but so far the results have been positive, and the state plans to expand it to accommodate more of the approximately 1,500 Washington state inmates who once served in the armed forces.\n    ",
+                "contentencoded": "<span id=\"docs-internal-guid-893428b6-18de-923c-f712-13f23101f536\">\n<p dir=\"ltr\"><span>Every morning the flags at Stafford Creek Corrections Center in Aberdeen, Washington, are raised in a color guard ceremony.</span></p>\n<p dir=\"ltr\"><span>The 10 men who do the job are inmates and veterans. </span></p>\n<p dir=\"ltr\"><span>The ceremony ends with a salute, although the solemnity and reverence can seem strange in this setting.</span></p>\n<p dir=\"ltr\"><span>The color guard, still in formation, walks along the concertina wire past the guard shack back to their housing unit, which they call their pod.</span></p>\n<p dir=\"ltr\"><span>Washington is among a handful of states that have started such programs to house incarcerated veterans together.</span></p>\n<p dir=\"ltr\"><span>Correctional unit supervisor Tera McElravy said the two-year-old program doesn&rsquo;t aim to recreate the military. Rather it enables the state Department of Corrections to use the inmates&rsquo; shared life experiences to help with rehabilitation and transition. &nbsp;</span></p>\n<p dir=\"ltr\"><span>&ldquo;We want to recapture that positive stuff that they learned in the military and them have them apply it to civilian life,&rdquo; McElravy said.</span></p>\n<p dir=\"ltr\"><span>The 90 or so men move about their unit freely. The walls are painted with armed forces insignia and flags.</span></p>\n<p dir=\"ltr\"><span>The program is attractive to prison officials largely because it doesn't cost extra money. Inmates with non-violent behavior while in prison are eligible; they work with the State Department of Veterans Affairs to sign up for VA benefits, services and job training.</span></p>\n<p dir=\"ltr\"><span>Inmate Michael Kent began serving time for robbery in 2011 and came to the vets pod a year and a half ago.</span></p>\n<p dir=\"ltr\"><span>&ldquo;When I came to the pod, people greeted me. I was like, &lsquo;Whoa, something is different here,&rsquo;&rdquo; Kent said. A common background helped to foster a sense of responsibility.</span></p>\n<p dir=\"ltr\"><span>&ldquo;There wasn&rsquo;t all the politics. There wasn't all the other garbage to be involved in,&rdquo; he said. &ldquo;All they were trying to do is help each other out. &ldquo;</span></p>\n<p dir=\"ltr\"><span>At Kent&rsquo;s feet was Snickers, a chocolate-colored dog, whose tail beats a steady thump on the tile floor. Kent is training Snickers as a service dog for a wounded veteran. It&rsquo;s one of a few community service programs inmates can participate in.</span></p>\n<p dir=\"ltr\"><span>There are skeptics who question the effectiveness of inmate-veteran programs in Oregon, Florida and Colorado.</span></p>\n<p dir=\"ltr\"><span>Among them is William Brown, a criminal justice professor at Western Oregon University. He&rsquo;s also a veteran.</span></p>\n<p dir=\"ltr\"><span>Brown said it makes sense that housing veterans together works well in prison. He said they're used to participating in what&rsquo;s known as a total institution &ndash; or a closed, formally structured way of living.</span></p>\n<p dir=\"ltr\"><span>&ldquo;They&rsquo;ve already adapted to the basic indispensable factors of the military total institution: obedience, discipline, survival and sacrifice,&rdquo; Brown said.</span></p>\n<p dir=\"ltr\"><span>Brown said the test of a program's success depends on what happens after the inmates are released. &ldquo;Eventually you're going to have to put them into the civilian culture. How are they going to navigate there?&rdquo;</span></p>\n<p dir=\"ltr\"><span>Even within this prison, inmates who are veterans face special challenges. Kent has experienced pushback from guards who were in the military. He has been called out by fellow Army Rangers while working out at the prison gym and jeered while serving on the color guard.</span></p>\n<p dir=\"ltr\"><span>&ldquo;It&rsquo;s almost like, &lsquo;What right do you think you have to touch the flag? You broke the law. You let people down,&rsquo;&rdquo; Kent said.</span></p>\n<p dir=\"ltr\"><span>That&rsquo;s something he and others in this unit know they will need to deal with on the outside. Not only being an ex-con, but being perceived as a failed veteran.</span></p>\n<p dir=\"ltr\"><span>&ldquo;That may be true, but that doesn&rsquo;t mean that we can&rsquo;t find it within ourselves to redeem that &ndash; to reach back,&rdquo; Kent said.</span></p>\n<p dir=\"ltr\"><span>So far eight offenders have been released from the veterans&rsquo; pods in Washington. One is back in prison.</span></p>\n<p dir=\"ltr\"><span>McElravy, the unit supervisor, said the program is a work in progress, but so far the results have been positive, and the state plans to expand it to accommodate more of the approximately 1,500 Washington state inmates who once served in the armed forces.</span></p>\n<br /> <br /> <br /> <br /> </span>",
+                "byline": "American Homefront Project",
+                "published": "2015-08-13T20:18:50+00:00",
+                "tags": [
+                    "Hard Feature",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-157297"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/cae1621e-7d8f-4890-a9d0-c6cb32c2adbb",
+                        "title": "Inmate and veteran Derron Alexus holds the flag during the color guard ceromony at Stafford Creek Corrections Center in Aberdeen, Washington.",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/2c470796-f9df-41da-9a4b-c8f8c832f7e7",
+                        "title": "0810 Prison Vets",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/157297"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/aef667c2-4a0d-420f-9f01-d7b77a2ce6b4",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/cae1621e-7d8f-4890-a9d0-c6cb32c2adbb",
+                    "attributes": {
+                        "created": "2015-08-11T05:13:33+00:00",
+                        "modified": "2015-08-11T05:13:33+00:00",
+                        "valid": {
+                            "from": "2015-08-11T05:13:33+00:00",
+                            "to": "3015-08-11T05:13:33+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "cae1621e-7d8f-4890-a9d0-c6cb32c2adbb",
+                        "title": "Inmate and veteran Derron Alexus holds the flag during the color guard ceromony at Stafford Creek Corrections Center in Aberdeen, Washington.",
+                        "byline": "Patricia Murphy/KUOW",
+                        "itags": [
+                            "prx:story_images-369311"
+                        ],
+                        "published": "2015-08-11T05:13:33+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/2b650e27982300257a9e69b0b6e5f49a/0/web/story_image/369311/medium/IMG_1027.JPG",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/cae1621e-7d8f-4890-a9d0-c6cb32c2adbb"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/2c470796-f9df-41da-9a4b-c8f8c832f7e7",
+                    "attributes": {
+                        "created": "2015-08-11T05:13:34+00:00",
+                        "modified": "2015-08-11T05:13:34+00:00",
+                        "valid": {
+                            "from": "2015-08-11T05:13:34+00:00",
+                            "to": "3015-08-11T05:13:34+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "2c470796-f9df-41da-9a4b-c8f8c832f7e7",
+                        "title": "0810 Prison Vets",
+                        "itags": [
+                            "prx:audio_files-947707"
+                        ],
+                        "published": "2015-08-11T05:13:34+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/bb43ca6c38507981a0651daeef395ede/0/web/audio_file/947707/broadcast/0810_Prison_Vets.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 245,
+                                    "size": 7859020
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/2c470796-f9df-41da-9a4b-c8f8c832f7e7"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/5be70df9-9fc4-41c0-b554-0dc1765e886b",
+            "attributes": {
+                "created": "2015-07-27T17:57:39+00:00",
+                "modified": "2015-07-27T17:57:39+00:00",
+                "valid": {
+                    "from": "2015-07-27T17:57:07+00:00",
+                    "to": "3015-07-27T17:57:07+00:00"
+                },
+                "hreflang": "en",
+                "guid": "5be70df9-9fc4-41c0-b554-0dc1765e886b",
+                "title": "Fortifying Armed Forces Recruiting Centers Might Make It Harder to Recruit",
+                "teaser": "Since this month's shootings at a military recruiting center and Navy Reserve center in Tennessee, some members of Congress have called for arming recruiters and fortifying recruiting centers against potential attackers.\n\nBut recruiters worry that could upset the tone that the armed forces recruiting command tries to present to potential recruits.\n\nPatricia Murphy reports.\n\n\n",
+                "description": "\n\n\nThe first thing a new recruit will encounter at the Army Career Center in&nbsp;Tukwila, Washington, is a locked door.\nIt&rsquo;s  one of the changes at recruiting stations since the shootings earlier  this month at a military facility&nbsp;in Chattanooga, Tennessee.\n&ldquo;We  have added a few anti-terrorism measures just out of caution,&rdquo; said  Army Captain&nbsp;Kellam&nbsp;Carmody, who&rsquo;s in charge of this facility.\nSome  members of Congress now&nbsp;want recruiters armed against potential  attackers.&nbsp;But while those measures may be necessary for safety, some  recruiters have mixed feelings about them, because they might also deter  potential recruits.&nbsp;\n&ldquo;We want to be approachable. It&rsquo;s an  all-volunteer force. We don&rsquo;t want to have any additional barriers to  those that may be interested in serving,&rdquo; Carmody said. &nbsp;\nThe center is located on a main road in a shopping center. It shares a parking lot with a Starbucks and a Value Village.&nbsp;\nCarmody&nbsp;said  recruiting offices rely on visibility and accessibly. &quot;Because we want  people to easily you know be able to find us and come speak with  us,&rdquo;&nbsp;Carmody&nbsp;said.\nMaintaining the ranks of the armed forces is  essential. In Washington state, that means getting at least 1,500 new  service members a year to sign up.\nAnd where a recruiting station is located can make all the difference.\nAs  a mission market analyst for the Army it&rsquo;s Tracy Cutler&rsquo;s job to find  the most fruitful locations. &ldquo;I analyze demographics, ethnicity,  languages spoken in the household,&rdquo; Cutler said.\nCutler watches  trends. A lot of the information he uses is publicly available. Some of  it comes from a data warehouse at Fort Knox.\n&ldquo;The biggest thing  is when I see high schools being built. When you see that expansion,  that pops. Also, when you look at some of where businesses are  populating. New businesses &ndash; Costcos,&nbsp;Wal-Marts,&nbsp;things like that,&ldquo;  Cutler said.\nAnd colleges. Recent graduates, or current students  looking for a change. &ldquo;They're underemployed. Maybe they're getting  tired of going to school. Or they want a break from school,&rdquo; Cutler  said.\nCutler tracks what motivates recruits from different  counties. The recruits who live in the areas around Washington&rsquo;s Joint  Base Lewis-McChord&nbsp;are driven by a desire to serve the county, and the  education benefits they can gain from military service.\nBut in  the northern part of the state, it&rsquo;s all about adventure. &ldquo;I want to  jump out of airplanes I want to be airborne ranger. I want to do civil  affairs. I want to be a combat engineer,&rdquo; Cutler said.\nCutler analyzes the recruitment numbers weekly and reports them to command. When a location&nbsp;underperforms, it&rsquo;s moved.\nThe&nbsp;Tukwila&nbsp;Center  is well established.&nbsp; It hosts recruiters from all four branches of the  service. About a dozen work in the Army office.\nEven after the  Tennessee shootings, as discussions continue in Washington, D.C., about  protecting centers like this, Carmody&nbsp;said his troops have to stay  focused. &ldquo;You know personally, any time one of our brothers in arms is  injured or killed it's a sad, sad situation. But we still have a job to  do so we have to focus on the task at hand and keep  working,&rdquo;&nbsp;Carmody&nbsp;said.\n\n\n",
+                "contentencoded": "<div class=\"field field-name-body field-type-text-with-summary field-label-hidden\">\n<div class=\"field-items\">\n<div class=\"field-item even\">\n<p>The first thing a new recruit will encounter at the Army Career Center in&nbsp;Tukwila, Washington, is a locked door.</p>\n<p>It&rsquo;s  one of the changes at recruiting stations since the shootings earlier  this month at a military facility&nbsp;in Chattanooga, Tennessee.</p>\n<p>&ldquo;We  have added a few anti-terrorism measures just out of caution,&rdquo; said  Army Captain&nbsp;Kellam&nbsp;Carmody, who&rsquo;s in charge of this facility.</p>\n<p>Some  members of Congress now&nbsp;want recruiters armed against potential  attackers.&nbsp;But while those measures may be necessary for safety, some  recruiters have mixed feelings about them, because they might also deter  potential recruits.&nbsp;</p>\n<p>&ldquo;We want to be approachable. It&rsquo;s an  all-volunteer force. We don&rsquo;t want to have any additional barriers to  those that may be interested in serving,&rdquo; Carmody said. &nbsp;</p>\n<p>The center is located on a main road in a shopping center. It shares a parking lot with a Starbucks and a Value Village.&nbsp;</p>\n<p>Carmody&nbsp;said  recruiting offices rely on visibility and accessibly. &quot;Because we want  people to easily you know be able to find us and come speak with  us,&rdquo;&nbsp;Carmody&nbsp;said.</p>\n<p>Maintaining the ranks of the armed forces is  essential. In Washington state, that means getting at least 1,500 new  service members a year to sign up.</p>\n<p>And where a recruiting station is located can make all the difference.</p>\n<p>As  a mission market analyst for the Army it&rsquo;s Tracy Cutler&rsquo;s job to find  the most fruitful locations. &ldquo;I analyze demographics, ethnicity,  languages spoken in the household,&rdquo; Cutler said.</p>\n<p>Cutler watches  trends. A lot of the information he uses is publicly available. Some of  it comes from a data warehouse at Fort Knox.</p>\n<p>&ldquo;The biggest thing  is when I see high schools being built. When you see that expansion,  that pops. Also, when you look at some of where businesses are  populating. New businesses &ndash; Costcos,&nbsp;Wal-Marts,&nbsp;things like that,&ldquo;  Cutler said.</p>\n<p>And colleges. Recent graduates, or current students  looking for a change. &ldquo;They're underemployed. Maybe they're getting  tired of going to school. Or they want a break from school,&rdquo; Cutler  said.</p>\n<p>Cutler tracks what motivates recruits from different  counties. The recruits who live in the areas around Washington&rsquo;s Joint  Base Lewis-McChord&nbsp;are driven by a desire to serve the county, and the  education benefits they can gain from military service.</p>\n<p>But in  the northern part of the state, it&rsquo;s all about adventure. &ldquo;I want to  jump out of airplanes I want to be airborne ranger. I want to do civil  affairs. I want to be a combat engineer,&rdquo; Cutler said.</p>\n<p>Cutler analyzes the recruitment numbers weekly and reports them to command. When a location&nbsp;underperforms, it&rsquo;s moved.</p>\n<p>The&nbsp;Tukwila&nbsp;Center  is well established.&nbsp; It hosts recruiters from all four branches of the  service. About a dozen work in the Army office.</p>\n<p>Even after the  Tennessee shootings, as discussions continue in Washington, D.C., about  protecting centers like this, Carmody&nbsp;said his troops have to stay  focused. &ldquo;You know personally, any time one of our brothers in arms is  injured or killed it's a sad, sad situation. But we still have a job to  do so we have to focus on the task at hand and keep  working,&rdquo;&nbsp;Carmody&nbsp;said.</p>\n</div>\n</div>\n</div>",
+                "byline": "American Homefront Project",
+                "published": "2015-07-27T17:57:07+00:00",
+                "tags": [
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-155924"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/2e296260-9ad9-4b5b-a38d-49cd5353246f",
+                        "title": "Army Cpt. Kellam Carmody discusses a recruites aptitiude test with Army recuriter Kevin Mitchell at the Armed Forces Recruiting Center  in Tukwila, Washington",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/40349df7-d5bc-4a87-bb4c-75cb7158ad62",
+                        "title": "Military Recruting Security",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/155924"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/5be70df9-9fc4-41c0-b554-0dc1765e886b",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/2e296260-9ad9-4b5b-a38d-49cd5353246f",
+                    "attributes": {
+                        "created": "2015-07-27T17:57:38+00:00",
+                        "modified": "2015-07-27T17:57:38+00:00",
+                        "valid": {
+                            "from": "2015-07-27T17:57:38+00:00",
+                            "to": "3015-07-27T17:57:38+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "2e296260-9ad9-4b5b-a38d-49cd5353246f",
+                        "title": "Army Cpt. Kellam Carmody discusses a recruites aptitiude test with Army recuriter Kevin Mitchell at the Armed Forces Recruiting Center  in Tukwila, Washington",
+                        "byline": "Patricia Murphy",
+                        "itags": [
+                            "prx:story_images-366723"
+                        ],
+                        "published": "2015-07-27T17:57:38+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/40a16502da334a521dcbd76f1ad3c091/0/web/story_image/366723/medium/cropped.jpg",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/2e296260-9ad9-4b5b-a38d-49cd5353246f"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/40349df7-d5bc-4a87-bb4c-75cb7158ad62",
+                    "attributes": {
+                        "created": "2015-07-27T17:57:39+00:00",
+                        "modified": "2015-07-27T17:57:39+00:00",
+                        "valid": {
+                            "from": "2015-07-27T17:57:39+00:00",
+                            "to": "3015-07-27T17:57:39+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "40349df7-d5bc-4a87-bb4c-75cb7158ad62",
+                        "title": "Military Recruting Security",
+                        "itags": [
+                            "prx:audio_files-939812"
+                        ],
+                        "published": "2015-07-27T17:57:39+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/501eb38c0714223267fc529be2f90d49/0/web/audio_file/939812/broadcast/NPM072815-RecrutingSecurity.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 218,
+                                    "size": 6983105
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/40349df7-d5bc-4a87-bb4c-75cb7158ad62"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/159ce579-9a6f-4473-9125-aabd7d45def1",
+            "attributes": {
+                "created": "2015-07-16T14:35:54+00:00",
+                "modified": "2015-07-16T14:35:55+00:00",
+                "valid": {
+                    "from": "2015-07-16T14:35:21+00:00",
+                    "to": "3015-07-16T14:35:21+00:00"
+                },
+                "hreflang": "en",
+                "guid": "159ce579-9a6f-4473-9125-aabd7d45def1",
+                "title": "First in Drones? NC Prepares for Boom in Unmanned Flight ",
+                "teaser": "North Carolina -- the state that boasts of being “First in Flight” -- is preparing for another major aviation development: an expected surge in unmanned flight.",
+                "description": "The state that boasts of being &ldquo;First in Flight&rdquo; is preparing for another major aviation development &ndash; an expected surge in unmanned flight.  The North Carolina Department of Transportation has hired its first official to oversee the regulation of drones. The department also is developing a test that by the end of the year will be mandatory for people who want to operate commercial and government drones.   Meanwhile, a center based at North Carolina State University is working with researchers, government agencies, and private companies that want to use drones in their work.  The preparations come as the Federal Aviation Administration readies new regulations that are expected to open the nation&rsquo;s skies to commercial drones sometime in the next year.  &ldquo;When the final rule is made into law, we will see tremendous growth,&rdquo; said Thomas Haun, the Vice President of Strategy for Raleigh-based PrecisionHawk. The company makes drones, but focuses on sophisticated analysis of the data they gather.  PrecisionHawk is developing drone-based systems that it hopes will help farmers monitor pests and diseases, boost harvest size, and use less seed, herbicides, and pesticides. It also works with insurance and energy companies. It has been working closely&nbsp; with N.C. State&rsquo;s NextGen Air Transportation Center (NGAT), which helps it test its drones in the field.  &ldquo;The market opportunity for UAVs is quite large,&rdquo; Haun said. &ldquo;There are estimates that the United States is in the hundreds of billions of dollars of market size in the future.&rdquo;  A toy-like plane with serious uses   NGAT conducts flight tests almost every day on what it calls &ldquo;unmanned aerial vehicles,&rdquo; or UAVs. Using a rubber strap, the drone operators yank the toy-like, foam winged plane up a ramp and into the sky.  At a Wake County cornfield, NGAT Director Kyle Snyder watched as the drone made a recent test flight.&nbsp; It passed methodically back and forth over the field, snapping photos. His group has special federal permits to use several test sites around the state. It&rsquo;s collecting both flight safety data for the FAA and agricultural information for farmers.  &ldquo;The flight data looking at the crops, we&rsquo;re sharing that with our industry partners,&rdquo; Synder said. &ldquo;We&rsquo;ve got one of our ag partners here today that&rsquo;s looking at yield predictions for corn.&rdquo;  Farmers are one of many groups eager to use drones. The state government also wants them for road surveys and bridge inspections. And at least one North Carolina town plans to use them to monitor construction projects.&nbsp;   Soon, they should all be able to fly without special permission, when the federal and state governments end their moratoriums on most commercial and government drone flights.  The state is rolling out a permit system, including the mandatory test for commercial and government fliers.  Chris Gibson, the new DOT drone officer, stressed the online test is not designed to assess flying skills, and he said recreational fliers won&rsquo;t have to take it. Rather, he said the exam is designed to ensure operators know the laws that apply to unmanned aerial vehicles.  &ldquo;If there&rsquo;s a law on the books that specifies something as a crime, just because you use a UAV to do the same type of thing doesn&rsquo;t mean that all of a sudden it&rsquo;s not a crime, &ldquo;Gibson said.  &ldquo;So, we have Peeping Tom laws for example. You can&rsquo;t go looking in your neighbors&rsquo; windows. Well, you can&rsquo;t do that with a UAV either.&rdquo;  Still, some experts say drones likely will raise some unforeseen issues and require additional laws.  &ldquo;As the technology improves, they could get smaller and smaller and therefore less and less noticeable, said Sarah Preston of the ACLU of North Carolina. &ldquo;Whereas you would maybe notice a helicopter hovering over your property for a period of time while pictures are being taken or video or whatever, you&rsquo;re less likely to notice something that&rsquo;s maybe the size of a bird and that doesn&rsquo;t make a lot of noise.&rdquo;  Preston said North Carolina&rsquo;s drone law, which went into effect last year, allows law enforcement agencies to fly drones over public gatherings, even on private property. She says they could even use facial recognition technology to identify people at a political meeting. Or even a neighborhood barbecue.  &ldquo;I think there&rsquo;s a lot to it that people are not necessarily thinking through,&rdquo; Preston said.  A birds eye view for local governments   Law enforcement is only part of what local governments are planning to do with drones. And just a small part for some of them.  A couple of years ago, the Town of Mooresville bought a small hovering drone for about $1,000.  It wanted aerial images of renovations to a town golf course for its web site. Before long, the town was using it to get crowd counts at street fairs.  Now, Town Manager Erskine Smith envisions using it to find lost people, give firefighters a birdseye view of fires, and help citizens track public works projects.  &ldquo;This is certainly an easy way to allow people to understand that you&rsquo;re going to build a road connecting from here to here,&rdquo; Smith said. &ldquo;They can actually see it and visualize it, and get an idea of &lsquo;Oh, yeah, now I know what they&rsquo;re talking about.&rsquo;&rdquo;  Mooresville had to mothball its drone because the state put a temporary moratorium on their use by local governments. That will end after the state permits are available and the FAA implements its regulations. But the town found the drone so useful that it applied for special permission to get back in the air sooner.  &ldquo;It&rsquo;s a very inexpensive tool that, you know, they always say a picture is worth a thousand words,&rdquo; Smith said.",
+                "contentencoded": "The state that boasts of being &ldquo;First in Flight&rdquo; is preparing for another major aviation development &ndash; an expected surge in unmanned flight.<br /> <br /> The North Carolina Department of Transportation has hired its first official to oversee the regulation of drones. The department also is developing a test that by the end of the year will be mandatory for people who want to operate commercial and government drones. <br /> <br /> Meanwhile, a center based at North Carolina State University is working with researchers, government agencies, and private companies that want to use drones in their work.<br /> <br /> The preparations come as the Federal Aviation Administration readies new regulations that are expected to open the nation&rsquo;s skies to commercial drones sometime in the next year.<br /> <br /> &ldquo;When the final rule is made into law, we will see tremendous growth,&rdquo; said Thomas Haun, the Vice President of Strategy for Raleigh-based PrecisionHawk. The company makes drones, but focuses on sophisticated analysis of the data they gather.<br /> <br /> PrecisionHawk is developing drone-based systems that it hopes will help farmers monitor pests and diseases, boost harvest size, and use less seed, herbicides, and pesticides. It also works with insurance and energy companies. It has been working closely&nbsp; with N.C. State&rsquo;s NextGen Air Transportation Center (NGAT), which helps it test its drones in the field.<br /> <br /> &ldquo;The market opportunity for UAVs is quite large,&rdquo; Haun said. &ldquo;There are estimates that the United States is in the hundreds of billions of dollars of market size in the future.&rdquo;<br /> <br /> <strong>A toy-like plane with serious uses</strong> <br /> <br /> NGAT conducts flight tests almost every day on what it calls &ldquo;unmanned aerial vehicles,&rdquo; or UAVs. Using a rubber strap, the drone operators yank the toy-like, foam winged plane up a ramp and into the sky.<br /> <br /> At a Wake County cornfield, NGAT Director Kyle Snyder watched as the drone made a recent test flight.&nbsp; It passed methodically back and forth over the field, snapping photos. His group has special federal permits to use several test sites around the state. It&rsquo;s collecting both flight safety data for the FAA and agricultural information for farmers.<br /> <br /> &ldquo;The flight data looking at the crops, we&rsquo;re sharing that with our industry partners,&rdquo; Synder said. &ldquo;We&rsquo;ve got one of our ag partners here today that&rsquo;s looking at yield predictions for corn.&rdquo;<br /> <br /> Farmers are one of many groups eager to use drones. The state government also wants them for road surveys and bridge inspections. And at least one North Carolina town plans to use them to monitor construction projects.&nbsp; <br /> <br /> Soon, they should all be able to fly without special permission, when the federal and state governments end their moratoriums on most commercial and government drone flights.<br /> <br /> The state is rolling out a permit system, including the mandatory test for commercial and government fliers.<br /> <br /> Chris Gibson, the new DOT drone officer, stressed the online test is not designed to assess flying skills, and he said recreational fliers won&rsquo;t have to take it. Rather, he said the exam is designed to ensure operators know the laws that apply to unmanned aerial vehicles.<br /> <br /> &ldquo;If there&rsquo;s a law on the books that specifies something as a crime, just because you use a UAV to do the same type of thing doesn&rsquo;t mean that all of a sudden it&rsquo;s not a crime, &ldquo;Gibson said.<br /> <br /> &ldquo;So, we have Peeping Tom laws for example. You can&rsquo;t go looking in your neighbors&rsquo; windows. Well, you can&rsquo;t do that with a UAV either.&rdquo;<br /> <br /> Still, some experts say drones likely will raise some unforeseen issues and require additional laws.<br /> <br /> &ldquo;As the technology improves, they could get smaller and smaller and therefore less and less noticeable, said Sarah Preston of the ACLU of North Carolina. &ldquo;Whereas you would maybe notice a helicopter hovering over your property for a period of time while pictures are being taken or video or whatever, you&rsquo;re less likely to notice something that&rsquo;s maybe the size of a bird and that doesn&rsquo;t make a lot of noise.&rdquo;<br /> <br /> Preston said North Carolina&rsquo;s drone law, which went into effect last year, allows law enforcement agencies to fly drones over public gatherings, even on private property. She says they could even use facial recognition technology to identify people at a political meeting. Or even a neighborhood barbecue.<br /> <br /> &ldquo;I think there&rsquo;s a lot to it that people are not necessarily thinking through,&rdquo; Preston said.<br /> <strong><br /> A birds eye view for local governments</strong> <br /> <br /> Law enforcement is only part of what local governments are planning to do with drones. And just a small part for some of them.<br /> <br /> A couple of years ago, the Town of Mooresville bought a small hovering drone for about $1,000.<br /> <br /> It wanted aerial images of renovations to a town golf course for its web site. Before long, the town was using it to get crowd counts at street fairs.<br /> <br /> Now, Town Manager Erskine Smith envisions using it to find lost people, give firefighters a birdseye view of fires, and help citizens track public works projects.<br /> <br /> &ldquo;This is certainly an easy way to allow people to understand that you&rsquo;re going to build a road connecting from here to here,&rdquo; Smith said. &ldquo;They can actually see it and visualize it, and get an idea of &lsquo;Oh, yeah, now I know what they&rsquo;re talking about.&rsquo;&rdquo;<br /> <br /> Mooresville had to mothball its drone because the state put a temporary moratorium on their use by local governments. That will end after the state permits are available and the FAA implements its regulations. But the town found the drone so useful that it applied for special permission to get back in the air sooner.<br /> <br /> &ldquo;It&rsquo;s a very inexpensive tool that, you know, they always say a picture is worth a thousand words,&rdquo; Smith said.",
+                "byline": "American Homefront Project",
+                "published": "2015-07-16T14:35:21+00:00",
+                "tags": [
+                    "NPR NewsMagazine-y",
+                    "News Reporting",
+                    "Public Affairs",
+                    "Science",
+                    "Technology"
+                ],
+                "itags": [
+                    "prx:stories-154983"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/f63baca0-a17e-4f5a-8fdc-7cdd06aca158",
+                        "title": "Darshan Divakaran of N.C. State University's NextGen Air Transportation Center prepares a drone for a test flight at a cornfield near Raleigh, NC. ",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/56ff4bf0-5945-4d9a-a99d-c3a3a37d1c45",
+                        "title": "dronemixdown std oc mixdown",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/154983"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/159ce579-9a6f-4473-9125-aabd7d45def1",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/f63baca0-a17e-4f5a-8fdc-7cdd06aca158",
+                    "attributes": {
+                        "created": "2015-07-16T14:35:53+00:00",
+                        "modified": "2015-07-16T14:35:53+00:00",
+                        "valid": {
+                            "from": "2015-07-16T14:35:53+00:00",
+                            "to": "3015-07-16T14:35:53+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "f63baca0-a17e-4f5a-8fdc-7cdd06aca158",
+                        "title": "Darshan Divakaran of N.C. State University's NextGen Air Transportation Center prepares a drone for a test flight at a cornfield near Raleigh, NC. ",
+                        "byline": "Jay Price/WUNC",
+                        "itags": [
+                            "prx:story_images-364671"
+                        ],
+                        "published": "2015-07-16T14:35:53+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/30e3d17c03861f7ebcc3c4285385c0fb/0/web/story_image/364671/medium/Divakaran.jpg",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/f63baca0-a17e-4f5a-8fdc-7cdd06aca158"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/56ff4bf0-5945-4d9a-a99d-c3a3a37d1c45",
+                    "attributes": {
+                        "created": "2015-07-16T14:35:54+00:00",
+                        "modified": "2015-07-16T14:35:54+00:00",
+                        "valid": {
+                            "from": "2015-07-16T14:35:54+00:00",
+                            "to": "3015-07-16T14:35:54+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "56ff4bf0-5945-4d9a-a99d-c3a3a37d1c45",
+                        "title": "dronemixdown std oc mixdown",
+                        "itags": [
+                            "prx:audio_files-932435"
+                        ],
+                        "published": "2015-07-16T14:35:54+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/eb46452ce90933a4064086543d6137af/0/web/audio_file/932435/broadcast/dronemixdown_std_oc_mixdown.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 369,
+                                    "size": 5890542
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/56ff4bf0-5945-4d9a-a99d-c3a3a37d1c45"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/39d9c72a-e050-4794-8459-d708a103a2f2",
+            "attributes": {
+                "created": "2015-07-10T19:20:37+00:00",
+                "modified": "2015-07-10T19:20:38+00:00",
+                "valid": {
+                    "from": "2015-07-10T19:20:01+00:00",
+                    "to": "3015-07-10T19:20:01+00:00"
+                },
+                "hreflang": "en",
+                "guid": "39d9c72a-e050-4794-8459-d708a103a2f2",
+                "title": "Vets Entering the Workforce Face Specific Challenges",
+                "teaser": "The Bureau of Labor Statistics has reported a downward trend in unemployment for post 9-11 vets that mirrors the general population. ",
+                "description": "In the Army you don&rsquo;t get a job, you get an MOS &ndash; a military occupational specialty.\nSergeant Madeline Warrington was a&nbsp;35M&nbsp;human intelligence collector. That meant that while she was in Iraq and Afghanistan, she gathered information on possible enemy threats.\nWhen she left the military and started looking for a civilian job, Warrington, now in her 20s, found that the MOS meant nothing to most employers.&nbsp;\nShe said she applied to more than a hundred jobs.\n&ldquo;The ones that required essentially no skills were willing to contact me back,&rdquo; Warrington said. &ldquo;But the ones that were more office-job related, they would be like, &lsquo;Hey we don&rsquo;t think you have the necessary qualifications.&rsquo;&quot;\nLike many members of the armed forces, Warrington did dangerous work overseas. She&nbsp;was responsible for troops and the safety of equipment and weapons.&nbsp;It was hard not to feel defeated as the rejections piled up.\n&quot;For the jobs I was going for, I knew I had the skill sets because of the various jobs I&rsquo;ve done while&nbsp;in the military,&rdquo; she said. &ldquo;But it&rsquo;s really hard to quantify that.&quot;&nbsp;\nAbout 200,000 service members leave the military every year, according to the Pentagon.&nbsp;Some retire, some return to school on the GI Bill, but a large number, like Warrington, must find work.\nThe Bureau of Labor Statistics has reported a downward trend in unemployment for post 9/11 veterans that mirrors the general population.&nbsp;Despite the decline, challenges remain for this unique group of job seekers.\nMonica&nbsp;McNeal&nbsp;tries to help vets like Warrington.&nbsp;McNeal is the Seattle program director at Four Block, a national nonprofit that works with former service members looking for employment.&nbsp;She&nbsp;says service members often baffle hiring managers when they talk about their military job experience.\n&ldquo;In some cases maybe using way too many military terms that they average civilian who&rsquo;s hiring maybe won&rsquo;t understand,&quot;&nbsp;McNeal&nbsp;said. &quot;You have to kind of interpret that on the resume so there&rsquo;s a correlation between what they're MOS is and what the civilian task is.&rdquo;\nMcNeal&nbsp;says the cultural shift of moving from active duty to civilian can be disorienting for new veterans seeking work.&nbsp;\nLife in the armed forces is regimented.&nbsp;Everyone has a job. The hierarchy is clear. You can tell a lot about someone by looking at the patches and medals on their uniform.\nMcNeal&nbsp;says it's not so clear outside the military, where office culture can range from three-piece suits to flip flops. &nbsp;\n&ldquo;In a civilian world you might be talking to a multimillionaire owner of the company and you may never know that,&rdquo; she said. &ldquo;It's really important to learn to network and figure out how to get to know people and talk about yourself.&quot;\nThat&rsquo;s what a group of young veterans at an airport hotel near Seattle are here to do with potential employers. The vets, shifting about nervously in their suits, work with Bradlee Morris, the Georgia-based military recruiting company.\nRecruiter Ty&nbsp;Terrazone&nbsp;says the group spent the previous day in a kind of interviewing boot camp. They practice everything from solid handshakes to interviewing via Skype.\n&ldquo;What we do is break them into small groups, about six or seven in a group answering questions. &lsquo;Tell me about yourself give me a time that you failed as a leader, tell me about some times that your leadership worked,&rsquo;&rdquo;&nbsp;Terrazone&nbsp;said.\nThat gives veterans an opportunity to work on&nbsp;framing&nbsp;their military service for potential non-military employers.&nbsp;Though many of the veterans here made contacts and picked up some interviewing skills,&nbsp;Terrazone&nbsp;says nobody actually walked away from the event with a job offer in hand.\nAnd Warrington knows how hard it can be for vets in the job market to seal the deal. She ended up taking a job she believed she was overqualified for &ndash; selling new cars at a Nissan dealership.\n&ldquo;If you twist it just right, you have the purpose of helping people get into the vehicle that they need,&rdquo; she said. &ldquo;But it&rsquo;s not on the same level as helping your country.&rdquo;\nShe didn&rsquo;t stay in that job for long.\nHer husband, on active duty in the Army, learned he would be transferred from Joint Base Lewis-McCord to Fort Bragg in Fayetteville, North Carolina. So she quit the car dealership job to get ready for the move.\nShe said once she and her family arrive, she&rsquo;ll start looking all over again.&nbsp;",
+                "contentencoded": "<p>In the Army you don&rsquo;t get a job, you get an MOS &ndash; a military occupational specialty.</p>\n<p>Sergeant Madeline Warrington was a&nbsp;35M&nbsp;human intelligence collector. That meant that while she was in Iraq and Afghanistan, she gathered information on possible enemy threats.</p>\n<p>When she left the military and started looking for a civilian job, Warrington, now in her 20s, found that the MOS meant nothing to most employers.&nbsp;</p>\n<p>She said she applied to more than a hundred jobs.</p>\n<p>&ldquo;The ones that required essentially no skills were willing to contact me back,&rdquo; Warrington said. &ldquo;But the ones that were more office-job related, they would be like, &lsquo;Hey we don&rsquo;t think you have the necessary qualifications.&rsquo;&quot;</p>\n<p>Like many members of the armed forces, Warrington did dangerous work overseas. She&nbsp;was responsible for troops and the safety of equipment and weapons.&nbsp;It was hard not to feel defeated as the rejections piled up.</p>\n<p>&quot;For the jobs I was going for, I knew I had the skill sets because of the various jobs I&rsquo;ve done while&nbsp;in the military,&rdquo; she said. &ldquo;But it&rsquo;s really hard to quantify that.&quot;&nbsp;</p>\n<p>About 200,000 service members leave the military every year, according to the Pentagon.&nbsp;Some retire, some return to school on the GI Bill, but a large number, like Warrington, must find work.</p>\n<p>The Bureau of Labor Statistics has reported a downward trend in unemployment for post 9/11 veterans that mirrors the general population.&nbsp;Despite the decline, challenges remain for this unique group of job seekers.</p>\n<p>Monica&nbsp;McNeal&nbsp;tries to help vets like Warrington.&nbsp;McNeal is the Seattle program director at Four Block, a national nonprofit that works with former service members looking for employment.&nbsp;She&nbsp;says service members often baffle hiring managers when they talk about their military job experience.</p>\n<p>&ldquo;In some cases maybe using way too many military terms that they average civilian who&rsquo;s hiring maybe won&rsquo;t understand,&quot;&nbsp;McNeal&nbsp;said. &quot;You have to kind of interpret that on the resume so there&rsquo;s a correlation between what they're MOS is and what the civilian task is.&rdquo;</p>\n<p>McNeal&nbsp;says the cultural shift of moving from active duty to civilian can be disorienting for new veterans seeking work.&nbsp;</p>\n<p>Life in the armed forces is regimented.&nbsp;Everyone has a job. The hierarchy is clear. You can tell a lot about someone by looking at the patches and medals on their uniform.</p>\n<p>McNeal&nbsp;says it's not so clear outside the military, where office culture can range from three-piece suits to flip flops. &nbsp;</p>\n<p>&ldquo;In a civilian world you might be talking to a multimillionaire owner of the company and you may never know that,&rdquo; she said. &ldquo;It's really important to learn to network and figure out how to get to know people and talk about yourself.&quot;</p>\n<p>That&rsquo;s what a group of young veterans at an airport hotel near Seattle are here to do with potential employers. The vets, shifting about nervously in their suits, work with Bradlee Morris, the Georgia-based military recruiting company.</p>\n<p>Recruiter Ty&nbsp;Terrazone&nbsp;says the group spent the previous day in a kind of interviewing boot camp. They practice everything from solid handshakes to interviewing via Skype.</p>\n<p>&ldquo;What we do is break them into small groups, about six or seven in a group answering questions. &lsquo;Tell me about yourself give me a time that you failed as a leader, tell me about some times that your leadership worked,&rsquo;&rdquo;&nbsp;Terrazone&nbsp;said.</p>\n<p>That gives veterans an opportunity to work on&nbsp;framing&nbsp;their military service for potential non-military employers.&nbsp;Though many of the veterans here made contacts and picked up some interviewing skills,&nbsp;Terrazone&nbsp;says nobody actually walked away from the event with a job offer in hand.</p>\n<p>And Warrington knows how hard it can be for vets in the job market to seal the deal. She ended up taking a job she believed she was overqualified for &ndash; selling new cars at a Nissan dealership.</p>\n<p>&ldquo;If you twist it just right, you have the purpose of helping people get into the vehicle that they need,&rdquo; she said. &ldquo;But it&rsquo;s not on the same level as helping your country.&rdquo;</p>\n<p>She didn&rsquo;t stay in that job for long.</p>\n<p>Her husband, on active duty in the Army, learned he would be transferred from Joint Base Lewis-McCord to Fort Bragg in Fayetteville, North Carolina. So she quit the car dealership job to get ready for the move.</p>\n<p>She said once she and her family arrive, she&rsquo;ll start looking all over again.&nbsp;</p>",
+                "byline": "American Homefront Project",
+                "published": "2015-07-10T19:20:01+00:00",
+                "tags": [
+                    "Education",
+                    "NPR NewsMagazine-y",
+                    "News",
+                    "News Reporting",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-154558"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/0ce88f9c-d73d-4340-9d65-fa91a23b5de3",
+                        "title": "Madeline Warrington was stationed at Washington's Joint Base Lewis-McChord while active in the Army. ",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/0e0a75c6-6117-46a8-9d16-0f9aa802e38e",
+                        "title": "0710 VET JOBS fix PRX",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/154558"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/39d9c72a-e050-4794-8459-d708a103a2f2",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/0ce88f9c-d73d-4340-9d65-fa91a23b5de3",
+                    "attributes": {
+                        "created": "2015-07-10T19:20:36+00:00",
+                        "modified": "2015-07-10T19:20:36+00:00",
+                        "valid": {
+                            "from": "2015-07-10T19:20:36+00:00",
+                            "to": "3015-07-10T19:20:36+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "0ce88f9c-d73d-4340-9d65-fa91a23b5de3",
+                        "title": "Madeline Warrington was stationed at Washington's Joint Base Lewis-McChord while active in the Army. ",
+                        "byline": "Courtesy Madeline Warrington",
+                        "itags": [
+                            "prx:story_images-363723"
+                        ],
+                        "published": "2015-07-10T19:20:36+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/5af6da95a00a6d7f213f8700cbbb3cbf/0/web/story_image/363723/medium/IMG_0753.JPG",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/0ce88f9c-d73d-4340-9d65-fa91a23b5de3"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/0e0a75c6-6117-46a8-9d16-0f9aa802e38e",
+                    "attributes": {
+                        "created": "2015-07-10T19:20:37+00:00",
+                        "modified": "2015-07-10T19:20:37+00:00",
+                        "valid": {
+                            "from": "2015-07-10T19:20:37+00:00",
+                            "to": "3015-07-10T19:20:37+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "0e0a75c6-6117-46a8-9d16-0f9aa802e38e",
+                        "title": "0710 VET JOBS fix PRX",
+                        "itags": [
+                            "prx:audio_files-929328"
+                        ],
+                        "published": "2015-07-10T19:20:37+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/17750f26245e4370a902363d7ba2f1ed/0/web/audio_file/929328/broadcast/0710_VET_JOBS_fix_PRX.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 255,
+                                    "size": 8164630
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/0e0a75c6-6117-46a8-9d16-0f9aa802e38e"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
+        },
+        {
+            "version": "1.0",
+            "href": "https://api.pmp.io/docs/46ec153e-521f-448f-9d79-3f822175500f",
+            "attributes": {
+                "created": "2015-06-22T18:59:39+00:00",
+                "modified": "2015-06-22T18:59:39+00:00",
+                "valid": {
+                    "from": "2015-06-22T18:59:08+00:00",
+                    "to": "3015-06-22T18:59:08+00:00"
+                },
+                "hreflang": "en",
+                "guid": "46ec153e-521f-448f-9d79-3f822175500f",
+                "title": "Military's use of social security numbers a vulnerability for veterans",
+                "teaser": "A massive data breach at the federal Office of Personnel Management has exposed the Social Security numbers and personnel records of nearly every federal worker.\n\nBut at a very basic level U.S. service members have been at high risk for identity theft for decades.",
+                "description": "A massive data breach at the federal Office of Personnel Management  has exposed the Social Security numbers and personnel records of nearly  every federal worker. The implications for federal employees, military  service members and the intelligence community could be extraordinary. &nbsp;\nBut at a very basic level U.S. service members have been at high risk for identity theft for decades.\nIn the military your nine-digit service&nbsp;ID number is used for  everything, whether you're checking out gym equipment or picking up your  laundry. Since the late&nbsp;1960s&nbsp;that number has been a service member&rsquo;s  Social Security number.\nAnd while the military is trying to change that, it&rsquo;s a long process.  &nbsp;For many service members their Social Security number is still printed  everywhere.&nbsp;\n&ldquo;Your dog tags, your medical records, your service records, any  advancement exams that you take -- I have thousands of pieces of paper  with my Social Security number on it,&quot; said Lindsay Church.\nChurch was a linguist in the Navy until three years ago. Now she&rsquo;s a  graduate student at the University of Washington. Shortly after she left  the Navy, somebody broke into her car in front of her mother's house.\n&ldquo;I thought the only thing that was stolen was my medication. Then I  realized that my medical records were missing. They started opening new  credit cards and opening new accounts and the police couldn&rsquo;t help me.  There was nothing they could do except give me the number of the credit  bureau,&quot; Church said.\nAccording to a report from the Federal Trade Commission, identity  theft is the most common consumer complaint from military personnel and  veterans. That&rsquo;s what happened to Church.\nOver the next year credit card bills showed up that weren&rsquo;t hers -- a  few hundred dollars at a time. Each time she had to call the company to  sort it out.\nRick&nbsp;Forno&nbsp;is the assistant director of the University of  Maryland-Baltimore County Center for Cyber Security. He said using  Social Security numbers as a unique identifier isn't new.&nbsp;\nBut while many organizations have already scrubbed the numbers off  forms and ID cards, the Department of Defense isn&rsquo;t scheduled to finish  doing that for seven more years. &ldquo;That seems rather unreasonable in my  view, given the importance of this issue to the&nbsp;DOD as an organization  and everybody involved,&rdquo;&nbsp;Forno&nbsp;said.\nThe Department of Defense wouldn&rsquo;t do an interview for this story,  but in a statement detailed the efforts it is making to protect service  members&rsquo; identities. &nbsp;The statement says the government began removing  printed Social Security numbers from ID cards in 2008 and plans to  finish that process this month. But it will be the year 2022 before the  numbers are fully removed from the cards&rsquo; bar codes,&nbsp;QR&nbsp;codes and  magnetic strips.\nTo&nbsp;Forno, that&rsquo;s too long.\n&ldquo;I would presume that if this were a critical issue to the military  DOD that it would not take six or seven more years to make this happen.  The DOD could accelerate this transition and do it in a much shorter  time frame,&rdquo;&nbsp;Forno&nbsp;said.\nThe Department of Defense says it&rsquo;s issuing new military ID cards as  the old ones expire. &nbsp;The cards will display a unique &nbsp;10-digit&nbsp;DOD  number instead of a Social Security number.&nbsp;\nThe Pentagon hopes that will reduce identity theft among service  members. But it comes too late for Church and the more than 26,000  members of the Armed Forces who the FTC says had their identities stolen  last year.&nbsp;\nChurch isn&rsquo;t exactly sure how having her identity stolen has affected her credit rating.\n&quot;It feels so overwhelming that I&rsquo;ve just pushed it off. I&rsquo;m going to  hate myself later for it but it&rsquo;s just so frustrating how much worse can  it get? It&rsquo;s just overwhelming,&rdquo; Church said.",
+                "contentencoded": "<p>A massive data breach at the federal Office of Personnel Management  has exposed the Social Security numbers and personnel records of nearly  every federal worker. The implications for federal employees, military  service members and the intelligence community could be extraordinary. &nbsp;</p>\n<p>But at a very basic level U.S. service members have been at high risk for identity theft for decades.</p>\n<p>In the military your nine-digit service&nbsp;ID number is used for  everything, whether you're checking out gym equipment or picking up your  laundry. Since the late&nbsp;1960s&nbsp;that number has been a service member&rsquo;s  Social Security number.</p>\n<p>And while the military is trying to change that, it&rsquo;s a long process.  &nbsp;For many service members their Social Security number is still printed  everywhere.&nbsp;</p>\n<p>&ldquo;Your dog tags, your medical records, your service records, any  advancement exams that you take -- I have thousands of pieces of paper  with my Social Security number on it,&quot; said Lindsay Church.</p>\n<p>Church was a linguist in the Navy until three years ago. Now she&rsquo;s a  graduate student at the University of Washington. Shortly after she left  the Navy, somebody broke into her car in front of her mother's house.</p>\n&ldquo;I thought the only thing that was stolen was my medication. Then I  realized that my medical records were missing. They started opening new  credit cards and opening new accounts and the police couldn&rsquo;t help me.  There was nothing they could do except give me the number of the credit  bureau,&quot; Church said.\n<p>According to a report from the Federal Trade Commission, identity  theft is the most common consumer complaint from military personnel and  veterans. That&rsquo;s what happened to Church.</p>\n<p>Over the next year credit card bills showed up that weren&rsquo;t hers -- a  few hundred dollars at a time. Each time she had to call the company to  sort it out.</p>\n<p>Rick&nbsp;Forno&nbsp;is the assistant director of the University of  Maryland-Baltimore County Center for Cyber Security. He said using  Social Security numbers as a unique identifier isn't new.&nbsp;</p>\n<p>But while many organizations have already scrubbed the numbers off  forms and ID cards, the Department of Defense isn&rsquo;t scheduled to finish  doing that for seven more years. &ldquo;That seems rather unreasonable in my  view, given the importance of this issue to the&nbsp;DOD as an organization  and everybody involved,&rdquo;&nbsp;Forno&nbsp;said.</p>\n<p>The Department of Defense wouldn&rsquo;t do an interview for this story,  but in a statement detailed the efforts it is making to protect service  members&rsquo; identities. &nbsp;The statement says the government began removing  printed Social Security numbers from ID cards in 2008 and plans to  finish that process this month. But it will be the year 2022 before the  numbers are fully removed from the cards&rsquo; bar codes,&nbsp;QR&nbsp;codes and  magnetic strips.</p>\n<p>To&nbsp;Forno, that&rsquo;s too long.</p>\n<p>&ldquo;I would presume that if this were a critical issue to the military  DOD that it would not take six or seven more years to make this happen.  The DOD could accelerate this transition and do it in a much shorter  time frame,&rdquo;&nbsp;Forno&nbsp;said.</p>\n<p>The Department of Defense says it&rsquo;s issuing new military ID cards as  the old ones expire. &nbsp;The cards will display a unique &nbsp;10-digit&nbsp;DOD  number instead of a Social Security number.&nbsp;</p>\n<p>The Pentagon hopes that will reduce identity theft among service  members. But it comes too late for Church and the more than 26,000  members of the Armed Forces who the FTC says had their identities stolen  last year.&nbsp;</p>\n<p>Church isn&rsquo;t exactly sure how having her identity stolen has affected her credit rating.</p>\n<p>&quot;It feels so overwhelming that I&rsquo;ve just pushed it off. I&rsquo;m going to  hate myself later for it but it&rsquo;s just so frustrating how much worse can  it get? It&rsquo;s just overwhelming,&rdquo; Church said.</p>",
+                "byline": "American Homefront Project",
+                "published": "2015-06-22T18:59:08+00:00",
+                "tags": [
+                    "Hard Feature",
+                    "NPR NewsMagazine-y",
+                    "Public Affairs",
+                    "War"
+                ],
+                "itags": [
+                    "prx:stories-152720"
+                ]
+            },
+            "links": {
+                "profile": [
+                    {
+                        "href": "https://api.pmp.io/profiles/story",
+                        "type": "application/vnd.collection.doc+json"
+                    }
+                ],
+                "creator": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "owner": [
+                    {
+                        "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://api.pmp.io/docs/4c6e24e5-484f-49e8-be8d-452cfddd6252",
+                        "title": "American Homefront Project",
+                        "rels": [
+                            "urn:collectiondoc:collection:property"
+                        ]
+                    }
+                ],
+                "item": [
+                    {
+                        "href": "https://api.pmp.io/docs/2a8f1e6b-0358-4d36-a868-db34a351d662",
+                        "title": "Former Navy linguist Linsdsay Church holds military ID tags for her grandfather, mother and her. The two later tags contain social security numbers. The numbers have been obsured in this photo to protect thier identities.",
+                        "rels": [
+                            "urn:collectiondoc:image"
+                        ]
+                    },
+                    {
+                        "href": "https://api.pmp.io/docs/d3229c35-e653-4504-a1ec-f8ba509359ec",
+                        "title": "Murphy: Identity theft",
+                        "rels": [
+                            "urn:collectiondoc:audio"
+                        ]
+                    }
+                ],
+                "alternate": [
+                    {
+                        "href": "https://www.prx.org/pieces/152720"
+                    }
+                ],
+                "navigation": [
+                    {
+                        "rels": [
+                            "self"
+                        ],
+                        "href": "https://api.pmp.io/docs/46ec153e-521f-448f-9d79-3f822175500f",
+                        "totalitems": 2,
+                        "totalpages": 1,
+                        "pagenum": 1
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/2a8f1e6b-0358-4d36-a868-db34a351d662",
+                    "attributes": {
+                        "created": "2015-06-22T18:59:37+00:00",
+                        "modified": "2015-06-22T18:59:38+00:00",
+                        "valid": {
+                            "from": "2015-06-22T18:59:37+00:00",
+                            "to": "3015-06-22T18:59:37+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "2a8f1e6b-0358-4d36-a868-db34a351d662",
+                        "title": "Former Navy linguist Linsdsay Church holds military ID tags for her grandfather, mother and her. The two later tags contain social security numbers. The numbers have been obsured in this photo to protect thier identities.",
+                        "byline": "Patricia Murphy/KUOW",
+                        "itags": [
+                            "prx:story_images-359959"
+                        ],
+                        "published": "2015-06-22T18:59:37+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/image",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/dab82388bc2ee94daf3e8c45e3b2239b/0/web/story_image/359959/medium/WUNCKPCC_000_EXCH89101162.jpg",
+                                "type": "image/jpeg",
+                                "meta": {
+                                    "crop": "medium"
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/2a8f1e6b-0358-4d36-a868-db34a351d662"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                },
+                {
+                    "version": "1.0",
+                    "href": "https://api.pmp.io/docs/d3229c35-e653-4504-a1ec-f8ba509359ec",
+                    "attributes": {
+                        "created": "2015-06-22T18:59:38+00:00",
+                        "modified": "2015-06-22T18:59:38+00:00",
+                        "valid": {
+                            "from": "2015-06-22T18:59:38+00:00",
+                            "to": "3015-06-22T18:59:38+00:00"
+                        },
+                        "hreflang": "en",
+                        "guid": "d3229c35-e653-4504-a1ec-f8ba509359ec",
+                        "title": "Murphy: Identity theft",
+                        "itags": [
+                            "prx:audio_files-916629"
+                        ],
+                        "published": "2015-06-22T18:59:38+00:00"
+                    },
+                    "links": {
+                        "profile": [
+                            {
+                                "href": "https://api.pmp.io/profiles/audio",
+                                "type": "application/vnd.collection.doc+json"
+                            }
+                        ],
+                        "creator": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "owner": [
+                            {
+                                "href": "https://api.pmp.io/docs/609a539c-9177-4aa7-acde-c10b77a6a525"
+                            }
+                        ],
+                        "enclosure": [
+                            {
+                                "href": "https://cms.prx.org/pub/cdf8801abf8537f112e93873b417b927/0/web/audio_file/916629/broadcast/WUNCKPCC_000_EXCH89098610.mp3",
+                                "type": "audio/mpeg",
+                                "meta": {
+                                    "duration": 207,
+                                    "size": 6622385
+                                }
+                            }
+                        ],
+                        "navigation": [
+                            {
+                                "rels": [
+                                    "self"
+                                ],
+                                "href": "https://api.pmp.io/docs/d3229c35-e653-4504-a1ec-f8ba509359ec"
+                            }
+                        ]
+                    },
+                    "scope": "read"
+                }
+            ],
+            "scope": "read"
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/spec/fixtures/api/pmp/ahp_story.json
+++ b/spec/fixtures/api/pmp/ahp_story.json
@@ -1,0 +1,539 @@
+{
+  "version": "1.0",
+  "href": "https://api-sandbox.pmp.io/docs/92dbabbf-fa82-b580-7240-e3bddb6310ff",
+  "attributes": {
+    "valid": {
+      "from": "2014-03-12T14:44:30+00:00",
+      "to": "3014-03-12T14:44:30+00:00"
+    },
+    "created": "2014-03-12T18:01:18+00:00",
+    "modified": "2014-03-12T18:01:18+00:00",
+    "description": "The president seeks to change overtime pay rules via executive powers.",
+    "hreflang": "en",
+    "contenttemplated": "[{\"type\":\"text/html\",\"content\":\"The White House wants to make more Americans eligible for overtime pay. Currently, because of what is referred to as the Fair Labor Standards Actâs â<a style=\\\"line-height: 1.42em; font-size: 14px;\\\" href=\\\"http://www.dol.gov/whd/regs/compliance/fairpay/fs17a_overview.pdf\\\">white collar exemption</a>,â many salaried professionals are not entitled to extra pay if they work more than 40 hours per week.\"},{\"content\":\"Later this week, the president intends to use his executive authority to change those rules. For 2014, which he is calling a âyear of action,â he has promised to pursue policy changes that do not involve congress.\",\"type\":\"text/html\"},{\"content\":\"So whom would this change affect? âPeople who are defined as âsupervisors,ââ says Gary Burtless, an economist at The Brookings Institution. âThey have responsibility over other people besides themselves, a certain amount of independence.â\",\"type\":\"text/html\"},{\"type\":\"text/html\",\"content\":\"The economic recovery, Burtless argues, âhas been better for profits than wages.â âThe government is trying to put its thumb on the scale, helping workers,â he says.\"},{\"content\":\"Economist Jared Bernstein, a senior fellow with the liberal Center on Budget and Policy Priorities, has pushed for this change for more than a decade, since President George W. Bush expanded the exemption in 2004:&nbsp;\",\"type\":\"text/html\"},{\"type\":\"text/html\",\"content\":\"âWeâre talking about millions of workers who would be newly eligible for overtime pay,â he says.\"},{\"type\":\"text/html\",\"content\":\"Critics argue changing the exemption would make it harder for businesses to hire new employees, and it could motivate them to trim their payrolls. In the long run, employers could simply reduce a white-collar supervisorâs base pay, so there would be no difference to his overall salary.\"},{\"content\":\"Bill Kilberg, a partner with the law firm Gibson, Dunn &amp; Crutcher, says he âdoesnât know if it is a good idea.â Kilberg suspects the courts will be asked to decide whether or not a rule change would be constitutional. âThey can give it deference or not give it deference.â\",\"type\":\"text/html\"}]",
+    "title": "Obama seeks expanded overtime pay",
+    "byline": "Gura, David",
+    "published": "2014-03-12T14:44:30+00:00",
+    "guid": "92dbabbf-fa82-b580-7240-e3bddb6310ff",
+    "tags": [
+      "Marketplace Morning Report for Wednesday, March 12, 2014",
+      "APM_TESTING",
+      "92dbabbffa82b5807240e3bddb6310ff",
+      "Marketplace Morning Report",
+      "PMP:Marketplace_PMP",
+      "Business",
+      "Marketplace"
+    ],
+    "teaser": "The president seeks to change overtime pay rules via executive powers.",
+    "contentencoded": "<p>The White House wants to make more Americans eligible for overtime pay. Currently, because of what is referred to as the Fair Labor Standards Act’s “<a style=\"line-height: 1.42em; font-size: 14px;\" href=\"http://www.dol.gov/whd/regs/compliance/fairpay/fs17a_overview.pdf\">white collar exemption</a>,” many salaried professionals are not entitled to extra pay if they work more than 40 hours per week.</p>\n<p>Later this week, the president intends to use his executive authority to change those rules. For 2014, which he is calling a “year of action,” he has promised to pursue policy changes that do not involve congress.</p>\n<p>So whom would this change affect? “People who are defined as ‘supervisors,’” says Gary Burtless, an economist at The Brookings Institution. “They have responsibility over other people besides themselves, a certain amount of independence.”</p>\n<p>The economic recovery, Burtless argues, “has been better for profits than wages.” “The government is trying to put its thumb on the scale, helping workers,” he says.</p>\n<p>Economist Jared Bernstein, a senior fellow with the liberal Center on Budget and Policy Priorities, has pushed for this change for more than a decade, since President George W. Bush expanded the exemption in 2004:&nbsp;</p>\n<p>“We’re talking about millions of workers who would be newly eligible for overtime pay,” he says.</p>\n<p>Critics argue changing the exemption would make it harder for businesses to hire new employees, and it could motivate them to trim their payrolls. In the long run, employers could simply reduce a white-collar supervisor’s base pay, so there would be no difference to his overall salary.</p>\n<p>Bill Kilberg, a partner with the law firm Gibson, Dunn &amp; Crutcher, says he “doesn’t know if it is a good idea.” Kilberg suspects the courts will be asked to decide whether or not a rule change would be constitutional. “They can give it deference or not give it deference.”</p>"
+  },
+  "links": {
+    "profile": [
+      {
+        "title": "APMStory",
+        "href": "https://api.pmp.io/profiles/story"
+      }
+    ],
+    "alternate": [
+      {
+        "type": "text/html",
+        "href": "http://www.marketplace.org/topics/business/obama-seeks-expanded-overtime-pay"
+      }
+    ],
+    "item": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs/1dc81410-d86d-3c03-6fcc-39f77f0b0301"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/0ee06f8c-b86b-b0c9-87e3-e8c17d59b132"
+      }
+    ],
+    "collection": [
+      {
+        "title": "Marketplace",
+        "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/df9a7bdb-c650-42c1-8691-55a154f07322",
+        "title": "Marketplace Morning Report"
+      }
+    ],
+    "distributor": [],
+    "copyright": [
+      {
+        "title": "Copyright (C) 2014 American Public Media Group",
+        "href": "http://www.publicradio.org/terms"
+      }
+    ],
+    "creator": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+      }
+    ],
+    "navigation": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs?guid=92dbabbf-fa82-b580-7240-e3bddb6310ff",
+        "rels": [
+          "self"
+        ],
+        "totalitems": 2,
+        "totalpages": 1,
+        "pagenum": 1
+      }
+    ],
+    "query": [
+      {
+        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for users",
+        "rels": [
+          "urn:collectiondoc:query:users"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/groups{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for groups",
+        "rels": [
+          "urn:collectiondoc:query:groups"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/profiles{/guid}",
+        "title": "Access profiles",
+        "rels": [
+          "urn:collectiondoc:hreftpl:profiles"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/profiles{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for profiles",
+        "rels": [
+          "urn:collectiondoc:query:profiles"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/schemas{/guid}",
+        "title": "Access schemas",
+        "rels": [
+          "urn:collectiondoc:hreftpl:schemas"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for schemas",
+        "rels": [
+          "urn:collectiondoc:query:schemas"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/docs{/guid}{?limit,offset}",
+        "title": "Access documents",
+        "rels": [
+          "urn:collectiondoc:hreftpl:docs"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/docs{?guid,limit,offset,tag,collection,text,searchsort,has,author,distributor,distributorgroup,startdate,enddate,profile,language}",
+        "title": "Query for documents",
+        "rels": [
+          "urn:collectiondoc:query:docs"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "author": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "distributor": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "distributorgroup": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "startdate": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "enddate": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "profile": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "language": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/guids",
+        "title": "Generate guids",
+        "rels": [
+          "urn:collectiondoc:query:guids"
+        ],
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "accept-post": [
+            "application/x-www-form-urlencoded"
+          ]
+        },
+        "type": "application/json"
+      }
+    ],
+    "edit": [
+      {
+        "href-template": "https://publish-sandbox.pmp.io/docs{/guid}",
+        "title": "Document Save",
+        "rels": [
+          "urn:collectiondoc:form:documentsave"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Collection.doc-JSON-Media-Type"
+        }
+      },
+      {
+        "href-template": "https://publish-sandbox.pmp.io/profiles{/guid}",
+        "title": "Profile Save",
+        "rels": [
+          "urn:collectiondoc:form:profilesave"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Profile-profile"
+        }
+      },
+      {
+        "href-template": "https://publish-sandbox.pmp.io/schemas{/guid}",
+        "title": "Schema Save",
+        "rels": [
+          "urn:collectiondoc:form:schemasave"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Schema-profile"
+        }
+      },
+      {
+        "href": "https://publish-sandbox.pmp.io/files",
+        "title": "Upload a rich media file",
+        "rels": [
+          "urn:collectiondoc:form:mediaupload"
+        ],
+        "href-vars": {
+          "submission": "http://docs.pmp.io/wiki/Media-File-Upload"
+        },
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "accept-post": [
+            "multipart/form-data"
+          ]
+        }
+      }
+    ],
+    "auth": [
+      {
+        "href": "https://api-sandbox.pmp.io/auth/access_token",
+        "title": "Issue OAuth2 Token",
+        "rels": [
+          "urn:collectiondoc:form:issuetoken"
+        ],
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Authentication-Model#token-management"
+        }
+      },
+      {
+        "href": "https://publish-sandbox.pmp.io/auth/access_token",
+        "title": "Revoke OAuth2 Token",
+        "rels": [
+          "urn:collectiondoc:form:revoketoken"
+        ],
+        "hints": {
+          "allow": [
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Authentication-Model#revoke-a-token"
+        }
+      }
+    ]
+  },
+  "items": [
+    {
+      "version": "1.0",
+      "href": "https://api-sandbox.pmp.io/docs/1dc81410-d86d-3c03-6fcc-39f77f0b0301",
+      "attributes": {
+        "valid": {
+          "from": "2014-03-12T14:44:30+00:00",
+          "to": "3014-03-12T14:44:30+00:00"
+        },
+        "created": "2014-03-12T18:01:17+00:00",
+        "modified": "2014-03-12T18:01:17+00:00",
+        "byline": "Gura, David",
+        "title": "111348788_1.jpg",
+        "guid": "1dc81410-d86d-3c03-6fcc-39f77f0b0301",
+        "tags": [
+          "Marketplace Morning Report for Wednesday, March 12, 2014",
+          "APM_TESTING",
+          "Marketplace Morning Report",
+          "PMP:Marketplace_PMP",
+          "1dc81410d86d3c036fcc39f77f0b0301",
+          "Marketplace",
+          "Business"
+        ],
+        "hreflang": "en",
+        "description": "The president seeks to change overtime pay rules via executive powers.",
+        "published": "2014-03-12T14:44:30+00:00"
+      },
+      "links": {
+        "profile": [
+          {
+            "href": "https://api.pmp.io/profiles/image",
+            "title": "APMImage"
+          }
+        ],
+        "copyright": [
+          {
+            "href": "http://www.publicradio.org/terms",
+            "title": "Copyright (C) 2014 American Public Media Group"
+          }
+        ],
+        "distributor": [],
+        "enclosure": [
+          {
+            "type": "image/jpeg",
+            "meta": {
+              "width": "610",
+              "crop": "primary",
+              "height": "340"
+            },
+            "href": "http://www.marketplace.org/sites/default/files/styles/primary-image-610x340/public/111348788_1.jpg?itok=UfS-D_BL"
+          }
+        ],
+        "collection": [
+          {
+            "title": "Marketplace",
+            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c"
+          },
+          {
+            "title": "Marketplace Morning Report",
+            "href": "https://api-sandbox.pmp.io/docs/df9a7bdb-c650-42c1-8691-55a154f07322"
+          }
+        ],
+        "creator": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+          }
+        ],
+        "item": [],
+        "navigation": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs?guid=1dc81410-d86d-3c03-6fcc-39f77f0b0301",
+            "rels": [
+              "self"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "version": "1.0",
+      "href": "https://api-sandbox.pmp.io/docs/0ee06f8c-b86b-b0c9-87e3-e8c17d59b132",
+      "attributes": {
+        "valid": {
+          "from": "2014-03-12T14:44:30+00:00",
+          "to": "3014-03-12T14:44:30+00:00"
+        },
+        "created": "2014-03-12T17:59:41+00:00",
+        "modified": "2014-03-12T17:59:41+00:00",
+        "byline": "Gura, David",
+        "title": "Obama seeks expanded overtime pay",
+        "hreflang": "en",
+        "description": "The president seeks to change overtime pay rules via executive powers.",
+        "guid": "0ee06f8c-b86b-b0c9-87e3-e8c17d59b132",
+        "tags": [
+          "Marketplace",
+          "Business",
+          "PMP:Marketplace_PMP",
+          "Marketplace Morning Report",
+          "APM_TESTING",
+          "Marketplace Morning Report for Wednesday, March 12, 2014",
+          "0ee06f8cb86bb0c987e3e8c17d59b132"
+        ],
+        "published": "2014-03-12T14:44:30+00:00"
+      },
+      "links": {
+        "profile": [
+          {
+            "href": "https://api.pmp.io/profiles/audio",
+            "title": "APMAudio"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/df9a7bdb-c650-42c1-8691-55a154f07322",
+            "title": "Marketplace Morning Report"
+          }
+        ],
+        "enclosure": [
+          {
+            "href": "http://ahp.org/segments/2014/03/12/segment09_20140312_64.mp3",
+            "type": "audio/mpeg",
+            "meta": {
+              "duration": "80000",
+              "api": {
+                "href": "http://api.publicradio.org/audio/v2?ref=pmp&id=apm-audio:/marketplace/segments/2014/03/12/marketplace_segment09_20140312_64.mp3",
+                "type": "application/json"
+              }
+            }
+          },
+          {
+            "href": "http://ahp.org/marketplace/segments/2014/03/12/segment09_20140312_64.mp3",
+            "type": "audio/mpeg",
+            "meta": {
+              "duration": "80000",
+              "api": {
+                "href": "http://api.publicradio.org/audio/v2?ref=pmp&id=apm-audio:/marketplace/segments/2014/03/12/marketplace_segment09_20140312_64.mp3",
+                "type": "application/json"
+              }
+            }
+          }
+        ],
+        "copyright": [
+          {
+            "href": "http://www.publicradio.org/terms",
+            "title": "Copyright (C) 2014 American Public Media Group"
+          }
+        ],
+        "distributor": [],
+        "creator": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+          }
+        ],
+        "item": [],
+        "navigation": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs?guid=0ee06f8c-b86b-b0c9-87e3-e8c17d59b132",
+            "rels": [
+              "self"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -33,7 +33,7 @@ describe PmpArticleImporter do
     it 'builds cached articles from the API response' do
       RemoteArticle.count.should eq 0
       added = PmpArticleImporter.sync
-      RemoteArticle.count.should eq 4 # Two stories in the JSON fixture grabbed twice(two for marketplace and two for veterans collection)
+      RemoteArticle.count.should eq 12 # Two stories from Marketplace fixture and 10 from AHP fixture
       added.first.headline.should match /billions and billions/
     end
 

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -88,17 +88,36 @@ describe PmpArticleImporter do
         news_story.related_links.first.url.should match /marketplace\.org/
       end
 
-      it "adds audio if it's available" do
-        remote_article = create :pmp_article
-        news_story = PmpArticleImporter.import(remote_article)
+      context "marketplace story" do
+        it "adds audio if it's available" do
+          remote_article = create :pmp_article
+          news_story = PmpArticleImporter.import(remote_article)
 
-        # The "story.json" file has 2 audio enclosures (they're the same,
-        # it's fake).
-        news_story.audio.size.should eq 2
-        audio = news_story.audio.first
-        audio.url.should eq("http://play.publicradio.org/pmp/d/podcast/marketplace/segments/2014/03/12/marketplace_segment09_20140312_64.mp3")
-        audio.duration.should eq 80000 / 1000
-        audio.description.should match /Marketplace Segment/
+          # The "story.json" file has 2 audio enclosures (they're the same,
+          # it's fake).
+          news_story.audio.size.should eq 2
+          audio = news_story.audio.first
+          audio.url.should eq("http://play.publicradio.org/pmp/d/podcast/marketplace/segments/2014/03/12/marketplace_segment09_20140312_64.mp3")
+          audio.duration.should eq 80000 / 1000
+          audio.description.should match /Marketplace Segment/
+        end
+      end
+
+      context "ahp story" do
+        it "adds audio if it's available" do
+          stub_request(:get, %r|pmp\.io/docs\?guid=.+|).to_return({
+            :content_type => "application/json",
+            :body => load_fixture('api/pmp/ahp_story.json')
+          })
+          remote_article = create :pmp_article, news_agency: "American Homefront Project"
+          news_story = PmpArticleImporter.import(remote_article)
+
+          news_story.audio.size.should eq 2
+          audio = news_story.audio.first
+          audio.url.should eq("http://ahp.org/segments/2014/03/12/segment09_20140312_64.mp3")
+          audio.duration.should eq 80000 / 1000
+          audio.description.should match /Obama seeks expanded overtime pay/
+        end
       end
 
       it "creates an asset if image is available" do

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -52,18 +52,18 @@ describe PmpArticleImporter do
         })
       end
 
-      context 'remote article with publisher name' do
+      context 'remote article with news agency name' do
         it 'sets the matching source and news agency' do
           remote_article = create :pmp_article
           news_story = PmpArticleImporter.import(remote_article)
-          news_story.source.should eq remote_article.publisher.downcase
-          news_story.news_agency.should eq remote_article.publisher
+          news_story.source.should eq remote_article.news_agency.downcase
+          news_story.news_agency.should eq remote_article.news_agency
         end
       end
 
-      context 'remote article without publisher name' do
+      context 'remote article without news agency name' do
         it 'sets the matching source and news agency to fallback of PMP' do
-          remote_article = create :pmp_article, publisher: nil
+          remote_article = create :pmp_article, news_agency: nil
           news_story = PmpArticleImporter.import(remote_article)
           news_story.source.should eq "pmp"
           news_story.news_agency.should eq "PMP"

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -95,7 +95,6 @@ describe PmpArticleImporter do
         # The "story.json" file has 2 audio enclosures (they're the same,
         # it's fake).
         news_story.audio.size.should eq 2
-
         audio = news_story.audio.first
         audio.url.should eq("http://play.publicradio.org/pmp/d/podcast/marketplace/segments/2014/03/12/marketplace_segment09_20140312_64.mp3")
         audio.duration.should eq 80000 / 1000

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -18,10 +18,16 @@ describe PmpArticleImporter do
 
   describe '::sync' do
     before do
-      stub_request(:get, %r|pmp\.io/docs|).to_return({
-        :content_type => "application/json",
-        :body => load_fixture('api/pmp/marketplace_stories.json')
-      })
+      stub_request(:get, %r|pmp\.io/docs|)
+        .with(query: {"limit" => "10", "profile" => "story", "tag" => "marketplace"}).to_return({
+          :content_type => "application/json",
+          :body => load_fixture('api/pmp/marketplace_stories.json')
+        })
+      stub_request(:get, %r|pmp\.io/docs|)
+          .with(query: {"collection" => '4c6e24e5-484f-49e8-be8d-452cfddd6252', "limit" => "10", "profile" => "story"}).to_return({
+          :content_type => "application/json",
+          :body => load_fixture('api/pmp/ahp_stories.json')
+        })
     end
 
     it 'builds cached articles from the API response' do

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -46,11 +46,22 @@ describe PmpArticleImporter do
         })
       end
 
-      it 'sets the source and news agency' do
-        remote_article = create :pmp_article
-        news_story = PmpArticleImporter.import(remote_article)
-        news_story.source.should eq "marketplace"
-        news_story.news_agency.should eq 'Marketplace'
+      context 'remote article with publisher name' do
+        it 'sets the matching source and news agency' do
+          remote_article = create :pmp_article
+          news_story = PmpArticleImporter.import(remote_article)
+          news_story.source.should eq remote_article.publisher.downcase
+          news_story.news_agency.should eq remote_article.publisher
+        end
+      end
+
+      context 'remote article without publisher name' do
+        it 'sets the matching source and news agency to fallback of PMP' do
+          remote_article = create :pmp_article, publisher: nil
+          news_story = PmpArticleImporter.import(remote_article)
+          news_story.source.should eq "pmp"
+          news_story.news_agency.should eq "PMP"
+        end
       end
 
       it 'imports the bylines' do


### PR DESCRIPTION
#354

This is accomplished by explicitly naming the articles as they come in, since there isn't a fool-proof way to get the name from the API.  The audio from AHP uses a different schema so it has to be handled differently.