### PR TITLE
Make video lead assets work in segment preview

### DIFF
--- a/app/views/programs/kpcc/_segment_preview.html.erb
+++ b/app/views/programs/kpcc/_segment_preview.html.erb
@@ -12,7 +12,7 @@
 
         <article class="prose">
 
-            <%= render_asset article.to_article, context:"segments" %>
+            <%= render_asset article, context:"segments" %>
 
             <%= content_widget "new/primary_audio", article, context: article.show.slug %>
 


### PR DESCRIPTION
Videos weren't displaying in the segment preview in outpost.  The video does display on the live site, however.  It's because the preview template passes an article to #render_asset rather than a ShowSegment like on the live site.  Not sure why this makes a difference, but just passing the ShowSegment solves this.  It should be possible to pass articles to #render_asset and have them always work the same when the contentbase changes are merged in, but for now this will make the preview work properly.