### PR TITLE
Beta Homepage: Get related content from content objects instead of articles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -519,7 +519,7 @@ module ApplicationHelper
   end
 
   def filter_related_content content, contents
-    homepage_content = contents.map{|c| c.content.to_article}
+    homepage_content_ids = contents.map(&:obj_key)
     @related_content_manifest ||= []
     ## This is mainly for display purposes on the new homepage
     ## where we want to get the latest 2 related contents for
@@ -528,9 +528,9 @@ module ApplicationHelper
     #
     # We are also filtering out anything that has already been
     # displayed, or is part of the series of homepage contents.
-    content.article.related_content_articles.select do |article|
+    content.related_content.select do |article|
       !@related_content_manifest.include?(article) &&
-      !homepage_content.include?(article) && 
+      !homepage_content_ids.include?(article.obj_key) && 
       ((article.public_datetime || 10.years.ago) > 48.hours.ago) &&
       @related_content_manifest.push(article)
     end

--- a/app/models/homepage_content.rb
+++ b/app/models/homepage_content.rb
@@ -66,6 +66,18 @@ class HomepageContent < ActiveRecord::Base
     content.try(:get_article) || Article.new
   end
 
+  # This way, we can treat homepage_content as a proxy
+  # to the actual content, so that we don't always have
+  # to call for it when we need it.
+  def method_missing mname, *args
+    @content ||= content
+    if @content && @content.respond_to?(mname)
+      @content.send(mname, *args)
+    else
+      super
+    end
+  end
+
   def media_class
     ## Not sure if this is needed anymore?
     case asset_scheme

--- a/app/models/show_segment.rb
+++ b/app/models/show_segment.rb
@@ -101,7 +101,6 @@ class ShowSegment < ActiveRecord::Base
   end
 
   def to_article
-    related_content = to_article_called_more_than_twice? ? [] : self.related_content.map(&:to_reference)
     @to_article ||= Article.new({
       :original_object    => self,
       :id                 => self.obj_key,
@@ -126,8 +125,7 @@ class ShowSegment < ActiveRecord::Base
       :links              => related_links.map(&:to_hash),
       :asset_display      => asset_display,
       :disqus_identifier  => self.disqus_identifier,
-      :abstract           => self.abstract,
-      :related_content    => related_content
+      :abstract           => self.abstract
     })
   end
 


### PR DESCRIPTION
Related to: #588

This is essentially undoing a specific change that may have been causing some performance problems, and uses a more direct means to get related content.  Initially, the homepage was relying on Elasticsearch but, since we are pre-caching the homepage, now there are things left over from that which rely on articles.  I'd like to further divorce the new homepage from articles over time.