### PR TITLE
Display election results on Homepage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,3 +46,4 @@
 
 //= require short-list-modules.js
 //= require jquery.scrolldepth
+//= require election-results

--- a/app/assets/javascripts/election-results.coffee
+++ b/app/assets/javascripts/election-results.coffee
@@ -1,0 +1,6 @@
+$(document).ready ->
+  currentDate = Date.now()
+  startDate   = Date.parse('2016-06-07T01:00:00-07:00')
+  endDate     = Date.parse('2016-06-07T23:59:59-07:00')
+  if (currentDate > startDate) and (currentDate < endDate)
+    $('.hero-election').load 'http://162.243.135.6/static/results/featured.html'

--- a/app/assets/javascripts/election-results.coffee
+++ b/app/assets/javascripts/election-results.coffee
@@ -1,6 +1,6 @@
 $(document).ready ->
   currentDate = Date.now()
-  startDate   = Date.parse('2016-05-07T01:00:00-07:00')
+  startDate   = Date.parse('2016-06-07T01:00:00-07:00')
   endDate     = Date.parse('2016-06-07T23:59:59-07:00')
   if (currentDate > startDate) and (currentDate < endDate)
     $('.hero-election').load 'http://162.243.135.6/static/results/featured.html'

--- a/app/assets/javascripts/election-results.coffee
+++ b/app/assets/javascripts/election-results.coffee
@@ -1,6 +1,6 @@
 $(document).ready ->
   currentDate = Date.now()
-  startDate   = Date.parse('2016-06-07T01:00:00-07:00')
+  startDate   = Date.parse('2016-05-07T01:00:00-07:00')
   endDate     = Date.parse('2016-06-07T23:59:59-07:00')
   if (currentDate > startDate) and (currentDate < endDate)
     $('.hero-election').load 'http://162.243.135.6/static/results/featured.html'

--- a/app/assets/javascripts/election-results.coffee
+++ b/app/assets/javascripts/election-results.coffee
@@ -1,6 +1,0 @@
-$(document).ready ->
-  currentDate = Date.now()
-  startDate   = Date.parse('2016-06-07T01:00:00-07:00')
-  endDate     = Date.parse('2016-06-07T23:59:59-07:00')
-  if (currentDate > startDate) and (currentDate < endDate)
-    $('.hero-election').load 'http://162.243.135.6/static/results/featured.html'

--- a/app/assets/javascripts/election-results.js
+++ b/app/assets/javascripts/election-results.js
@@ -1,0 +1,9 @@
+$(document).ready(function(){
+  var currentDate = Date.now();
+  var startDate   = Date.parse('2016-06-07T01:00:00-07:00');
+  var endDate     = Date.parse('2016-06-07T23:59:59-07:00');
+  if ((currentDate > startDate) && (currentDate < endDate)){
+    $('.hero-election').load('http://162.243.135.6/static/results/featured.html');
+  }
+  return
+});

--- a/app/assets/javascripts/election-results.js
+++ b/app/assets/javascripts/election-results.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
   var currentDate = Date.now();
-  var startDate   = Date.parse('2016-06-07T01:00:00-07:00');
+  var startDate   = Date.parse('2016-06-07T08:00:00-07:00');
   var endDate     = Date.parse('2016-06-07T23:59:59-07:00');
   if ((currentDate > startDate) && (currentDate < endDate)){
     $('.hero-election').load('http://162.243.135.6/static/results/featured.html');

--- a/app/assets/javascripts/election-results.js
+++ b/app/assets/javascripts/election-results.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
   var currentDate = Date.now();
   var startDate   = Date.parse('2016-06-07T08:00:00-07:00');
-  var endDate     = Date.parse('2016-06-07T23:59:59-07:00');
+  var endDate     = Date.parse('2016-06-08T23:59:59-07:00');
   if ((currentDate > startDate) && (currentDate < endDate)){
     $('.hero-election').load('http://162.243.135.6/static/results/featured.html');
   }

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -94,7 +94,7 @@
 
 
   <%= yield :hero_roadblock %>
-
+  <div class="hero-election container-fluid"></div>
 
   <div id="main" class="container-fluid main-content">
     <section class="homepage-top">


### PR DESCRIPTION
#531

Grabs markup from one of our servers that returns election results for the upcoming primary, and displays it in the hero position on our homepage.  Starts displaying on June 7 at 8am and stops displaying June 8 at 11:59pm.