### PR TITLE
Add model to handle pledge drive date ranges.

### DIFF
--- a/app/controllers/listen_controller.rb
+++ b/app/controllers/listen_controller.rb
@@ -45,7 +45,7 @@ class ListenController < ApplicationController
   private
 
   def check_pledge_status
-    return redirect_to("/listen_live/pledge-free/off-air") if !PLEDGE_DRIVE
+    return redirect_to("/listen_live/pledge-free/off-air") unless PledgeDrive.happening?
   end
 
   def require_pledge_token

--- a/app/controllers/outpost/pledge_drives_controller.rb
+++ b/app/controllers/outpost/pledge_drives_controller.rb
@@ -1,0 +1,23 @@
+class Outpost::PledgeDrivesController < Outpost::ResourceController
+  outpost_controller
+
+  define_list do |l|
+    l.default_order_attribute   = "starts_at"
+    l.default_order_direction   = ASCENDING
+
+    l.column :id
+    l.column :starts_at,
+      :sortable                   => true,
+      :default_order_direction    => ASCENDING
+    l.column :ends_at,
+      :sortable => true,
+      :default_order_direction => ASCENDING
+    l.column :created_at,
+      :sortable => true,
+      :default_order_direction => ASCENDING
+    l.column :updated_at,
+      :sortable => true,
+      :default_order_direction => ASCENDING
+  end
+
+end

--- a/app/controllers/outpost/podcasts_controller.rb
+++ b/app/controllers/outpost/podcasts_controller.rb
@@ -19,4 +19,5 @@ class Outpost::PodcastsController < Outpost::ResourceController
       :title        => "Listed?",
       :collection   => :boolean
   end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -492,5 +492,20 @@ module ApplicationHelper
     }
     doc.css('body').children.to_s.html_safe
   end
+
+  class ActionView::Helpers::FormBuilder
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::FormTagHelper
+    include ActionView::Helpers::FormOptionsHelper
+    include ActionView::Helpers::CaptureHelper
+    include ActionView::Helpers::AssetTagHelper
+    # This just makes it easy to create a check box
+    # that will also send a false value
+    def boolean_checkbox *args
+      self.input *args do
+        @template.check_box self.object.class.name.underscore, args[0], {checked: self.object.send(args[0])}, "1", "0"
+      end
+    end
+  end
   
 end

--- a/app/models/pledge_drive.rb
+++ b/app/models/pledge_drive.rb
@@ -1,0 +1,14 @@
+class PledgeDrive < ActiveRecord::Base
+  outpost_model
+  validates :starts_at, presence: true
+  validates :ends_at, presence: true
+
+  scope :enabled, ->{where(enabled: true)}
+  scope :finished, ->{where('ends_at <= ?', Time.zone.now)}
+  scope :happening, ->{enabled.where('starts_at < ?', Time.zone.now).where('ends_at > ?', Time.zone.now)}
+  class << self
+    def happening?
+      happening.any?
+    end
+  end
+end

--- a/app/views/outpost/pledge_drives/_form_fields.html.erb
+++ b/app/views/outpost/pledge_drives/_form_fields.html.erb
@@ -1,0 +1,5 @@
+<%= form_block "Details" do %>
+  <%= f.input :starts_at %>
+  <%= f.input :ends_at %>
+  <%= f.boolean_checkbox :enabled, hint: "The pledge drive will not take effect unless this checked." %>
+<% end %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,4 @@
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.clear :drives
+  inflect.irregular 'drive', 'drives'
+end

--- a/config/initializers/pledge_drive.rb
+++ b/config/initializers/pledge_drive.rb
@@ -1,3 +1,0 @@
-## Change to true to enable features/behavior that should happen
-## only during a drive
-PLEDGE_DRIVE = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,6 +296,7 @@ Scprv4::Application.routes.draw do
     resources :news_stories, concerns: [:preview, :search]
     resources :blog_entries, concerns: [:preview, :search]
     resources :events, concerns: [:preview, :search]
+    resources :pledge_drives, concerns: [:search]
 
     resources :remote_articles, only: [:index], concerns: [:search] do
       member do

