### PR TITLE
Remove some of the crust from the caching.

### DIFF
--- a/app/views/better_homepage/index.html.erb
+++ b/app/views/better_homepage/index.html.erb
@@ -1,4 +1,4 @@
-<%= cache ['better-homepage', 'content', @content], expires_in: 5.minutes do %>
+<%= cache ['better-homepage', 'content', @content] do %>
   <%= render partial: 'better_homepage/feedback' %>
   <section id="content" class="container container--med">
     <aside class="c-ad">

--- a/app/views/layouts/better_homepage/_header.html.erb
+++ b/app/views/layouts/better_homepage/_header.html.erb
@@ -18,7 +18,7 @@
       </svg>
     </a>
     <span class="mast__divider"></span>
-    <% cache ['better-homepage', 'broadcast-bar', @current_program], expires_in: 5.minutes do%>
+    <% cache ['better-homepage', 'broadcast-bar', @current_program] do%>
       <%= render partial: "layouts/better_homepage/broadcast_bar" , locals: {program: @current_program}%>
     <% end %>
   </div>


### PR DESCRIPTION
I removed a few things, one of which was gaining us a trivial performance boost but was probably preventing the homepage cache from expiring when content changes.  The other part I removed was the periodic cache expiry; now it's supposed to only expire if content changes.