### PR TITLE
Don't show events in recent content for the new homepage outpost aggregator.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'dalli'
 gem 'outpost-cms', github: "SCPR/outpost", tag: "v0.2.0"
 gem 'outpost-publishing'
 gem 'outpost-asset_host', github: "SCPR/outpost-asset_host", branch: "inline_assets"
-gem 'outpost-aggregator', github: "SCPR/outpost-aggregator", tag: "v2.0.1"
+gem 'outpost-aggregator', github: "SCPR/outpost-aggregator", tag: "v2.1.0"
 gem 'outpost-secretary', github:"SCPR/outpost-secretary", tag:"v0.1.1"
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: git://github.com/SCPR/outpost-aggregator.git
-  revision: 6db288266918768a13a50d7a417b38e8d52b8c12
-  tag: v2.0.1
+  revision: 0ddb35922584b978eecaed00c0a9a89d895f6912
+  tag: v2.1.0
   specs:
     outpost-aggregator (2.0.0)
 

--- a/app/views/outpost/better_homepages/_form_fields.html.erb
+++ b/app/views/outpost/better_homepages/_form_fields.html.erb
@@ -32,7 +32,8 @@
         },
         params: {
           limit: 20,
-          types: "news,blogs,segments,shells,queries,events",
+          types: "news,blogs,segments,shells,queries",
+          search_types: "news,blogs,segments,shells,queries,events",
           token: "<%= Rails.configuration.x.api.kpcc.private.api_token %>",
           order: "public_datetime",
           sort_mode: "desc",


### PR DESCRIPTION
#549 

This prevents events from being returned in the results for the aggregator in the Outpost editor for the new homepage, but allows for them to still be searchable.

