### PR TITLE
Outpost Autosave Release 2

### DIFF
--- a/app/assets/javascripts/outpost/autosave.js.coffee
+++ b/app/assets/javascripts/outpost/autosave.js.coffee
@@ -128,7 +128,7 @@ class outpost.Autosave
     query = []
     query.push("#main #{elName}[id]") for elName in @elementNames
     query = query.join(", ")
-    $(query).not(':button').not('[type=hidden]').not('#autosave-revisions')
+    $(query).not(':button').not(':hidden').not('#autosave-revisions')
 
   # private
 
@@ -290,7 +290,7 @@ class outpost.Autosave
   _writeDialog: (text) ->
     # Writes a snippet of text to the submit-row.
     # Could be useful to display status.
-    $(".submit-row span#dialog").text text    
+    $(".submit-row span#dialog").text text
 
   DefaultSerializers: 
     ## Serializers are used to convert a field element

--- a/app/assets/javascripts/outpost/autosave.js.coffee
+++ b/app/assets/javascripts/outpost/autosave.js.coffee
@@ -86,6 +86,7 @@ class outpost.Autosave
     options.revs     ||= true
     @db.remove @doc, options, (error, doc) =>
       unless error
+        @doc = undefined
         console.log 'doc removed'
         callback(error, doc) if callback
       else

--- a/app/assets/javascripts/outpost/autosave.js.coffee
+++ b/app/assets/javascripts/outpost/autosave.js.coffee
@@ -206,6 +206,7 @@ class outpost.Autosave
       if e.target.id is 'yes'
         @_reflect()
       else if e.target.id is 'no'
+        @shouldWarn = false
         @removeDoc()
       modal.remove()
     modal.modal({show: true, background: true})

--- a/app/assets/javascripts/outpost/autosave.js.coffee
+++ b/app/assets/javascripts/outpost/autosave.js.coffee
@@ -195,7 +195,7 @@ class outpost.Autosave
     $("form.simple_form").on 'submit', =>
       @shouldWarn = false
       true
-    $(window).on 'beforeunload', =>
+    $(window).one 'beforeunload', =>
       if @shouldWarn
         return 'This content has unsaved changes.  If you want to keep these changes, you can stay on the page and click \'Save\'.'
 

--- a/app/views/outpost/resource/edit.html.erb
+++ b/app/views/outpost/resource/edit.html.erb
@@ -35,5 +35,6 @@
         "el": "#newsroom-edit_user-list" }
     );
   </script>
+  
   <%= render partial: 'outpost/shared/sections/autosave', locals: {id: @record.id, obj_key: @record.obj_key, type: @record.class.to_s.underscore} %>
 <% end %>

--- a/app/views/outpost/shared/sections/_autosave.html.erb
+++ b/app/views/outpost/shared/sections/_autosave.html.erb
@@ -40,7 +40,4 @@
     collections: ['aggregator.baseView', 'assetManager.assetsView'],
     elements: ['tbody#bylines-fields', 'fieldset#form-block-related-links tbody'] //removed 'fieldset#form-block-audio' until we can figure out how to deal with it.
   });
-
-  autosaver.checkForChanges();
-  autosaver.listen();
 </script>


### PR DESCRIPTION
We had to roll back the last release because the keyup/down events we were tracking were conflicting with key combos.  Instead, we're now shimming DOM objects so that we can directly track changes on all of them, including things like the textareas that are being dynamically modified so their change/input events aren't triggered.