### PR TITLE
Rescue error from pmp and log it to NewRelic.

### DIFF
--- a/app/models/pmp/pmp_content.rb
+++ b/app/models/pmp/pmp_content.rb
@@ -29,6 +29,8 @@ class PmpContent < ActiveRecord::Base
         self.update guid: nil
       end
     end
+  rescue RuntimeError => err
+    NewRelic.log_error(err)
   end
 
   def retrieve action="read"


### PR DESCRIPTION
Here's the scoop on why I'm choosing to do this.

Stories and related assets publish to the PMP just fine.  What happens is, if a story is updated or changed, say a piece of audio is switched, there's an ActiveRecord callback specified to destroy the old content from the PMP before publishing the new stuff.  The problem is occurring when, on delete, we need to grab the existing document from the PMP and then call #delete on it, which is a method provided by the PMP gem.  Somehow the document that we are getting back from the PMP isn't the expected one and it raises an error because it's trying to perform a delete API request for something without a GUID.  i.e., we are getting back the wrong thing from the API.

However, it's yet another problem that seems to not occur when I do it myself from the command line.  Since I know that the error 500 page, as unhelpful as it may be, is coming from the one call to the gem's #delete method, I decided to add a rescue to the method that calls it and log it to NewRelic; this might be the only way to get a stack trace in a timely manner.

The expected result of merging this is to allow news stories to save edits despite this problem, continue to allow stories to publish to the PMP, and get a log of the error that is more helpful.  Some things may not delete from the PMP when triggered to, but that's of course the next piece to focus on when there's more information.