### PR TITLE
Revert to CKDEDITOR autosave plugin.

### DIFF
--- a/app/assets/javascripts/outpost/application.js
+++ b/app/assets/javascripts/outpost/application.js
@@ -36,4 +36,4 @@
 //= require outpost/aggregator
 //= require outpost/ckeditor/inline_assets
 //= require outpost/dockable
-//= require outpost/autosave
+// require outpost/autosave

--- a/app/views/outpost/shared/sections/_autosave.html.erb
+++ b/app/views/outpost/shared/sections/_autosave.html.erb
@@ -33,12 +33,12 @@
 </script>
 
 <script>
-  autosaver = new outpost.Autosave({
-    _id:  '<%= obj_key %>',
-    id:   '<%= id %>',
-    type: '<%= type %>',
-    collections: ['aggregator.baseView', 'assetManager.assetsView'],
-    elements: ['tbody#bylines-fields', 'fieldset#form-block-related-links tbody'], //removed 'fieldset#form-block-audio' until we can figure out how to deal with it.
-    exclude: ['[id*=published_at_date]', '[id*=published_at]'] // published_at inputs show up after save/publish, which creates a false positive change.
-  });
+  // autosaver = new outpost.Autosave({
+  //   _id:  '<%= obj_key %>',
+  //   id:   '<%= id %>',
+  //   type: '<%= type %>',
+  //   collections: ['aggregator.baseView', 'assetManager.assetsView'],
+  //   elements: ['tbody#bylines-fields', 'fieldset#form-block-related-links tbody'], //removed 'fieldset#form-block-audio' until we can figure out how to deal with it.
+  //   exclude: ['[id*=published_at_date]', '[id*=published_at]'] // published_at inputs show up after save/publish, which creates a false positive change.
+  // });
 </script>

--- a/public/static/ckeditor/config.js
+++ b/public/static/ckeditor/config.js
@@ -13,6 +13,7 @@ CKEDITOR.editorConfig = function(config) {
   config.format_tags = 'p;h2;h3';
 
   config.extraPlugins = [
+    'autosave',
     'image', // This plugin has custom changes so we didn't include it in the build
     'embed-placeholder',
     'webkit-span-fix',


### PR DESCRIPTION
This reverts the autosave feature in Outpost to the old CKEDITOR autosave plugin, as there have been continuing issues with the new version.