### PR TITLE
Add migration to clear existing external episode duplicates.

### DIFF
--- a/db/migrate/20160322172046_clear_duplicate_external_episodes.rb
+++ b/db/migrate/20160322172046_clear_duplicate_external_episodes.rb
@@ -1,0 +1,7 @@
+class ClearDuplicateExternalEpisodes < ActiveRecord::Migration
+  def up
+    ExternalEpisode.where.not(id: ExternalEpisode.select("MAX(id) as id").group([:title, :external_program_id]).pluck(:id)).destroy_all
+  end
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160302193341) do
+ActiveRecord::Schema.define(version: 20160322172046) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255


### PR DESCRIPTION
This migration cleans out any external episodes that are duplicates based on title and program id.  
In reference to #468.