### PR TITLE
Make story timestamp snappier.

### DIFF
--- a/app/assets/javascripts/better_homepage/application.js
+++ b/app/assets/javascripts/better_homepage/application.js
@@ -3,9 +3,7 @@
 // require slideshow/new_slideshow
 //= require jquery.scrolldepth
 // require page_mapping
-//= require timeago
 //= require shared
-//= require smart_time
 //= require better_homepage/better_homepage
 
 jQuery(document).ready(function() {

--- a/app/assets/javascripts/better_homepage/better_homepage.js.coffee
+++ b/app/assets/javascripts/better_homepage/better_homepage.js.coffee
@@ -1,6 +1,7 @@
 scpr.Framework      = require 'framework'
 scpr.EventTracking  = require 'event_tracking'
 Boundary            = require './lib/boundary'
+SmarterTime         = require './smarter-time'
 
 class scpr.BetterHomepage extends scpr.Framework
 
@@ -17,19 +18,7 @@ class scpr.BetterHomepage extends scpr.Framework
       bounds.bottom = bounds.top + @outerHeight()
       !(viewport.right < bounds.left or viewport.left > bounds.right or viewport.bottom < bounds.top or viewport.top > bounds.bottom)
 
-    $.timeago.settings.strings =
-      suffixAgo: ' ago'
-      minute: 'about a minute'
-      minutes: '%dm'
-      hour: 'about 1h'
-      hours: '%dh'
-      day: '1d'
-      days: '%dd'
-      month: '1mo'
-      months: '%dmo'
-
-    @$el.find('#homepage-timestamp time.timeago').timeago()
-    @smartTime = new (scpr.SmartTime)
+    @smarterTime = new SmarterTime
       prefix: "Today's Top Stories <span class='divider'>|</span> Last Updated "
       finder: ['#homepage-timestamp time']
       wrapText: true

--- a/app/assets/javascripts/better_homepage/lib/article-component.js.coffee
+++ b/app/assets/javascripts/better_homepage/lib/article-component.js.coffee
@@ -1,4 +1,6 @@
 Framework = require('framework')
+SmarterTime = require('better_homepage/smarter-time')
+
 module.exports = class ArticleComponent extends Framework.Component
   name: 'article-component'
   events:
@@ -12,19 +14,29 @@ module.exports = class ArticleComponent extends Framework.Component
       if @isScrolledIntoView()
         @markAsSeen()
 
-    @$el.find('time.timeago').timeago()
-    @smartTime = new (scpr.SmartTime)
-      prefix: 'Last Updated '
+    @smarterTime = new SmarterTime
+      prefix: ''
       finder: @$el.find('.media__meta time')
+      relativeTimeStrings:
+        future: 'in %s'
+        past: '%s ago'
+        s: 'seconds'
+        m: '1ms'
+        mm: '%dm'
+        h: '1h'
+        hh: '%dh'
+        d: '1d'
+        dd: '%dd'
+        M: '1m'
+        MM: '%dm'
+        y: '1y'
+        yy: '%dy'
+
     # If no timestamp is present(which can change on conditions),
     # display the feature type.
     if @$el.find('time').text().length
       label = @$el.find(".media__meta .media__label")
       label.addClass 'hidden'
-      # if label.attr('data-media-label')
-      #   label.append label.attr('data-media-label')
-      #   label.find('use').attr('xlink:href', "#icon_line-audio")
-
 
   insertTracking: ->
     # I'd prefer to do this here because it's a pain

--- a/app/assets/javascripts/better_homepage/smarter-time.js.coffee
+++ b/app/assets/javascripts/better_homepage/smarter-time.js.coffee
@@ -1,0 +1,149 @@
+(->
+    class SmarterTime
+
+        moment = class extends require('moment')
+
+        DefaultOptions:
+            finder:             ".smarttime, .smartertime"
+            time_format:        "%I:%M %p"
+            date_format:        "%B %d"
+            prefix:             ""
+            relative:           "8h"
+            timecut:            "36h"
+            window:             null
+            class:              "sttime"
+            wrapText:           false
+
+        constructor: (options) ->
+            @options = _.defaults options||{}, @DefaultOptions
+
+            # build some defaults
+            for opt in ['relative','timecut','window']
+                if @options[opt]
+                    @options[opt] = ( @options[opt].match /(\d+)\s?(\w+)/)?[1..2].reverse()
+                    @options[opt][1] = parseInt(@options[opt][1])
+
+            # now find our elements
+            @elements = _.compact( new SmarterTime.Instance(el,@options) for el in $ @options.finder )
+
+        #----------
+
+        class SmarterTime.Instance
+
+            constructor: (el,options) ->
+                @$el = $(el)
+                @options = options
+
+                @time       = null
+                @window     = @options.window
+                @relative   = @options.relative
+                @timecut    = @options.timecut
+
+                # -- find our time -- #
+
+                if @$el.attr("data-unixtime")
+                    # if there's a data-unixtime attribute, that's our preferred choice
+                    # for grabbing a time
+                    @time = moment Number(@$el.attr("data-unixtime")) * 1000
+
+                else if $(el).attr("datetime")
+                    # a datetime value is our next fallback. for now, we'll just let
+                    # moment try to figure it out
+                    @time = moment @$el.attr("datetime")
+
+
+                # Allows for custom relative time strings.  For example:
+                  # future: 'in %s'
+                  # past: '%s ago'
+                  # s: 'seconds'
+                  # m: 'a minute'
+                  # mm: '%d minutes'
+                  # h: 'an hour'
+                  # hh: '%d hours'
+                  # d: 'a day'
+                  # dd: '%d days'
+                  # M: 'a month'
+                  # MM: '%d months'
+                  # y: 'a year'
+                  # yy: '%d years'
+
+                if @time and @options.relativeTimeStrings
+                    for key, value of @options.relativeTimeStrings
+                        @time._locale._relativeTime[key] = value
+
+                # -- look for display limits -- #
+                for opt in ['relative','timecut','window']
+                    if @$el.attr("data-#{opt}")
+                        @[opt] = (@$el.attr("data-#{opt}").match /(\d+)\s?(\w+)/)?[1..2].reverse()
+                        @[opt][1] = parseInt(@[opt][1])
+                # -- now figure out our display -- #
+
+                @update()
+
+            #----------
+
+            render: (text) ->
+                if (text and text.length)
+                    if @options.wrapText
+                        @$el.html "<span>#{text}</span>"
+                    else
+                        @$el.text text
+                else
+                    @$el.text ""
+
+            #----------
+
+            update: ->
+                now = moment()
+                # Dup the Moment object
+                # All limits are Lower limits
+                # "Outside" = Before
+                # "Inside"  = After
+                windowLimit   = moment(now).subtract(@window...)   if @window
+                relativeLimit = moment(now).subtract(@relative...) if @relative
+                timecutLimit  = moment(now).subtract(@timecut...)  if @timecut
+
+                # if we have a window, are we inside of it?
+                if @time < windowLimit
+                    # @time is outside of the windowLimit
+                    # eg:
+                    #   now     = 8:00pm
+                    #   @time   = 6:00am
+                    #   @window = "10h"
+                    #
+                    #   windowLimit = (now - @window) = 10:00am
+                    #
+                    #   @time is outside (before) the windowLimit, so don't show anything
+                    #
+                    @render ''
+                    @$el.removeClass @options.class if @options.class
+                    return true
+
+                # are we doing relative or absolute timing?
+                if @time > relativeLimit
+                    # @time is inside of the relativeLimit
+                    # Show a relative time
+                    # eg:
+                    #   now       = 1:00pm
+                    #   @time     = 12:00pm
+                    #   @relative = "2h"
+                    #
+                    #   relativeLimit = (now - @relative) = 11:00am
+                    #
+                    #   @time is inside (after) relativeLimit, so show Relative time
+                    #
+                    # If (now - @time) is negative (i.e., @time is AFTER now),
+                    # then display "Just Now". This can happen just because of slight
+                    # discrepancies between server and client times.
+                    if now.diff(@time, "seconds") < 0
+                        @render 'Just Now'
+                    else
+                        # relative formatting
+                        @render "" + @options.prefix + @time.fromNow()
+
+
+                @$el.addClass @options.class if @options.class
+
+    module.exports = SmarterTime
+
+)(module or ({}).__defineSetter__ 'exports', (x)-> window.scpr ?= {}; window.scpr.SmarterTime = x; return x;)


### PR DESCRIPTION
It turned out that moment.js, inside SmartTime, was being interfered with by the plugins it was using.  This was preventing any modification I made to locale strings from having any effect.  I ended up "forking" the SmartTime code and placing it in the BetterHomepage javascripts directory.  The changes were simply to remove those plugins, which we aren't actually using on the new homepage, and include an option to pass in custom locale/strftime strings.

As a result, the timestamps for stories are more "snappy".