### PR TITLE
Pmp import ca counts

### DIFF
--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -22,15 +22,19 @@ module PmpArticleImporter
       ## concatenated to the stories array.
       stories.concat download_stories("Marketplace", tag: "marketplace")
       stories.concat download_stories("American Homefront Project", collection: "4c6e24e5-484f-49e8-be8d-452cfddd6252")
-
+      stories.concat download_stories("California Counts", tag: "CACounts", creator: "!aa9342f6-6e25-4ea2-93e3-31d89a010668") # stories that are not our own
       stories
+    end
+
+    def query query={}
+      pmp.root.query['urn:collectiondoc:query:docs']
+        .where({profile: PROFILE, limit: LIMIT}.merge(query))
+        .retrieve.items
     end
 
     def download_stories news_agency_name, query={}
       added = []
-      stories = pmp.root.query['urn:collectiondoc:query:docs']
-        .where({profile: PROFILE, limit: LIMIT}.merge(query))
-        .retrieve.items
+      stories = query(query)
       log "#{stories.size} PMP stories from #{news_agency_name} found"
       stories.reject { |s|
         RemoteArticle.exists?(source: SOURCE, article_id: s.guid)

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -28,6 +28,11 @@ describe PmpArticleImporter do
           :content_type => "application/json",
           :body => load_fixture('api/pmp/ahp_stories.json')
         })
+      stub_request(:get, %r|pmp\.io/docs|)
+          .with(query: {"tag" => "CACounts", "limit" => "10", "profile" => "story"}).to_return({
+          :content_type => "application/json",
+          :body => load_fixture('api/pmp/ahp_stories.json')
+        })
     end
 
     it 'builds cached articles from the API response' do


### PR DESCRIPTION
PMP Article Importer now imports CA Counts stories from partners.