### PR TITLE
Remote article search in Outpost

### DIFF
--- a/app/models/remote_article.rb
+++ b/app/models/remote_article.rb
@@ -11,6 +11,7 @@ class RemoteArticle < ActiveRecord::Base
   include Outpost::Model::Identifier
   include Outpost::Model::Naming
   include Concern::Sanitizers::Url
+  include Concern::Model::Searchable
 
   before_validation ->{ sanitize_urls :url }
   

--- a/db/migrate/20151116220729_index_all_remote_articles.rb
+++ b/db/migrate/20151116220729_index_all_remote_articles.rb
@@ -1,0 +1,14 @@
+class IndexAllRemoteArticles < ActiveRecord::Migration
+  def up
+    ## This method goes by batches of 1000 and runs the block
+    ## on every element of each batch
+    RemoteArticle.find_each do |remote_article|
+      remote_article.__elasticsearch__.index_document
+    end
+  end
+  def down
+    RemoteArticle.find_each do |remote_article|
+      remote_article.__elasticsearch__.delete_document
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151030202328) do
+ActiveRecord::Schema.define(version: 20151116220729) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -33,8 +33,9 @@ ActiveRecord::Schema.define(version: 20151030202328) do
     t.integer "content_id",   limit: 4
     t.integer "position",     limit: 4,          default: 99
     t.integer "asset_id",     limit: 4
-    t.text    "caption",      limit: 4294967295,              null: false
+    t.text    "caption",      limit: 4294967295,                 null: false
     t.string  "content_type", limit: 255
+    t.boolean "inline",                          default: false
   end
 
   add_index "assethost_contentasset", ["content_id", "content_type"], name: "index_assethost_contentasset_on_content_id_and_content_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,9 +33,8 @@ ActiveRecord::Schema.define(version: 20151116220729) do
     t.integer "content_id",   limit: 4
     t.integer "position",     limit: 4,          default: 99
     t.integer "asset_id",     limit: 4
-    t.text    "caption",      limit: 4294967295,                 null: false
+    t.text    "caption",      limit: 4294967295,              null: false
     t.string  "content_type", limit: 255
-    t.boolean "inline",                          default: false
   end
 
   add_index "assethost_contentasset", ["content_id", "content_type"], name: "index_assethost_contentasset_on_content_id_and_content_type", using: :btree


### PR DESCRIPTION
#377

Added the ability to search RemoteArticles in Outpost.  This was basically just including the correct concern in the model.  Also wrote a migration to index existing remote articles.