### PR TITLE
Update NPR gem version to 3.0.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'parse-ruby-client', github: "sheerun/parse-ruby-client", ref: "a4eb5618c816
 # gem 'pmp', '0.4.0'
 gem 'pmp', '0.5.6'
 #gem "npr", path:"../npr"
-gem 'npr', '~> 2.0', github:"scpr/npr"
+gem 'npr', '~> 3.0', github:"scpr/npr"
 gem 'asset_host_client', github:"scpr/asset_host_client", tag:"v2.0.0"
 gem 'audio_vision', '~> 1.0'
 gem 'slack-notifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,9 +72,9 @@ GIT
 
 GIT
   remote: git://github.com/scpr/npr.git
-  revision: 8d423d530d287ba4852b705999085dfe7c1e2895
+  revision: 6a6a650e92eb9ed0acb2f51d0958685fcf97d931
   specs:
-    npr (2.0.2)
+    npr (3.0.0)
       faraday (~> 0.8.0)
       faraday_middleware (~> 0.9.0)
 
@@ -493,7 +493,7 @@ DEPENDENCIES
   launchy
   mysql2 (~> 0.3.14)
   newrelic_rpm (~> 3.7)
-  npr (~> 2.0)!
+  npr (~> 3.0)!
   oauth2 (~> 0.8)
   outpost-aggregator!
   outpost-asset_host!


### PR DESCRIPTION
#482 

This updates the gemfile to point to v3 of the NPR gem, which resolves the bug introduced by a change in behavior with the NPR API that prevents importing some shows.