### PR TITLE
Only render a photo for the PMP lead asset

### DIFF
--- a/app/views/pmp/story.html.erb
+++ b/app/views/pmp/story.html.erb
@@ -1,11 +1,11 @@
 <% article = content.to_article %>
 
-<%= render_asset article.original_object, context:"news", fallback:true, kpcc_only: true %>
+<%= render_asset article.original_object, context:"news", display: "photo", fallback:true, kpcc_only: true %>
 
 <article>
     <div>
         <% if should_inline_top_asset_for(article.original_object) %>
-          <%= render_asset article, context:"news", display:"inline", kpcc_only: true %>
+          <% render_asset article, context:"news", display:"inline", kpcc_only: true %>
         <% end %>
 
         <%= render_with_inline_assets article, kpcc_only: true %>

--- a/db/migrate/20160302011026_force_republish_of_pmp_content.rb
+++ b/db/migrate/20160302011026_force_republish_of_pmp_content.rb
@@ -1,0 +1,8 @@
+class ForceRepublishOfPmpContent < ActiveRecord::Migration
+  def up
+    PmpStory.where.not(guid: nil).map(&:content).each(&:publish_pmp_content)
+  end
+  def down
+    # sorry, amigo
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229171922) do
+ActiveRecord::Schema.define(version: 20160302011026) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255


### PR DESCRIPTION
Because we were using the render_asset method as normal, stories set to display a slideshow also include the slideshow and script tags in the rendered body.  This is a case where there should just be a photo.