### PR TITLE
Fix #rendered_body method for PMP Content Association

### DIFF
--- a/app/concerns/concern/associations/pmp_content_association.rb
+++ b/app/concerns/concern/associations/pmp_content_association.rb
@@ -89,7 +89,7 @@ module Concern
           content.reload
           @content = content
           @pmp_content = content.pmp_content
-          super(ActionController::Base.view_paths, {})
+          super ActionController::Base.view_paths, {}, ActionController::Base.new
         end
 
         def render_with_assets
@@ -100,6 +100,9 @@ module Concern
         end
         def render_templated
           @content.body
+        end
+        def params
+          {} # ActionView expects this, but we obviously it isn't useful in this context.
         end
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -181,8 +181,7 @@ module ApplicationHelper
         placeholder.replace Nokogiri::HTML::DocumentFragment.parse("")
       end
     end
-
-    doc.to_s.html_safe
+    doc.css("body").children.to_s.html_safe
   end
 
   #----------

--- a/spec/concerns/concern/associations/pmp_content_association_spec.rb
+++ b/spec/concerns/concern/associations/pmp_content_association_spec.rb
@@ -101,5 +101,15 @@ describe Concern::Associations::PmpContentAssociation do
         end
       end
     end
+
+    describe 'rendering' do
+      describe 'rendered body' do
+        it "renders html" do
+          story = create :news_story, status: 0, publish_to_pmp: true, body: "Lorem ipsum dolor sit amet"
+          rendered_body = story.rendered_body
+          expect(Nokogiri::HTML(story.rendered_body).css("article").inner_text).to include story.body
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Stories were failing to be published because an issue with the underlying implementation of #rendered_body was failing.  Not exactly sure how that came to be, since I basically re-wrote all that code yesterday.  But now I've written a test for it and it should be ready for another try.