### PR TITLE
Check if episode exists based on title and program id.

### DIFF
--- a/app/importers/rss_program_importer.rb
+++ b/app/importers/rss_program_importer.rb
@@ -84,7 +84,7 @@ class RssProgramImporter
   def episode_exists?(item)
     ExternalEpisode.exists?(
       :external_program_id    => @external_program.id,
-      :external_id            => item.guid.content
+      :title                  => item.title
     )
   end
 


### PR DESCRIPTION
#468

This should prevent the duplication we've been seeing, since it appears that episodes are occasionally modified and the GUIDs for what is conceptually the same episode are different between duplicates, as well as summary content.  The only consistent key seems to be the title of the episode so, instead of looking at the GUID(which is oddly unreliable), this checks if an episode exists for a program using the title.