### PR TITLE
Add format selector to ckeditor.

### DIFF
--- a/public/static/ckeditor/config.js
+++ b/public/static/ckeditor/config.js
@@ -10,7 +10,7 @@ CKEDITOR.editorConfig = function(config) {
     ['Source', 'Maximize']
   ];
 
-  config.format_tags = 'p;h1;h2;h3';
+  config.format_tags = 'p;h2;h3';
 
   config.extraPlugins = [
     'image', // This plugin has custom changes so we didn't include it in the build

--- a/public/static/ckeditor/config.js
+++ b/public/static/ckeditor/config.js
@@ -3,14 +3,14 @@ CKEDITOR.timestamp = '20140219';
 CKEDITOR.editorConfig = function(config) {
 
   config.toolbar = [
-    ['Bold', 'Italic', 'Underline', "RemoveFormat"],
+    ['Format', 'Bold', 'Italic', 'Underline', "RemoveFormat"],
     ['NumberedList', 'BulletedList', 'Blockquote'],
     ['Link', 'Unlink', 'DockAssetManager', 'EmbedPlaceholder'],
     ['Find', 'Paste'],
     ['Source', 'Maximize']
   ];
 
-  config.format_tags = 'p;h2;h3';
+  config.format_tags = 'p;h1;h2;h3';
 
   config.extraPlugins = [
     'image', // This plugin has custom changes so we didn't include it in the build


### PR DESCRIPTION
#389 

Configured the WYSIWYG in Outpost to include a dropdown for formatting with heading tags.