--- a/db/migrate/20160201231927_create_pledge_drives.rb
+++ b/db/migrate/20160201231927_create_pledge_drives.rb
@@ -1,0 +1,10 @@
+class CreatePledgeDrives < ActiveRecord::Migration
+  def change
+    create_table :pledge_drives do |t|
+      t.datetime :starts_at, index: true, null: false
+      t.datetime :ends_at, index: true, null: false
+      t.boolean :enabled, default: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160202002651_create_pledge_drives_permission.rb
+++ b/db/migrate/20160202002651_create_pledge_drives_permission.rb
@@ -1,0 +1,8 @@
+class CreatePledgeDrivesPermission < ActiveRecord::Migration
+  def up
+    Permission.where(resource: "PledgeDrive").first_or_create
+  end
+  def down
+    Permission.where(resource: "PledgeDrive").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151210190834) do
+ActiveRecord::Schema.define(version: 20160202002651) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -462,6 +462,10 @@ ActiveRecord::Schema.define(version: 20151210190834) do
     t.boolean  "mobile_notification_sent",                    default: false, null: false
     t.integer  "status",                   limit: 4
     t.datetime "published_at"
+    t.datetime "starts_at"
+    t.datetime "ends_at"
+    t.boolean  "should_rewind",                               default: false
+    t.boolean  "bypass_preroll",                              default: false
   end
 
   add_index "layout_breakingnewsalert", ["alert_type"], name: "index_layout_breakingnewsalert_on_alert_type", using: :btree
@@ -600,6 +604,17 @@ ActiveRecord::Schema.define(version: 20151210190834) do
   add_index "pij_query", ["query_type"], name: "index_pij_query_on_query_type", using: :btree
   add_index "pij_query", ["slug"], name: "slug", unique: true, using: :btree
   add_index "pij_query", ["status"], name: "index_pij_query_on_status", using: :btree
+
+  create_table "pledge_drives", force: :cascade do |t|
+    t.datetime "starts_at",                  null: false
+    t.datetime "ends_at",                    null: false
+    t.boolean  "enabled",    default: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "pledge_drives", ["ends_at"], name: "index_pledge_drives_on_ends_at", using: :btree
+  add_index "pledge_drives", ["starts_at"], name: "index_pledge_drives_on_starts_at", using: :btree
 
   create_table "podcasts", force: :cascade do |t|
     t.string   "slug",               limit: 255

--- a/spec/factories/pledge_drives.rb
+++ b/spec/factories/pledge_drives.rb
@@ -1,0 +1,22 @@
+##
+# Categories
+#
+FactoryGirl.define do
+  factory :pledge_drive do
+    trait :happened do
+      starts_at 3.days.ago
+      ends_at 1.day.ago
+    end
+    trait :happening do
+      starts_at 1.day.ago
+      ends_at Time.zone.now + 1.day
+    end
+    trait :will_happen do
+      starts_at Time.zone.now + 1.day
+      ends_at Time.zone.now + 2.days
+    end
+    trait :enabled do
+      enabled true
+    end
+  end
+end

--- a/spec/models/pledge_drive_spec.rb
+++ b/spec/models/pledge_drive_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe PledgeDrive do
+  describe '#happening?' do
+    context 'happening now' do
+      context 'that is enabled' do
+        it 'returns true' do
+          create :pledge_drive, :happening, :enabled
+          expect(PledgeDrive.happening?).to be true
+        end
+      end
+      context 'that is not enabled' do
+        it 'returns false' do
+          create :pledge_drive, :happening
+          expect(PledgeDrive.happening?).to be false
+        end
+      end
+    end
+    context 'no pledge drives are happening' do
+      context 'and none exist' do
+        it 'returns false' do
+          PledgeDrive.delete_all
+          expect(PledgeDrive.happening?).to be false
+        end
+      end
+      context 'that are in the past' do
+        it 'returns false' do
+          create :pledge_drive, :happened, :enabled
+          expect(PledgeDrive.happening?).to be false
+        end
+      end
+      context 'that are awaiting' do
+        it 'returns false' do
+          create :pledge_drive, :will_happen, :enabled
+          expect(PledgeDrive.happening?).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#376

Not sure if it's overkill, but I decided to try handling pledges using a table.  That way nobody has to commit and deploy code just to start a pledge drive, and they can be scheduled ahead of time.  Since it's an Outpost model, permission can be restricted to only certain people.  Pledge drives can also be enabled and disabled, overriding whether or not the current date falls within their time range.  I'd be happy to scrap this if all we really wanted was a second config parameter.