### PR TITLE
Don't reset article statuses to 'new' on load

### DIFF
--- a/app/assets/javascripts/better_homepage/better_homepage.js.coffee
+++ b/app/assets/javascripts/better_homepage/better_homepage.js.coffee
@@ -20,9 +20,14 @@ class scpr.BetterHomepage extends scpr.Framework
     @collection = new ArticleCollection()
     articleEls = @$el.find('[data-obj-key]')
     @collection.reset ({'id': $(el).attr('data-obj-key'), title: $(el).find('a.headline__link').text()} for el in articleEls)
-    @collection.toArray().forEach (m) => 
-      m.set 'state', 'new'
-      m.save()
+
+    # reset stories to 'new' if development is set to true.
+    # I'm sure there's a better way to apply properties
+    # to all models in a collection.
+    if options.development
+      @collection.toArray().forEach (m) => 
+        m.set 'state', 'new'
+        m.save()
 
     # make our article components
     @articlesComponent = new ArticlesComponent
@@ -94,8 +99,7 @@ class scpr.BetterHomepage extends scpr.Framework
       @render()
     render: ->
       unless @hasNone()
-        # @hideIfBlocked()
-        super() #unless @isVisible()
+        super()
       else
         @$el.addClass 'hidden'
     hasNone: ->
@@ -143,7 +147,7 @@ class scpr.BetterHomepage extends scpr.Framework
       firstIndex  = Math.round(fc.length * 0.5) - 1
       secondIndex = Math.round(fc.length * 0.75) - 1
       thirdIndex  = fc.length - 1
-      [fc[firstIndex], fc[secondIndex], fc[thirdIndex]]
+      _.reject [fc[firstIndex], fc[secondIndex], fc[thirdIndex]], (m) => m is undefined 
 
   class ArticleComponent extends @Component
     name: 'article-component'

--- a/app/assets/javascripts/framework.js.coffee
+++ b/app/assets/javascripts/framework.js.coffee
@@ -22,6 +22,7 @@ class Framework
   Handlebars            = require 'handlebars/dist/handlebars'
 
   constructor: (options={}) ->
+    @beforeInit?()
     # As a convention, `options.debug` is intended
     # to enable console logging in areas where it 
     # is useful.  `options.development` is meant
@@ -29,7 +30,12 @@ class Framework
     # like resetting localStorage values(as an
     # example.)  This convention should be reflected
     # in all framework classes.
-    @beforeInit?()
+    #
+    # For further convenience, options for development
+    # purposes can be saved to localStorage and loaded
+    # automatically.
+    for option, value of JSON.parse(window.localStorage.getItem('framework-options') or "{}")
+      options[option] = value
     # The framework app can accept an element.
     if options.el
       @el  = options.el

--- a/app/assets/javascripts/framework.js.coffee
+++ b/app/assets/javascripts/framework.js.coffee
@@ -22,13 +22,20 @@ class Framework
   Handlebars            = require 'handlebars/dist/handlebars'
 
   constructor: (options={}) ->
-    # Call init function, to stay uniform with
-    # the rest of the framework.
+    # As a convention, `options.debug` is intended
+    # to enable console logging in areas where it 
+    # is useful.  `options.development` is meant
+    # to enable code for development convenience,
+    # like resetting localStorage values(as an
+    # example.)  This convention should be reflected
+    # in all framework classes.
     @beforeInit?()
     # The framework app can accept an element.
     if options.el
       @el  = options.el
       @$el = $(@el) 
+    # Call init function, to stay uniform with
+    # the rest of the framework.
     @init?(options)
     @afterInit?()
 
@@ -433,9 +440,10 @@ class Framework
       load: ->
         # Uses the current object and retrieves any
         # data that is in localStorage
-        if json = @storage?.getItem(@itemKey()) 
+        if json = @storage?.getItem(@itemKey())
           if props = JSON.parse(json)
             @set(props) # tries for a collection and then a model
+            props
       itemKey: ->
         "#{@name}-#{@id}"
     _class:


### PR DESCRIPTION
#551 

This behavior can still be enforced optionally because now options for the frontend app can be side-loaded from localStorage like so:

`window.localStorage.setItem('framework-options', JSON.stringify({development: true}))`

☝️ That ugly snippet will enable the app to reset the statuses of the homepage stories for development purposes.

👇 And this one will clear side-loaded options.

`window.localStorage.removeItem('framework-options')`