### PR TITLE
Allow episode rundowns to include any content base content

### DIFF
--- a/app/concerns/concern/controller/show_episodes.rb
+++ b/app/concerns/concern/controller/show_episodes.rb
@@ -3,7 +3,7 @@ module Concern
     module ShowEpisodes
       extend ActiveSupport::Concern
       def render_kpcc_episode
-        @segments   = @episode.segments.published
+        @content = @episode.published_content.map(&:to_article)
         @featured_programs = KpccProgram.where.not(id: @program.id, is_featured: false).first(4)
         if @program.is_segmented?
           @episodes = @program.episodes.published.order("air_date").first(4)

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -10,7 +10,8 @@ class Episode
     :assets,
     :audio,
     :program,
-    :segments
+    :segments,
+    :content
 
 
   def initialize(attributes={})
@@ -23,6 +24,7 @@ class Episode
     @assets           = Array(attributes[:assets])
     @audio            = Array(attributes[:audio])
     @segments         = Array(attributes[:segments])
+    @content          = Array(attributes[:content])
   end
 
   def to_episode

--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -121,6 +121,10 @@ class ShowEpisode < ActiveRecord::Base
     rundowns.map(&:content)
   end
 
+  def published_content
+    content.select(&:published?)
+  end
+
   def to_article
     return nil if !self.show
     @to_article ||= Article.new({

--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -170,7 +170,8 @@ class ShowEpisode < ActiveRecord::Base
       :assets             => self.assets.top,
       :audio              => self.audio.available,
       :program            => self.show,
-      :segments           => self.segments.published.map(&:to_article)
+      :segments           => self.segments.published.map(&:to_article),
+      :content            => self.published_content.map(&:to_article)
     })
   end
 

--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -118,7 +118,7 @@ class ShowEpisode < ActiveRecord::Base
   end
 
   def content
-    rundowns.map(&:content)
+    rundowns.includes(:content).map(&:content)
   end
 
   def published_content

--- a/app/models/show_rundown.rb
+++ b/app/models/show_rundown.rb
@@ -1,18 +1,19 @@
 class ShowRundown < ActiveRecord::Base
   self.table_name = 'shows_rundown'
-  self.versioned_attributes = ["segment_id", "position"]
+  self.versioned_attributes = ["content_id", "position"]
 
   belongs_to :episode, class_name: "ShowEpisode", inverse_of: :rundowns
-  belongs_to :segment, class_name: "ShowSegment", inverse_of: :rundowns
+  belongs_to :content, polymorphic: true
 
   validates :episode, presence:true, associated:true
-  validates :segment, presence:true, associated:true
+  validates :content, presence:true, associated:true
 
   #------------------------
 
   def simple_json
     {
-      "id"       => self.segment.try(:obj_key), # TODO Store this in join table
+      "id"       => self.content.try(:obj_key), # TODO Store this in join table
+      "type"     => self.content_type,
       "position" => self.position.to_i
     }
   end

--- a/app/models/show_segment.rb
+++ b/app/models/show_segment.rb
@@ -49,7 +49,8 @@ class ShowSegment < ActiveRecord::Base
 
   has_many :rundowns,
     :class_name     => "ShowRundown",
-    :foreign_key    => "segment_id",
+    :foreign_key    => "content_id",
+    :as             => "content",
     :dependent      => :destroy
 
   has_many :episodes,

--- a/app/views/api/public/v2/episodes/_episode.json.jbuilder
+++ b/app/views/api/public/v2/episodes/_episode.json.jbuilder
@@ -37,7 +37,7 @@ json.cache! [Api::Public::V2::VERSION, "v3", episode] do
 
   json.content do
     json.partial! 'api/public/v2/articles/collection',
-      articles: episode.published_content.map(&:to_article)
+      articles: episode.content.map(&:to_article)
   end
 
 end

