### PR TITLE
Caching and a UI fix

### DIFF
--- a/app/assets/stylesheets/better_homepage/application.css.sass
+++ b/app/assets/stylesheets/better_homepage/application.css.sass
@@ -10,19 +10,19 @@ section#content
   .media.story
     .media__figure--widescreen, .media--hp-large
       z-index: 3
-    .media__headline
+    .media__headline.headline
       position: relative
     &.media--visited-and-read // adds a checkmark for now until this is officialized
-      .media__headline
+      .media__headline.headline
         position: relative
         &::before
           opacity: 1
     // fade animation
     &.media--new-and-unread
-      .media__headline:before
+      .media__headline.headline:before
         transition: all .5s linear
       &.media--seen-and-unread // also unofficial
-        .media__headline::before
+        .media__headline.headline::before
           transition: all 0.8s linear
           opacity: 0
 
@@ -34,6 +34,10 @@ section#content
         color: #01AED5
         font-size: 0.9rem
         font-weight: 500
+      .related-content
+        .media__headline::before
+          display: none // this is to override the fact that any media__headlines nested under
+          // media--new-and-unread gets the 'new' status indicator
     .media__headline--top
       color: #017397
     .media__indicator-visited

--- a/app/views/better_homepage/index.html.erb
+++ b/app/views/better_homepage/index.html.erb
@@ -1,12 +1,14 @@
-<%= render partial: 'better_homepage/feedback' %>
-<section id="content" class="container container--med">
-  <aside class="c-ad">
-    <div class="c-ad__container">
-      <%= render "shared/ads/dfp", ad_key: "slot_a" %>
-      <a class="c-ad__attribution" href="http://www.scpr.org/support/underwriting/">Become a KPCC Sponsor</a>
-    </div>
-  </aside>
-  <%= render partial: 'better_homepage/contents', locals: {object: @content} %>
-</section><!-- .welcome -->
-<%= include_handlebars_template 'better_homepage/whats-next-component' %>
-<%= include_handlebars_template 'better_homepage/whats-next-headline-component' %>
+<% cache ['better-homepage', @content], expires_in: 5.minutes do %> 
+  <%= render partial: 'better_homepage/feedback' %>
+  <section id="content" class="container container--med">
+    <aside class="c-ad">
+      <div class="c-ad__container">
+        <%= render "shared/ads/dfp", ad_key: "slot_a" %>
+        <a class="c-ad__attribution" href="http://www.scpr.org/support/underwriting/">Become a KPCC Sponsor</a>
+      </div>
+    </aside>
+    <%= render partial: 'better_homepage/contents', locals: {object: @content} %>
+  </section><!-- .welcome -->
+  <%= include_handlebars_template 'better_homepage/whats-next-component' %>
+  <%= include_handlebars_template 'better_homepage/whats-next-headline-component' %>
+<% end %>

--- a/app/views/layouts/better_homepage/_check_it_out.html.erb
+++ b/app/views/layouts/better_homepage/_check_it_out.html.erb
@@ -1,10 +1,12 @@
-<% if (links || []).any? %>
-  <div id="check-it-out" class="c-well c-well--info">
-    <ul class="c-list c-list--horiz u-text-size--sm">
-      <li><h5 class="heading heading--h5 u-text-color--sec-dk">Check It Out</h5></li>
-      <% links.each do |link| %>
-        <li><%= link_to link.title, link.url %></li>
-      <% end %>
-    </ul>
-  </div>
+<% cache ['better-homepage', links] do %>
+  <% if (links || []).any? %>
+    <div id="check-it-out" class="c-well c-well--info">
+      <ul class="c-list c-list--horiz u-text-size--sm">
+        <li><h5 class="heading heading--h5 u-text-color--sec-dk">Check It Out</h5></li>
+        <% links.each do |link| %>
+          <li><%= link_to link.title, link.url %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This implements some basic fragment caching on the new homepage, and fixes a problem where the 'new' status pips were displaying on the headlines in the related content.