### PR TITLE
Serialize cache values as a temp fix for emojis causing encoding issu…

### DIFF
--- a/app/models/cache.rb
+++ b/app/models/cache.rb
@@ -17,4 +17,18 @@ class Cache < ActiveRecord::Base
       delete_all
     end
   end
+
+  class MarshalSerializer
+    class << self
+      include Marshal
+      def load string
+        super if string
+      end
+      def dump string
+        super if string
+      end
+    end
+  end
+
+  serialize :value, MarshalSerializer
 end

--- a/db/migrate/20160216223149_make_cache_values_binary.rb
+++ b/db/migrate/20160216223149_make_cache_values_binary.rb
@@ -1,0 +1,17 @@
+class MakeCacheValuesBinary < ActiveRecord::Migration
+  require 'rake'
+  def up
+    Cache.clear
+    change_column :caches, :value, :binary, limit: 2.megabytes
+    Rake::Task.clear
+    Scprv4::Application.load_tasks
+    Rake::Task['scprv4:cache'].invoke
+  end
+  def down
+    Cache.clear
+    change_column :caches, :value, :text, limit: 4294967295
+    Rake::Task.clear
+    Scprv4::Application.load_tasks
+    Rake::Task['scprv4:cache'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160208220816) do
+ActiveRecord::Schema.define(version: 20160216223149) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 20160208220816) do
 
   create_table "caches", force: :cascade do |t|
     t.string "key",   limit: 255
-    t.text   "value", limit: 4294967295
+    t.binary "value", limit: 16777215
   end
 
   add_index "caches", ["key"], name: "index_caches_on_key", using: :btree
@@ -497,9 +497,9 @@ ActiveRecord::Schema.define(version: 20160208220816) do
   add_index "layout_homepage", ["updated_at"], name: "index_layout_homepage_on_updated_at", using: :btree
 
   create_table "layout_homepagecontent", force: :cascade do |t|
-    t.integer "homepage_id",  limit: 4,                null: false
+    t.integer "homepage_id",  limit: 4,                      null: false
     t.integer "content_id",   limit: 4
-    t.integer "position",     limit: 4,   default: 99, null: false
+    t.integer "position",     limit: 4,   default: 99,       null: false
     t.string  "content_type", limit: 255
   end
 

--- a/spec/models/cache_spec.rb
+++ b/spec/models/cache_spec.rb
@@ -68,5 +68,10 @@ describe Cache do
       Rails.cache.read('existingkey').should eq value2
     end
 
+    it 'writes arrays' do
+      test_array = ['one', 2, 'three', 4, 'five']
+      Cache.write 'testarray', ['one', 2, 'three', 4, 'five']
+      Cache.read('testarray').should eq test_array
+    end
   end
 end


### PR DESCRIPTION
The problem preventing Twitter posts from being cached came from an emoji causing an encoding problem with our Cache model.  This is because we chose the type of the value column to be text, but this turns out to also be insufficient as there is a case where we are caching an array as well.  So I changed the column type to `binary` and I am serializing passed objects by Marshalizing them.