### PR TITLE
PMP Importer shouldn't fail if no "alternate" array is provided

### DIFF
--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -112,7 +112,7 @@ module PmpArticleImporter
       # Is "alternate" always going to be a usable link?
       # I guess we'll find out eventually.
       # For now it seems that it's used to point to the live article.
-      link = pmp_story.alternate.first
+      link = (pmp_story.alternate || []).first
       if link && link.href
         related_link = RelatedLink.new(
           :link_type    => "website",


### PR DESCRIPTION
Some CA Counts stories may not have any alternate links included with their PMP document.  The importer shouldn't fail when this happens since not all stories we will be receiving will have been published yet.