### PR TITLE
Alert badge

### DIFF
--- a/app/models/breaking_news_alert.rb
+++ b/app/models/breaking_news_alert.rb
@@ -116,7 +116,7 @@ class BreakingNewsAlert < ActiveRecord::Base
     push = Parse::Push.new({
       :title      => "KPCC - #{self.break_type}",
       :alert      => alert_subject,
-      :badge      => "Increment",
+      :badge      => badge,
       :alertId    => self.id
     })
     push.channels = self.alert_type == "audio" ? [IPHONE_CHANNEL,IPAD_CHANNEL] : [IPAD_CHANNEL]
@@ -162,6 +162,11 @@ class BreakingNewsAlert < ActiveRecord::Base
     }
   end
 
+  def badge
+    unless alert_type == "audio"
+      "Increment"
+    end
+  end
 
   private
 

--- a/spec/models/breaking_news_alert_spec.rb
+++ b/spec/models/breaking_news_alert_spec.rb
@@ -227,4 +227,21 @@ describe BreakingNewsAlert do
       BreakingNewsAlert.latest_visible_alert.should be_nil
     end
   end
+
+  #-----------------------
+
+  describe "#badge" do
+    context "alert is an audio alert" do
+      it "returns nil" do
+        alert = create :breaking_news_alert, alert_type: 'audio'
+        expect(alert.badge).to be_nil
+      end
+    end
+    context "alert is not an audio alert" do
+      it 'returns increment string' do
+        alert = create :breaking_news_alert, alert_type: 'break'
+        expect(alert.badge.include?('Increment')).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Re-merging because of a previous revert I did.

Addresses #402. Only uses the "increment" badge string if the alert is not of the "audio" type.