### PR TITLE
Make rundown content touch its parent episodes when it is updated

### DIFF
--- a/app/concerns/concern/associations/episode_rundown_association.rb
+++ b/app/concerns/concern/associations/episode_rundown_association.rb
@@ -1,0 +1,31 @@
+module Concern
+  module Associations
+    module EpisodeRundownAssociation
+      extend ActiveSupport::Concern
+
+      included do
+        has_many :rundowns,
+          :class_name     => "ShowRundown",
+          :foreign_key    => "content_id",
+          :as             => "content",
+          :dependent      => :destroy,
+          :before_add     => :set_rundown_position
+
+        has_many :episodes,
+          -> { order('status desc,air_date desc') },
+          :through    => :rundowns,
+          :source     => :episode,
+          :autosave   => true
+
+        before_save ->{episodes.update_all(updated_at: Time.now) if changed?}
+      end
+
+      def set_rundown_position(rundown)
+        if !rundown.position
+          rundown.position = self.rundowns.length + 1
+        end
+      end
+
+    end
+  end
+end

--- a/app/models/abstract.rb
+++ b/app/models/abstract.rb
@@ -49,6 +49,7 @@ class Abstract < ActiveRecord::Base
   include Concern::Associations::AudioAssociation
   include Concern::Associations::EditionsAssociation
   include Concern::Associations::PmpContentAssociation::StoryProfile
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Callbacks::TouchCallback
   include Concern::Sanitizers::Url
   include Concern::Model::Searchable

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -6,6 +6,7 @@ class Blog < ActiveRecord::Base
   include Concern::Validations::SlugValidation
   include Concern::Associations::RelatedLinksAssociation
   include Concern::Associations::PmpContentAssociation::StoryProfile
+  include Concern::Associations::EpisodeRundownAssociation
 
   include Concern::Model::Searchable
 

--- a/app/models/blog_entry.rb
+++ b/app/models/blog_entry.rb
@@ -23,6 +23,7 @@ class BlogEntry < ActiveRecord::Base
   include Concern::Associations::VerticalArticleAssociation
   include Concern::Associations::ProgramArticleAssociation
   include Concern::Associations::PmpContentAssociation::StoryProfile
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Validations::ContentValidation
   include Concern::Callbacks::SetPublishedAtCallback
   include Concern::Callbacks::GenerateShortHeadlineCallback

--- a/app/models/content_shell.rb
+++ b/app/models/content_shell.rb
@@ -18,6 +18,7 @@ class ContentShell < ActiveRecord::Base
   include Concern::Associations::MissedItContentAssociation
   include Concern::Associations::EditionsAssociation
   include Concern::Associations::VerticalArticleAssociation
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Validations::PublishedAtValidation
   include Concern::Associations::PmpContentAssociation::StoryProfile
   #include Concern::Callbacks::CacheExpirationCallback

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,7 @@ class Event < ActiveRecord::Base
   include Concern::Associations::MissedItContentAssociation
   include Concern::Associations::VerticalArticleAssociation
   include Concern::Associations::ProgramArticleAssociation
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Associations::PmpContentAssociation::StoryProfile
   include Concern::Callbacks::GenerateSlugCallback
   include Concern::Callbacks::GenerateTeaserCallback

--- a/app/models/news_story.rb
+++ b/app/models/news_story.rb
@@ -22,6 +22,7 @@ class NewsStory < ActiveRecord::Base
   include Concern::Associations::EditionsAssociation
   include Concern::Associations::VerticalArticleAssociation
   include Concern::Associations::ProgramArticleAssociation
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Validations::ContentValidation
   include Concern::Callbacks::SetPublishedAtCallback
   include Concern::Callbacks::GenerateShortHeadlineCallback

--- a/app/models/pij_query.rb
+++ b/app/models/pij_query.rb
@@ -15,6 +15,7 @@ class PijQuery < ActiveRecord::Base
   include Concern::Associations::MissedItContentAssociation
   include Concern::Associations::VerticalArticleAssociation
   include Concern::Associations::ProgramArticleAssociation
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Validations::SlugValidation
   include Concern::Callbacks::GenerateSlugCallback
   include Concern::Model::Searchable

--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -14,6 +14,7 @@ class ShowEpisode < ActiveRecord::Base
   include Concern::Associations::BylinesAssociation
   include Concern::Associations::EditionsAssociation
   include Concern::Associations::PmpContentAssociation::StoryProfile
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Callbacks::SetPublishedAtCallback
   #include Concern::Callbacks::CacheExpirationCallback
   include Concern::Callbacks::PublishNotificationCallback
@@ -187,12 +188,6 @@ class ShowEpisode < ActiveRecord::Base
 
   def generate_body
     self.body = self.teaser
