### PR TITLE
Cache data in MySQL in case Memcached goes down

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   private
 
   def get_popular_articles
-    @popular_articles = Rails.cache.read("popular/viewed")
+    @popular_articles = Cache.read("popular/viewed")
   end
 
   #----------

--- a/app/controllers/cache_controller.rb
+++ b/app/controllers/cache_controller.rb
@@ -45,7 +45,7 @@ class CacheController < AbstractController::Base
   private
 
   def write(key, value)
-    Rails.cache.write(key, value)
+    Cache.write(key, value)
     true
   end
 end

--- a/app/jobs/job/most_commented.rb
+++ b/app/jobs/job/most_commented.rb
@@ -13,7 +13,7 @@ module Job
         comments  = task.fetch
         articles  = task.parse(comments).map(&:to_article)
 
-        Rails.cache.write("popular/commented", articles)
+        Cache.write("popular/commented", articles)
 
         self.cache(articles,
           "/shared/widgets/cached/popular",

--- a/app/jobs/job/most_viewed.rb
+++ b/app/jobs/job/most_viewed.rb
@@ -27,7 +27,7 @@ module Job
           -obj.public_datetime.to_i
         }
 
-        Rails.cache.write("popular/viewed", articles)
+        Cache.write("popular/viewed", articles)
 
         self.cache(
           articles,

--- a/app/jobs/job/most_viewed_blog_entries.rb
+++ b/app/jobs/job/most_viewed_blog_entries.rb
@@ -27,7 +27,7 @@ module Job
           data = silence_stream(STDOUT) { task.fetch(api_params(blog)) }
           if blog_entry = task.parse(data['rows'])
             article = blog_entry.to_article
-            Rails.cache.write("popular/#{blog}", article)
+            Cache.write("popular/#{blog}", article)
             self.cache(
               article,
               "/shared/widgets/cached/popular_blog",

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -9,12 +9,9 @@ class Cache < ActiveRecord::Base
       end
     end
     def write key, value
-      if return_value = Rails.cache.write(key, value)
-        return_value
-      else
-        create key: key, value: value
-        value
-      end
+      Rails.cache.write(key, value)
+      create key: key, value: value
+      value
     end
     def clear
       delete_all

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -1,0 +1,23 @@
+class Cache < ActiveRecord::Base
+  class << self
+    def read key
+      if value = Rails.cache.read(key)
+        value
+      elsif value = where(key: key).limit(1).pluck(:value).pop
+        Rails.cache.write key, value
+        value
+      end
+    end
+    def write key, value
+      if return_value = Rails.cache.write(key, value)
+        return_value
+      else
+        create key: key, value: value
+        value
+      end
+    end
+    def clear
+      delete_all
+    end
+  end
+end

--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -3,7 +3,7 @@ class Cache < ActiveRecord::Base
     def read key
       if value = Rails.cache.read(key)
         value
-      elsif value = where(key: key).limit(1).pluck(:value).pop
+      elsif value = find_by(key: key).try(:value)
         Rails.cache.write key, value
         value
       end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,7 +26,7 @@
       <h6>Most Popular</h6>
       <div class="tab-content">
         <div class="tab-pane active popular" id="pop_tab1" data-vr-zone="Most Popular">
-          <%= raw Rails.cache.read("views/popular/viewed") %>
+          <%= raw Cache.read("views/popular/viewed") %>
         </div>
       </div>
     </div>
@@ -57,5 +57,5 @@
 <% end %>
 
 <% content_for :lower do %>
-  <%= raw Rails.cache.read("home/sections") %>
+  <%= raw Cache.read("home/sections") %>
 <% end %>

--- a/app/views/shared/masthead/_news.html.erb
+++ b/app/views/shared/masthead/_news.html.erb
@@ -36,14 +36,14 @@
     <div class="span8">
       <div class="section">
         <h6>Latest News</h6>
-        <%= raw Rails.cache.read("masthead-latest-news") %>
+        <%= raw Cache.read("masthead-latest-news") %>
       </div> <!-- section -->
     </div> <!-- span -->
 
     <div class="span10">
       <div class="section">
         <h6>From Our Blogs</h6>
-        <%= raw Rails.cache.read("masthead-latest-blogs") %>
+        <%= raw Cache.read("masthead-latest-blogs") %>
       </div> <!-- section -->
     </div> <!-- span -->
   </div> <!-- row fluid -->

--- a/app/views/shared/new/_single_blog.html.erb
+++ b/app/views/shared/new/_single_blog.html.erb
@@ -41,7 +41,7 @@
 
             </div><!--/ .prose-body -->
 
-            <%= raw Rails.cache.read("views/popular/#{@entry.blog.slug}") %>
+            <%= raw Cache.read("views/popular/#{@entry.blog.slug}") %>
 
             <%= render 'shared/widgets/short_list_subscribe' %>
 

--- a/app/views/shared/widgets/_most_popular.html.erb
+++ b/app/views/shared/widgets/_most_popular.html.erb
@@ -7,11 +7,11 @@
   <div class="tab-content">
 
     <div class="tab-pane active popular" id="pop_tab1" data-vr-zone="Most Popular">
-    <%= raw Rails.cache.read("views/popular/viewed") %>
+    <%= raw Cache.read("views/popular/viewed") %>
     </div>
 
     <div class="tab-pane popular" id="pop_tab2" data-vr-zone="Most Discussed">
-    <%= raw Rails.cache.read("views/popular/commented") %>
+    <%= raw Cache.read("views/popular/commented") %>
     </div>
 
   </div>

--- a/app/views/verticals/business.html.erb
+++ b/app/views/verticals/business.html.erb
@@ -56,7 +56,7 @@
                 <a href="http://www.marketplace.org">More Marketplace</a>
             </header>
 
-        <%= raw Rails.cache.read("views/business/marketplace") %>
+        <%= raw Cache.read("views/business/marketplace") %>
         </section>
 
     </div><!--/ .ataglance -->

--- a/db/migrate/20160205232526_create_caches.rb
+++ b/db/migrate/20160205232526_create_caches.rb
@@ -1,0 +1,8 @@
+class CreateCaches < ActiveRecord::Migration
+  def change
+    create_table :caches do |t|
+      t.string :key, index: true
+      t.string :value
+    end
+  end
+end

--- a/db/migrate/20160205232526_create_caches.rb
+++ b/db/migrate/20160205232526_create_caches.rb
@@ -1,7 +1,7 @@
 class CreateCaches < ActiveRecord::Migration
   def change
     create_table :caches do |t|
-      t.string :key, index: true
+      t.string :key, index: true, unique: true
       t.text :value, limit: 4294967295
     end
   end

--- a/db/migrate/20160205232526_create_caches.rb
+++ b/db/migrate/20160205232526_create_caches.rb
@@ -2,7 +2,7 @@ class CreateCaches < ActiveRecord::Migration
   def change
     create_table :caches do |t|
       t.string :key, index: true
-      t.string :value
+      t.text :value, limit: 4294967295
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 20160205232526) do
 
   create_table "caches", force: :cascade do |t|
     t.string "key",   limit: 255
-    t.string "value", limit: 255
+    t.text   "value", limit: 4294967295
   end
 
   add_index "caches", ["key"], name: "index_caches_on_key", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160204215547) do