--- a/app/views/api/public/v2/episodes/_episode.json.jbuilder
+++ b/app/views/api/public/v2/episodes/_episode.json.jbuilder
@@ -34,4 +34,10 @@ json.cache! [Api::Public::V2::VERSION, "v3", episode] do
   end
 
   json.teaser episode.summary.to_s.html_safe # Deprecated
+
+  json.content do
+    json.partial! 'api/public/v2/articles/collection',
+      articles: episode.published_content.map(&:to_article)
+  end
+
 end

--- a/app/views/api/public/v3/episodes/_episode.json.jbuilder
+++ b/app/views/api/public/v3/episodes/_episode.json.jbuilder
@@ -25,4 +25,10 @@ json.cache! [Api::Public::V3::VERSION, "v2", episode] do
     json.partial! api_view_path("articles", "collection"),
       articles: episode.segments.map(&:to_article)
   end
+
+  json.content do
+    json.partial! api_view_path("articles", "collection"),
+      articles: episode.published_content.map(&:to_article)
+  end
+
 end

--- a/app/views/api/public/v3/episodes/_episode.json.jbuilder
+++ b/app/views/api/public/v3/episodes/_episode.json.jbuilder
@@ -28,7 +28,7 @@ json.cache! [Api::Public::V3::VERSION, "v2", episode] do
 
   json.content do
     json.partial! api_view_path("articles", "collection"),
-      articles: episode.published_content.map(&:to_article)
+      articles: episode.content.map(&:to_article)
   end
 
 end

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -47,10 +47,10 @@
                   <!-- Segments -->
                   <ul class="cbase">
 
-                  <% episode.segments.published.each_with_index do |segment, i| %>
+                  <% episode.published_content.each_with_index do |content, i| %>
                     <li>
-                      <h5 class="headline"><%= link_to segment.short_headline, segment.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => "#{i==0 ? 'Lead' : 'Offlead'} Segment"} %></h5>
-                      <%= comment_count_for segment %>
+                      <h5 class="headline"><%= link_to content.short_headline, content.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => "#{i==0 ? 'Lead' : 'Offlead'} Segment"} %></h5>
+                      <%= comment_count_for content %>
                     </li>
                   <% end %>
 

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -44,13 +44,13 @@
                   <h6><%= link_to episode.headline, episode.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => 'Current Episode'} %></h6>
                   <%= render_asset episode, display: 'thumbnail' %>
 
-                  <!-- Segments -->
+                  <!-- Content -->
                   <ul class="cbase">
 
-                  <% episode.published_content.each_with_index do |content, i| %>
+                  <% episode.published_content.map(&:to_article).each_with_index do |content, i| %>
                     <li>
-                      <h5 class="headline"><%= link_to content.short_headline, content.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => "#{i==0 ? 'Lead' : 'Offlead'} Segment"} %></h5>
-                      <%= comment_count_for content %>
+                      <h5 class="headline"><%= link_to content.short_title, content.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => "#{i==0 ? 'Lead' : 'Offlead'} Content"} %></h5>
+                      <%= comment_count_for content.original_object %>
                     </li>
                   <% end %>
 

