### PR TITLE
Retry failed eloqua emails

### DIFF
--- a/app/jobs/job/retry_emails.rb
+++ b/app/jobs/job/retry_emails.rb
@@ -1,0 +1,14 @@
+module Job
+  class RetryEmails < Base
+    @priority = :mid
+
+    class << self
+      def perform
+        logger.info "Sending unsent emails to Eloqua. - #{Time.zone.now}"
+        unsent_emails = EloquaEmail.unsent
+        unsent_emails.each(&:async_send_email)
+        logger.info "Finished sending #{unsent_emails.count} unsent emails to Eloqua. - #{Time.zone.now}"
+      end
+    end
+  end
+end

--- a/app/models/eloqua_email.rb
+++ b/app/models/eloqua_email.rb
@@ -63,6 +63,12 @@ class EloquaEmail < ActiveRecord::Base
     email_type || (emailable ? emailable.class.name : nil) || self.class.name
   end
 
+  def publish_email options={}
+    super
+    self.attempts_made += 1
+    save
+  end
+
   private
 
   def locals

--- a/app/models/eloqua_email.rb
+++ b/app/models/eloqua_email.rb
@@ -4,6 +4,8 @@ class EloquaEmail < ActiveRecord::Base
   after_save :async_send_email, if: :not_sent? # enqueues the record in Resque, which then calls #publish_email on the record
   belongs_to :emailable, polymorphic: true
 
+  scope :unsent, ->{ where(email_sent: false).where(attempts_made: 1..2) }
+
   ## This method is named this way in order to make it compatible
   ## with the way that EloquaSendbale already works.  Perhaps
   ## it should be globally renamed in the future to prevent

--- a/app/models/eloqua_email.rb
+++ b/app/models/eloqua_email.rb
@@ -65,6 +65,9 @@ class EloquaEmail < ActiveRecord::Base
 
   def publish_email options={}
     super
+  rescue => e
+    logger.error e.message
+  ensure
     self.attempts_made += 1
     save
   end

--- a/app/models/eloqua_email.rb
+++ b/app/models/eloqua_email.rb
@@ -66,7 +66,7 @@ class EloquaEmail < ActiveRecord::Base
   def publish_email options={}
     super
   rescue => e
-    logger.error e.message
+    NewRelic.log_error(e)
   ensure
     self.attempts_made += 1
     save

--- a/db/migrate/20151125223240_add_attempts_made_to_eloqua_emails.rb
+++ b/db/migrate/20151125223240_add_attempts_made_to_eloqua_emails.rb
@@ -1,0 +1,5 @@
+class AddAttemptsMadeToEloquaEmails < ActiveRecord::Migration
+  def change
+    add_column :eloqua_emails, :attempts_made, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151116220729) do
+ActiveRecord::Schema.define(version: 20151125223240) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -322,6 +322,8 @@ ActiveRecord::Schema.define(version: 20151116220729) do
     t.string   "email_type",          limit: 255
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
+    t.datetime "send_at"
+    t.integer  "attempts_made",       limit: 4,   default: 0
   end
 
   create_table "events", force: :cascade do |t|
@@ -859,6 +861,8 @@ ActiveRecord::Schema.define(version: 20151116220729) do
     t.datetime "updated_at"
     t.datetime "began_at"
     t.datetime "most_recent_at"
+    t.string   "image",          limit: 255
+    t.string   "tag_type",       limit: 255,   default: "keyword"
   end
 
   add_index "tags", ["created_at"], name: "index_tags_on_created_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -322,7 +322,6 @@ ActiveRecord::Schema.define(version: 20151125223240) do
     t.string   "email_type",          limit: 255
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
-    t.datetime "send_at"
     t.integer  "attempts_made",       limit: 4,   default: 0
   end
 
@@ -861,8 +860,6 @@ ActiveRecord::Schema.define(version: 20151125223240) do
     t.datetime "updated_at"
     t.datetime "began_at"
     t.datetime "most_recent_at"
-    t.string   "image",          limit: 255
-    t.string   "tag_type",       limit: 255,   default: "keyword"
   end
 
   add_index "tags", ["created_at"], name: "index_tags_on_created_at", using: :btree

--- a/lib/eloqua/entity.rb
+++ b/lib/eloqua/entity.rb
@@ -34,7 +34,7 @@ module Eloqua
       #--------------------
 
       def process_response(resp)
-        if resp.body.present?
+        if resp.body.present? && resp.success?
           new(resp.body)
         else
           nil

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -59,6 +59,11 @@ task :scheduler => [:environment] do
     Job::SyncRemoteArticles.enqueue()
   end
 
+  # retry failed Eloqua emails
+  scheduler.every '1m' do |job|
+    Job::RetryEmails.enqueue()
+  end
+
   # Go!
   puts "Scheduler running."
   scheduler.join

--- a/spec/models/eloqua_email_spec.rb
+++ b/spec/models/eloqua_email_spec.rb
@@ -74,6 +74,26 @@ describe EloquaEmail do
         eloqua_email.publish_email
         eloqua_email.attempts_made.should eq 1
       end
+      context "500 status from API" do
+        before do 
+          stub_request(:any, /.*/).to_return(body: "", status: 500)
+        end
+        it "leaves email_sent as false" do
+          edition = build :edition, :with_abstract
+          edition.save
+          eloqua_email = edition.eloqua_emails.last
+          eloqua_email.publish_email
+          eloqua_email.email_sent.should be false
+        end
+        it "increments attempts_made" do
+          edition = build :edition, :with_abstract
+          edition.save
+          eloqua_email = edition.eloqua_emails.last
+          eloqua_email.attempts_made.should be 0
+          eloqua_email.publish_email
+          eloqua_email.attempts_made.should be 1
+        end
+      end
     end
 
   end

--- a/spec/models/eloqua_email_spec.rb
+++ b/spec/models/eloqua_email_spec.rb
@@ -68,6 +68,12 @@ describe EloquaEmail do
         eloqua_email.should_not_receive(:async_send_email).with(:email_sent, true)
         eloqua_email.publish_email
       end
+      it "increments attempts_made" do
+        eloqua_email = build :eloqua_email, email_sent: true
+        eloqua_email.attempts_made.should eq 0
+        eloqua_email.publish_email
+        eloqua_email.attempts_made.should eq 1
+      end
     end
 
   end


### PR DESCRIPTION
#384

Per the discussion between @sdillingham and myself, I've left the changes to the way we send emails on hold and have implemented a job that retries emails that have failed.  I think that creating a unified email queue is a good approach but this alone better addresses the heart of the ticket.  If this ends up being successful, then we can later consider merging in the work that changes the way that the emails get sent.

To sum it up, we are sending emails as we normally have been but now we have a job that looks for eloqua_emails that have been attempted at least once but still have not been marked as sent.  