+ActiveRecord::Schema.define(version: 20160205232526) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -137,6 +137,13 @@ ActiveRecord::Schema.define(version: 20160204215547) do
   add_index "blogs_entry", ["status", "published_at"], name: "index_blogs_entry_on_status_and_published_at", using: :btree
   add_index "blogs_entry", ["status"], name: "index_blogs_entry_on_status", using: :btree
   add_index "blogs_entry", ["updated_at"], name: "index_blogs_entry_on_updated_at", using: :btree
+
+  create_table "caches", force: :cascade do |t|
+    t.string "key",   limit: 255
+    t.string "value", limit: 255
+  end
+
+  add_index "caches", ["key"], name: "index_caches_on_key", using: :btree
 
   create_table "category_articles", force: :cascade do |t|
     t.integer  "position",     limit: 4
@@ -830,13 +837,6 @@ ActiveRecord::Schema.define(version: 20160204215547) do
   add_index "shows_segment", ["status", "published_at"], name: "index_shows_segment_on_status_and_published_at", using: :btree
   add_index "shows_segment", ["status"], name: "index_shows_segment_on_status", using: :btree
   add_index "shows_segment", ["updated_at"], name: "index_shows_segment_on_updated_at", using: :btree
-
-  create_table "sql_store", force: :cascade do |t|
-    t.string "key",   limit: 255,      null: false
-    t.binary "value", limit: 16777215
-  end
-
-  add_index "sql_store", ["key"], name: "index_sql_store_on_key", using: :btree
 
   create_table "taggings", force: :cascade do |t|
     t.string   "taggable_type", limit: 255

