### PR TITLE
Allow default twitter description to be overridden.

### DIFF
--- a/app/views/shared/content/default/_opengraph.html.erb
+++ b/app/views/shared/content/default/_opengraph.html.erb
@@ -10,7 +10,8 @@
   <meta name="twitter:site" value="@kpcc">
   <meta name="twitter:url" value="<%= article.public_url %>">
   <meta name="twitter:title" value="<%= h(article.short_title) %>">
-  <meta name="twitter:description" value="<%= h(strip_tags(article.teaser)) %>">
+  <% meta_information[:description] ||= h(strip_tags(article.teaser)) %>
+  <meta name="twitter:description" value="<%= meta_information[:description] %>">
 
   <meta property="article:published_time" content="<%=article.public_datetime%>" />
   <meta property="article:modified_time" content="<%=article.updated_at%>" />

--- a/app/views/shared/new/_document_header.html.erb
+++ b/app/views/shared/new/_document_header.html.erb
@@ -31,7 +31,8 @@
     <%= tag "meta", name: "twitter:url", content: meta_information[:url] || "http://scpr.org" %>
     <%= tag "meta", name: "twitter:domain", content: meta_information[:url] || "http://scpr.org" %>
     <%= tag "meta", name: "twitter:title", content: h(meta_information[:title] || page_title) %>
-    <%= tag "meta", name: "twitter:description", content: h(meta_information[:description] || "Member-supported public radio for Southern California. Award-winning local news and cultural programming alongside the best of NPR.") %>
+    <% meta_information[:description] ||= "Member-supported public radio for Southern California. Award-winning local news and cultural programming alongside the best of NPR." %>
+    <%= tag "meta", name: "twitter:description", content: h(meta_information[:description]) %>
 
     <%= tag "link", rel: "alternate", type: "application/rss+xml", title: "RSS", href: meta_information[:rss_feed] || "http://scpr.org/feeds/all_news" %>
 


### PR DESCRIPTION
#595

Prevents the default description from overriding the more specific one.