-  end
-
-  def set_rundown_position(rundown)
-    if !rundown.position
-      rundown.position = self.rundowns.length + 1
-    end
   end
 
   def build_rundown_association(rundown_hash, segment)

--- a/app/models/show_segment.rb
+++ b/app/models/show_segment.rb
@@ -22,6 +22,8 @@ class ShowSegment < ActiveRecord::Base
   include Concern::Associations::EditionsAssociation
   include Concern::Associations::VerticalArticleAssociation
   include Concern::Associations::ProgramArticleAssociation
+  include Concern::Associations::PmpContentAssociation::StoryProfile
+  include Concern::Associations::EpisodeRundownAssociation
   include Concern::Validations::ContentValidation
   include Concern::Callbacks::SetPublishedAtCallback
   include Concern::Callbacks::GenerateSlugCallback
@@ -37,7 +39,6 @@ class ShowSegment < ActiveRecord::Base
   include Concern::Methods::CommentMethods
   include Concern::Methods::AssetDisplayMethods
   include Concern::Sanitizers::Content
-  include Concern::Associations::PmpContentAssociation::StoryProfile
 
   self.disqus_identifier_base = "shows/segment"
   self.public_route_key = "segment"
@@ -46,18 +47,6 @@ class ShowSegment < ActiveRecord::Base
   belongs_to :show,
     :class_name   => "KpccProgram",
     :touch        => true
-
-  has_many :rundowns,
-    :class_name     => "ShowRundown",
-    :foreign_key    => "content_id",
-    :as             => "content",
-    :dependent      => :destroy
-
-  has_many :episodes,
-    -> { order('status desc,air_date desc') },
-    :through    => :rundowns,
-    :source     => :episode,
-    :autosave   => true
 
   alias_attribute :url, :public_url
 

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -46,12 +46,13 @@
 
                   <!-- Content -->
                   <ul class="cbase">
-
-                  <% episode.published_content.map(&:to_article).each_with_index do |content, i| %>
-                    <li>
-                      <h5 class="headline"><%= link_to content.short_title, content.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => "#{i==0 ? 'Lead' : 'Offlead'} Content"} %></h5>
-                      <%= comment_count_for content.original_object %>
-                    </li>
+                  <%= cache ["homepage", "content", episode] do %>
+                    <% episode.published_content.map(&:to_article).each_with_index do |content, i| %>
+                      <li>
+                        <h5 class="headline"><%= link_to content.short_title, content.public_path, :class => 'track-event', :data => {'ga-category' => 'Broadcast Bar', 'ga-action' => 'Episode Guide', 'ga-label' => "#{i==0 ? 'Lead' : 'Offlead'} Content"} %></h5>
+                        <%= comment_count_for content.original_object %>
+                      </li>
+                    <% end %>
                   <% end %>
 
                     <li class="more"><a href="<%= p.program.public_path %>">More <%= p.program.title %></a></li>

--- a/app/views/programs/kpcc/_segment.html.erb
+++ b/app/views/programs/kpcc/_segment.html.erb
@@ -51,10 +51,12 @@
                 <h1><%= link_to article.published_episode.headline, article.published_episode.public_path %></h1>
                 <nav>
                   <ul>
-                    <% article.episode.published_content.map(&:to_article).each do |content| %>
-                      <li class="<%= ("selected" if article.id == content.id) %>">
-                        <%= link_to content.short_title, content.public_path %>
-                      </li>
+                    <%= cache ["segment", "content", article.episode] do %>
+                      <% article.episode.published_content.map(&:to_article).each do |content| %>
+                        <li class="<%= ("selected" if article.id == content.id) %>">
+                          <%= link_to content.short_title, content.public_path %>
+                        </li>
+                      <% end %>
                     <% end %>
                   </ul>
                 </nav>

--- a/spec/concerns/concern/associations/episode_rundown_association_spec.rb
+++ b/spec/concerns/concern/associations/episode_rundown_association_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Concern::Associations::EpisodeRundownAssociation do
+  it 'updates the episode when the object has changed' do
+
+    episode = nil
+    segment = nil
+    first_timestamp = nil
+
+    Timecop.freeze(Date.parse('2015-08-13')) do
+        episode       = create :show_episode
+        segment       = create :show_segment
+        segment.episodes << episode
+        episode.reload
+        first_timestamp = episode.updated_at
+    end
+
+    Timecop.freeze(Date.parse('2015-08-14')) do
+        segment.update body: "updated body"
+    end
+
+    expect(episode.reload.updated_at).to be > first_timestamp
+  end
+end


### PR DESCRIPTION
What I've done here is extracted the episode rundown relation code into a concern and included a before_save callback that will touch the parent episodes if the content has changed.  Theoretically, this should make it so that lists of episode rundown content in views can be fragment cached based on the episode object so that we do not always have to retrieve the individual pieces of content(which can come from multiple tables).