### PR TITLE
Remove autosaved doc on form submit because we are still somehow getting modals triggered after save.

### DIFF
--- a/app/assets/javascripts/outpost/autosave.js.coffee
+++ b/app/assets/javascripts/outpost/autosave.js.coffee
@@ -193,12 +193,12 @@ class outpost.Autosave
     # no changes have occurred.
     @shouldWarn  = false
     $("form.simple_form").on 'submit', =>
-      if @options._id.match('-new') or @options._id is 'new'
-        @removeDoc() # this is the only way that I can think of
-        # preventig the modal from coming up after a new document
-        # has been saved, since we don't want old data to show up
-        # when we are creating a new content.  can you think of a
-        # better way to achieve this?
+      # if @options._id.match('-new') or @options._id is 'new'
+      @removeDoc() # this is the only way that I can think of
+      # preventig the modal from coming up after a new document
+      # has been saved, since we don't want old data to show up
+      # when we are creating a new content.  can you think of a
+      # better way to achieve this?
       @shouldWarn = false
       true
     $(window).one 'beforeunload', =>


### PR DESCRIPTION
This turns off the modal after form submit no matter what, which is a temporary workaround for a few issues causing the modal to bug people even after they have saved.