### PR TITLE
Have changes to publish_to_pmp boolean reflect in versions

### DIFF
--- a/spec/concerns/concern/associations/pmp_content_association_spec.rb
+++ b/spec/concerns/concern/associations/pmp_content_association_spec.rb
@@ -32,6 +32,38 @@ describe Concern::Associations::PmpContentAssociation do
       end
     end
 
+    describe 'versions' do
+      context 'published_to_pmp? changes' do
+        context 'from false to true' do
+          it 'is included in a version' do
+            content = create :news_story
+            content.update publish_to_pmp: true
+            expect(content.versions.last.object_changes['publish_to_pmp']).to eq ['false', 'true']
+          end
+        end
+        context 'from true to false' do
+          it 'is included in a version' do
+            content = create :news_story, publish_to_pmp: true
+            content.update publish_to_pmp: false
+            expect(content.versions.last.object_changes['publish_to_pmp']).to eq ['true', 'false']
+          end
+        end
+        it 'is included with other changes in version' do
+          content = create :news_story
+          content.update publish_to_pmp: true, headline: "a new headline"
+          expect(content.versions.last.object_changes['publish_to_pmp']).to be
+          expect(content.versions.last.object_changes['headline']).to include('a new headline')
+        end
+      end
+      context 'published_to_pmp? does not change' do
+        it 'is not included in a version' do
+          content = create :news_story, publish_to_pmp: true
+          content.update headline: "Title changed"
+          expect(content.versions.last.object_changes['publish_to_pmp']).to eq nil
+        end
+      end
+    end
+
     describe '#pmp_permission_groups' do
       context 'content has california-counts tag' do
         it 'returns a link' do


### PR DESCRIPTION
#450 

When someone checks the 'publish to pmp' checkbox in Outpost, that change is not reflected in a Secretary::Version.  This is because it isn't a real ActiveRecord attribute but set as an instance variable and is reflected from the existence of a related pmp_content record.  The problem is we can't `tracks_association` on the pmp_content because it's being created/destroyed with a callback and not a setter method.

I decided to make this change here because, while it would be nice to make Secretary support arbitrary methods(i.e. virtual attributes), it currently relies a lot on the way that ActiveRecord handles showing changes and I don't think it's a good idea to meddle with what ActiveRecord is doing.  At least this minor change is kept where all the PMP association behavior is contained and, in the future, it can be referred to if we feel like this behavior needs to be generalized and live in Secretary.