### PR TITLE
Change moment-strftime and moment-twitter to use Sprockets directive.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,5 +47,5 @@
 //= require short-list-modules.js
 //= require jquery.scrolldepth
 
-moment = require('moment-strftime');
-moment = require('moment-twitter');
+//= require moment-strftime/lib/moment-strftime.js
+//= require moment-twitter/moment-twitter.js


### PR DESCRIPTION
Use of moment functions were failing in production because, for some reason, Browserify require functions are not working properly after minification(works just fine in development).  The fix was to change it to use Sprockets require directives, and I'm not sure why I couldn't do it this way previously.