--- a/spec/models/cache_spec.rb
+++ b/spec/models/cache_spec.rb
@@ -10,10 +10,12 @@ describe Cache do
     context "value exists in cache store" do
       before :each do
         Rails.cache.clear
-        Rails.cache.write('somekey', '12345')
         Cache.clear
+        Rails.cache.write('somekey', '12345')
       end
       it 'returns the value from the cache store' do
+        allow(Rails.cache).to receive(:read).and_return("12345")
+        expect(Rails.cache).to receive(:read)
         Cache.read('somekey').should eq '12345'
       end
       it 'should not touch the database' do
@@ -43,6 +45,7 @@ describe Cache do
     it 'writes a value to both the cache store and the cache table' do
       Cache.write "testkey", "whoohoo"
       Rails.cache.read('testkey').should eq "whoohoo"
+      Cache.read("testkey").should eq "whoohoo"
     end
   end
 end

--- a/spec/models/cache_spec.rb
+++ b/spec/models/cache_spec.rb
@@ -28,10 +28,11 @@ describe Cache do
     context 'cache store got wiped but there is a table record' do
       before :each do
         Cache.clear
-        Rails.cache.clear
         Cache.create key: 'lostkey', value: '456'
+        Rails.cache.clear
       end
       it 'writes the value back to the now online cache store' do
+        Rails.cache.read('lostkey').should be_nil
         Cache.read('lostkey')
         Rails.cache.read('lostkey').should eq '456'
       end

--- a/spec/models/cache_spec.rb
+++ b/spec/models/cache_spec.rb
@@ -16,10 +16,12 @@ describe Cache do
       it 'returns the value from the cache store' do
         Cache.read('somekey').should eq '12345'
       end
-      # it 'writes the value to a table record' do
-      #   Cache.read('somekey').should eq '12345'
-      #   Cache.where(key: 'somekey').first.value.should eq '12345'
-      # end
+      it 'should not touch the database' do
+        expect(Cache).not_to receive(:write)
+        expect(Cache).not_to receive(:create)
+        expect(Cache).not_to receive(:save)
+        Cache.read('somekey')
+      end
     end
     context 'cache store got wiped but there is a table record' do
       before :each do
@@ -31,6 +33,16 @@ describe Cache do
         Cache.read('lostkey')
         Rails.cache.read('lostkey').should eq '456'
       end
+    end
+  end
+  describe '#write' do
+    before :each do
+      Rails.cache.clear
+      Cache.clear
+    end
+    it 'writes a value to both the cache store and the cache table' do
+      Cache.write "testkey", "whoohoo"
+      Rails.cache.read('testkey').should eq "whoohoo"
     end
   end
 end

--- a/spec/models/cache_spec.rb
+++ b/spec/models/cache_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+Rails.application.configure do
+  config.cache_store = :null_store
+end
+
+
+describe Cache do
+  describe '#read' do
+    context "value exists in cache store" do
+      before :each do
+        Rails.cache.clear
+        Rails.cache.write('somekey', '12345')
+        Cache.clear
+      end
+      it 'returns the value from the cache store' do
+        Cache.read('somekey').should eq '12345'
+      end
+      # it 'writes the value to a table record' do
+      #   Cache.read('somekey').should eq '12345'
+      #   Cache.where(key: 'somekey').first.value.should eq '12345'
+      # end
+    end
+    context 'cache store got wiped but there is a table record' do
+      before :each do
+        Cache.clear
+        Rails.cache.clear
+        Cache.create key: 'lostkey', value: '456'
+      end
+      it 'writes the value back to the now online cache store' do
+        Cache.read('lostkey')
+        Rails.cache.read('lostkey').should eq '456'
+      end
+    end
+  end
+end


### PR DESCRIPTION
#407

I wrote a model that wraps around the Rails cache store that caches data in MySQL for items that are usually stored out-of-band.  This is so that, if a cache server goes down, we don't end up rendering all these items on every request.  If a cache server comes back online and there is an item that has been cached in MySQL, it will also write that data back to the cache server.