### PR TITLE
#get_article should be called instead of #to_article so that we aren't generating an article when we already have one indexed.

### DIFF
--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -175,8 +175,8 @@ class ShowEpisode < ActiveRecord::Base
       :assets             => self.assets.top,
       :audio              => self.audio.available,
       :program            => self.show,
-      :segments           => self.segments.published.map(&:to_article),
-      :content            => self.published_content.map(&:to_article)
+      :segments           => self.segments.published.map(&:get_article),
+      :content            => self.published_content.map(&:get_article)
     })
   end
 


### PR DESCRIPTION
Looking at staging, I'm not really sure how much of a temporary improvement this will be, but it should be safe to deploy and that might provide a better indication.