### PR TITLE
Allow persistent models in framework to only load specific attributes

### DIFF
--- a/app/assets/javascripts/better_homepage/better_homepage.js.coffee
+++ b/app/assets/javascripts/better_homepage/better_homepage.js.coffee
@@ -139,7 +139,7 @@ class scpr.BetterHomepage extends scpr.Framework
     defaults:
       state: 'new'
     init: ->
-      @load() # get saved attributes from localstorage, if any
+      @load(['state']) # get saved attributes from localstorage, if any
       @listenTo @, 'change', => @save()
     whatsNext: ->
       (@collection or new ArticleCollection).whatsNext()

--- a/app/assets/javascripts/framework.js.coffee
+++ b/app/assets/javascripts/framework.js.coffee
@@ -445,12 +445,20 @@ class Framework
         @storage?.removeItem @itemKey()
       stringify: ->
         JSON.stringify @toJSON()
-      load: ->
+      load: (attributes) ->
         # Uses the current object and retrieves any
         # data that is in localStorage
+        #
+        # If an array of attributes is provided, 
+        # then only those attributes get loaded.
         if json = @storage?.getItem(@itemKey())
           if props = JSON.parse(json)
-            @set(props) # tries for a collection and then a model
+            if attributes
+              for key, value of props
+                if _.contains attributes, key
+                  @set key, value
+            else
+              @set(props) # tries for a collection and then a model
             props
       itemKey: ->
         "#{@name}-#{@id}"


### PR DESCRIPTION
This just adds an option to persistent model behavior that specifies only what attributes we want to load from local storage.