--- a/app/views/outpost/show_episodes/_form_fields.html.erb
+++ b/app/views/outpost/show_episodes/_form_fields.html.erb
@@ -34,7 +34,7 @@
           params: {
             limit: 20,
             token: "<%= Rails.configuration.x.api.kpcc.private.api_token %>",
-            types: 'segments,news,shells,blogs,episodes',
+            types: 'segments,stories,shells,blogs,episodes,abstracts,events,pij_queries',
             order: "updated_at", // Don't use published_at - we're finding unpublished content too.
             sort_mode: "desc",
             with: {

--- a/app/views/outpost/show_episodes/_form_fields.html.erb
+++ b/app/views/outpost/show_episodes/_form_fields.html.erb
@@ -24,17 +24,17 @@
   <%= f.input :rundowns_json, as: :hidden, input_html: { id: "rundowns_json" } %>
 
   <% content_for :footer do %>
-    <script>
+    <script id="rundowns-aggregator">
       aggregator = new outpost.Aggregator(
         {
           el: "#segmented-aggregator", 
           inputEl: "#rundowns_json",
-          collection: <%= render_json('api/private/v2/articles/collection', articles: record.segments.map(&:to_article)) %>,
+          collection: <%= render_json('api/private/v2/articles/collection', articles: record.content.map(&:to_article)) %>,
           apiType: "private",
           params: {
             limit: 20,
             token: "<%= Rails.configuration.x.api.kpcc.private.api_token %>",
-            types: "segments",
+            types: 'segments,news,shells,blogs,episodes',
             order: "updated_at", // Don't use published_at - we're finding unpublished content too.
             sort_mode: "desc",
             with: {

--- a/app/views/programs/kpcc/_featured_story.html.erb
+++ b/app/views/programs/kpcc/_featured_story.html.erb
@@ -42,18 +42,18 @@
         <h2>In this episode</h2>
         <nav>
           <ul>
-            <% story_segments = featured_story.original_object.segments.first(8).map(&:to_article) %>
-            <% story_segments.each do |segment| %>
-              <li><a href="<%= segment.public_path %>"><%= segment.short_title %></a></li>
+            <% story_content = featured_story.original_object.content.first(8).map(&:to_article) %>
+            <% story_content.each do |content| %>
+              <li><a href="<%= content.public_path %>"><%= content.short_title %></a></li>
             <% end %>
           </ul>
         </nav>
         <footer>
-          <% if story_segments.count > 8 %>
+          <% if story_content.count > 8 %>
             <a href="<%= featured_story.public_path %>">
               <figure>
                 <mark>See all from <%= format_date(featured_story.public_datetime, with: "%B %e") %></mark>
-                <% story_count = (story_segments - story_segments.first(8)).count %>
+                <% story_count = (story_content - story_content.first(8)).count %>
                 <% if story_count > 0 %>
                   <figcaption><span><%= story_count %></span> more <%= 'story'.pluralize(story_count) %></figcaption>
                 <% end %>

--- a/app/views/programs/kpcc/_segment.html.erb
+++ b/app/views/programs/kpcc/_segment.html.erb
@@ -51,9 +51,9 @@
                 <h1><%= link_to article.published_episode.headline, article.published_episode.public_path %></h1>
                 <nav>
                   <ul>
-                    <% article.episode_segments.each do |segment| %>
-                      <li class="<%= ("selected" if article.id == segment.id) %>">
-                        <%= link_to segment.short_headline, segment.public_path %>
+                    <% article.episode.published_content.each do |content| %>
+                      <li class="<%= ("selected" if article.id == content.id) %>">
+                        <%= link_to content.short_headline, content.public_path %>
                       </li>
                     <% end %>
                   </ul>

--- a/app/views/programs/kpcc/_segment.html.erb
+++ b/app/views/programs/kpcc/_segment.html.erb
@@ -51,9 +51,9 @@
                 <h1><%= link_to article.published_episode.headline, article.published_episode.public_path %></h1>
                 <nav>
                   <ul>
-                    <% article.episode.published_content.each do |content| %>
+                    <% article.episode.published_content.map(&:to_article).each do |content| %>
                       <li class="<%= ("selected" if article.id == content.id) %>">
-                        <%= link_to content.short_headline, content.public_path %>
+                        <%= link_to content.short_title, content.public_path %>
                       </li>
                     <% end %>
                   </ul>

--- a/app/views/programs/kpcc/episode.html.erb
+++ b/app/views/programs/kpcc/episode.html.erb
@@ -29,39 +29,41 @@
 
         <section class="episode-enumeration">
 
-          <h1>Segments From This Episode</h1>
+          <h1>From This Episode</h1>
 
-          <%= any_to_list? @segments, title: "Segments" do %>
-            <%= cache ["segment-teasers", @segments.to_a] do %>
-              <% @segments.each.with_index do |segment, index| %>
+          <%= any_to_list? @content, title: "Content" do %>
+            <%= cache ["segment-teasers", @content.to_a] do %>
+              <% @content.each.with_index do |content, index| %>
               <article class="clearfix">
-                <a href="<%= segment.public_path %>">
+                <a href="<%= content.public_path %>">
                   <figure class="asset">
                     <mark class="order"><%= index + 1 %></mark>
                     <div class="ratio">
                       <div class="fill"></div>
                       <b class="img-contain">
-                        <% if segment.asset.present? %>
-                        <img src="<%= segment.asset.full.url %>" alt="" data-width="<%= segment.asset.full.width %>" data-height="<%= segment.asset.full.height %>" />
+                        <% if content.asset.present? %>
+                        <img src="<%= content.asset.full.url %>" alt="" data-width="<%= content.asset.full.width %>" data-height="<%= content.asset.full.height %>" />
                         <% end %>
                       </b>
                     </div>
                   </figure>
                 </a>
                 <div class="exposition">
-                  <a href="<%= segment.public_path %>">
-                    <h1><%= segment.short_headline %></h1>
+                  <a href="<%= content.public_path %>">
+                    <h1><%= content.original_object.short_headline %></h1>
                   </a>
                   <div class="precis">
-                    <p><a href="<%= segment.public_path %>"><%= segment.teaser.html_safe %></a></p>
+                    <p><a href="<%= content.public_path %>"><%= content.teaser.html_safe %></a></p>
                     <aside class="meta">
                       <ul>
-                        <li><%= comment_widget_for segment, partial: "new/comment_count_small", to_article: false, non_zero: true %></li>
-                        <li class="play"><%= content_widget "primary_audio", segment, context: segment.show.slug %></li>
+                        <li><%= comment_widget_for content, partial: "new/comment_count_small", to_article: false, non_zero: true %></li>
+                        <% if content.original_object.is_a?(ShowSegment) %>
+                          <li class="play"><%= content_widget "primary_audio", content, context: content.show.slug %></li>
+                        <% end %>
                       </li>
                     </aside>
                   </div>
-                  <%= timestamp_if_segment_is_legacy segment.published_at, @episode.air_date %>
+                  <%= timestamp_if_segment_is_legacy content.original_object.published_at, @episode.air_date %>
                 </div><!--/ .exposition -->
               </article>
 

--- a/app/views/programs/kpcc/episode.html.erb
+++ b/app/views/programs/kpcc/episode.html.erb
@@ -50,7 +50,7 @@
                 </a>
                 <div class="exposition">
                   <a href="<%= content.public_path %>">
-                    <h1><%= content.original_object.short_headline %></h1>
+                    <h1><%= content.short_title %></h1>
                   </a>
                   <div class="precis">
                     <p><a href="<%= content.public_path %>"><%= content.teaser.html_safe %></a></p>

--- a/app/views/programs/kpcc/episode.html.erb
+++ b/app/views/programs/kpcc/episode.html.erb
@@ -63,7 +63,7 @@
                       </li>
                     </aside>
                   </div>
-                  <%= timestamp_if_segment_is_legacy content.original_object.published_at, @episode.air_date %>
+                  <%= timestamp_if_segment_is_legacy content.public_datetime, @episode.air_date %>
                 </div><!--/ .exposition -->
               </article>
 

--- a/db/migrate/20160218003730_make_show_rundowns_polymorphic.rb
+++ b/db/migrate/20160218003730_make_show_rundowns_polymorphic.rb
@@ -1,0 +1,12 @@
+class MakeShowRundownsPolymorphic < ActiveRecord::Migration
+  def up
+    add_column :shows_rundown, :content_type, :string
+    rename_column :shows_rundown, :segment_id, :content_id
+    ShowRundown.update_all(content_type: "ShowSegment")
+  end
+  def down
+    ShowRundown.where.not(content_type: "ShowSegment").destroy_all
+    remove_column :shows_rundown, :content_type
+    rename_column :shows_rundown, :content_id, :segment_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160216223149) do
+ActiveRecord::Schema.define(version: 20160218003730) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -469,10 +469,6 @@ ActiveRecord::Schema.define(version: 20160216223149) do
     t.boolean  "mobile_notification_sent",                    default: false, null: false
     t.integer  "status",                   limit: 4
     t.datetime "published_at"
-    t.datetime "starts_at"
-    t.datetime "ends_at"
-    t.boolean  "should_rewind",                               default: false
-    t.boolean  "bypass_preroll",                              default: false
   end
 
   add_index "layout_breakingnewsalert", ["alert_type"], name: "index_layout_breakingnewsalert_on_alert_type", using: :btree
@@ -501,6 +497,7 @@ ActiveRecord::Schema.define(version: 20160216223149) do
     t.integer "content_id",   limit: 4
     t.integer "position",     limit: 4,   default: 99,       null: false
     t.string  "content_type", limit: 255
+    t.string  "size",         limit: 255, default: "medium"
   end
 
   add_index "layout_homepagecontent", ["content_id", "content_type"], name: "index_layout_homepagecontent_on_content_id_and_content_type", using: :btree
@@ -817,14 +814,15 @@ ActiveRecord::Schema.define(version: 20160216223149) do
   add_index "shows_episode", ["status"], name: "index_shows_episode_on_status", using: :btree
 
   create_table "shows_rundown", force: :cascade do |t|
-    t.integer "episode_id", limit: 4, null: false
-    t.integer "segment_id", limit: 4, null: false
-    t.integer "position",   limit: 4, null: false
+    t.integer "episode_id",   limit: 4,   null: false
+    t.integer "content_id",   limit: 4,   null: false
+    t.integer "position",     limit: 4,   null: false
+    t.string  "content_type", limit: 255
   end
 
+  add_index "shows_rundown", ["content_id"], name: "shows_rundown_segment_id", using: :btree
   add_index "shows_rundown", ["episode_id"], name: "shows_rundown_episode_id", using: :btree
   add_index "shows_rundown", ["position"], name: "index_shows_rundown_on_segment_order", using: :btree
-  add_index "shows_rundown", ["segment_id"], name: "shows_rundown_segment_id", using: :btree
 
   create_table "shows_segment", force: :cascade do |t|
     t.integer  "show_id",          limit: 4,          null: false

--- a/spec/controllers/programs_controller_spec.rb
+++ b/spec/controllers/programs_controller_spec.rb
@@ -271,11 +271,10 @@ describe ProgramsController do
       assigns(:episode).should eq episode
     end
 
-    it "gets the episode's segments" do
-      episode.rundowns.create(segment: segment)
+    it "gets the episode's content" do
+      episode.rundowns.create(content: segment)
       get :episode, params
-
-      assigns(:segments).to_a.should eq [segment]
+      assigns(:content).to_a.should eq [segment.to_article]
     end
   end
 

--- a/spec/models/show_episode_spec.rb
+++ b/spec/models/show_episode_spec.rb
@@ -64,7 +64,7 @@ describe ShowEpisode do
     it "uses simple_json for the join model" do
       episode = create :show_episode
       segment = create :show_segment
-      rundown = episode.rundowns.build(segment: segment, position: 0)
+      rundown = episode.rundowns.build(content: segment, position: 0)
       rundown.save!
 
       episode.rundowns_json.should eq [rundown.simple_json].to_json

--- a/spec/models/show_rundown_spec.rb
+++ b/spec/models/show_rundown_spec.rb
@@ -3,6 +3,6 @@ require "spec_helper"
 describe ShowRundown do
   describe "associations" do
     it { should belong_to(:episode).class_name("ShowEpisode") }
-    it { should belong_to(:segment).class_name("ShowSegment") }
+    it { should belong_to(:content) }
   end
 end


### PR DESCRIPTION
#432 

Episodes can now be related to any Content Base model through rundowns.  So now, instead of simply having segments, an episode can have many segments, stories, shells, blogs, episodes, abstracts, events, pij_queries.  All of the content can be accessed at once using the `#content` method on the episode.