### PR TITLE
Apple news improvements

### DIFF
--- a/app/concerns/concern/callbacks/expire_ingest_feed_cache_callback.rb
+++ b/app/concerns/concern/callbacks/expire_ingest_feed_cache_callback.rb
@@ -1,0 +1,25 @@
+module Concern
+  module Callbacks
+    module ExpireIngestFeedCacheCallback
+      extend ActiveSupport::Concern
+
+      # Here, we are assuming that if an article is published,
+      # it will effect the list of articles in the Facebook 
+      # and Apple ingest RSS feeds.  Since the controller that
+      # handles those feeds uses caching due to the slow performance
+      # of the queries, we need to clear that cache upon an 
+      # article being published.
+
+      included do
+        after_save :expire_ingest_feed_cache, if: ->{(published? || publishing?) && changed?}
+      end
+
+      private
+
+      def expire_ingest_feed_cache
+        Rails.cache.delete "controller/ingest-feed-controller"
+      end
+
+    end
+  end
+end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,6 +1,6 @@
 class FeedsController < ApplicationController
   layout false
-  helper InstantArticlesHelper
+
   def all_news
     response.headers["Content-Type"] = 'text/xml'
 
@@ -53,22 +53,6 @@ class FeedsController < ApplicationController
       comp.zero? ? (a.id <=> b.id) : comp
     end
     render template: 'feeds/npr_ingest.xml.builder', format: :xml
-  end
-  
-  def facebook_ingest
-    response.headers["Content-Type"] = 'text/xml'
-
-    @feed = {
-      :title       => "Instant Articles | 89.3 KPCC",
-      :description => "Instant Articles from KPCC's reporters, bloggers and shows."
-    }
-
-    records = NewsStory.published.where(source: "kpcc").order("published_at DESC").limit(15).concat BlogEntry.published.order('published_at DESC').limit(15)
-    @content = records.map(&:get_article).sort_by(&:public_datetime).reverse.first(15)
-
-    xml = render_to_string(action: "facebook", formats: :xml)
-
-    render text: xml, format: :xml
   end
 
 end

--- a/app/controllers/ingest_feed_controller.rb
+++ b/app/controllers/ingest_feed_controller.rb
@@ -1,0 +1,49 @@
+class IngestFeedController < ApplicationController
+  layout false
+  helper InstantArticlesHelper
+  # This is similar to the feeds controller,
+  # but contains some helper method overrides
+  # to render a more consistently clean body
+  # to support Facebook and Apples' specs.
+  before_action :retrieve_content
+
+  def facebook_ingest
+    response.headers["Content-Type"] = 'text/xml'
+
+    @feed = {
+      :title       => "Instant Articles | 89.3 KPCC",
+      :description => "Instant Articles from KPCC's reporters, bloggers and shows."
+    }
+
+    xml = render_to_string(template: 'feeds/facebook.xml.builder', formats: :xml)
+
+    render text: xml, format: :xml
+  end
+
+  def apple_ingest
+    response.headers["Content-Type"] = 'text/xml'
+
+    @feed = {
+      :title       => "Apple News | 89.3 KPCC",
+      :description => "Apple News articles from KPCC's reporters, bloggers and shows.",
+      :url         => apple_ingest_feed_url(format: :xml)
+    }
+
+    xml = render_to_string(template: 'feeds/apple.xml.builder', formats: :xml)
+
+    render text: xml, format: :xml
+  end
+
+  private
+
+  def retrieve_content
+    # This is slow, but ElasticSearch wasn't behaving the way I'd 
+    # expect when trying to match the bylines of articles to discount
+    # non-kpcc articles.
+    @content = cache "ingest-feed-controller", skip_digest: true do
+      # Cache should be expiring whenever a news story or a blog entry is published or modified(after publish).
+      records = NewsStory.published.where(source: "kpcc").order("published_at DESC").limit(15).concat BlogEntry.published.order('published_at DESC').limit(15)
+      records.map(&:get_article).sort_by(&:public_datetime).reverse.first(15)
+    end
+  end
+end

--- a/app/models/blog_entry.rb
+++ b/app/models/blog_entry.rb
@@ -33,6 +33,7 @@ class BlogEntry < ActiveRecord::Base
   include Concern::Callbacks::PublishNotificationCallback
   include Concern::Callbacks::HomepageCachingCallback
   include Concern::Callbacks::TouchCallback
+  include Concern::Callbacks::ExpireIngestFeedCacheCallback
   include Concern::Methods::ArticleStatuses
   include Concern::Methods::CommentMethods
   include Concern::Methods::AssetDisplayMethods

--- a/app/models/news_story.rb
+++ b/app/models/news_story.rb
@@ -30,6 +30,7 @@ class NewsStory < ActiveRecord::Base
   include Concern::Callbacks::GenerateSlugCallback
   #include Concern::Callbacks::CacheExpirationCallback
   include Concern::Callbacks::PublishNotificationCallback
+  include Concern::Callbacks::ExpireIngestFeedCacheCallback
   include Concern::Model::Searchable
   include Concern::Callbacks::HomepageCachingCallback
   include Concern::Callbacks::TouchCallback

--- a/app/views/feeds/apple.xml.builder
+++ b/app/views/feeds/apple.xml.builder
@@ -1,0 +1,31 @@
+xml.rss(RSS_SPEC) do
+  xml.channel do
+    xml.title       @feed[:title]
+    xml.link        @feed[:link] || "http://www.scpr.org"
+    xml.description @feed[:description]
+    xml.language 'en-us'
+    xml.atom :link, {
+      :href   => @feed[:url],
+      :rel    => "self",
+      :type   => "application/rss+xml"
+    }
+    @content.each do |content|
+      xml.item do
+        xml.title content.title
+        xml.description render(
+          partial: 'feeds/shared/apple_article', 
+          formats: ['html'],
+          layout: false, 
+          locals: {content: content}
+        ).gsub("\n", "")
+        xml.guid    content.public_url
+        xml.link    content.public_url
+        xml.author  content.byline
+        if content.asset
+          xml.enclosure url: content.asset.full.url, type: "image/jpeg"
+        end
+        xml.pubDate content.public_datetime.iso8601
+      end
+    end
+  end
+end

--- a/app/views/feeds/shared/_apple_article.html.erb
+++ b/app/views/feeds/shared/_apple_article.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="<%= content.public_url %>">
+    <meta property="op:markup_version" content="v1.0">
+    <meta property="og:locale" content='en-us'/>
+    <meta name='author' property='article:author' itemprop='author' value='<%= content.byline %>' />
+    <% if asset = content.asset %>
+      <meta property='og:image' itemprop='thumbnailUrl' content="<%= asset.full.url %>" />
+      <meta property="og:image:type" content="image/jpeg" />
+      <meta property="og:image:width" content="<%= asset.full.width %>" />
+      <meta property="og:image:height" content="<%= asset.full.height%>" />
+    <% end %>
+    <title><%= content.title %></title>
+  </head>
+  <body>
+    <article>
+      <%= render_body content %>
+      <footer>
+        <small>© 2016 Southern California Public Radio</small>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require 'rails/all'
 
 Bundler.require(:default, Rails.env)
 
-if Rails.env.development?
+if Rails.env.development? || ENV['USE_DOCKER_MACHINE']
   ## Initialize Docker Machine environment variables so
   ## that database.yml can pick up the MySQL database host
   `docker-machine env default`.scan(/(\w+)="(.*)"/).each{|p| ENV[p[0]] = p[1]}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,11 @@ Scprv4::Application.routes.draw do
   get '/news/'                                       => 'category#news',              as: :latest_news
 
   # RSS
-  get '/feeds/all_news'   => 'feeds#all_news',    as: :all_news_feed
-  get '/feeds/take_two'   => 'feeds#take_two',    as: :take_two_feed # Deprecated, delete once replaced with npr_ingest
-  get '/feeds/npr_ingest' => 'feeds#npr_ingest',  as: :npr_ingest_feed
-  get '/feeds/facebook_ingest' => 'feeds#facebook_ingest',  as: :facebook_ingest_feed
+  get '/feeds/all_news'        => 'feeds#all_news',    as: :all_news_feed
+  get '/feeds/take_two'        => 'feeds#take_two',    as: :take_two_feed # Deprecated, delete once replaced with npr_ingest
+  get '/feeds/npr_ingest'      => 'feeds#npr_ingest',  as: :npr_ingest_feed
+  get '/feeds/facebook_ingest' => 'ingest_feed#facebook_ingest',  as: :facebook_ingest_feed
+  get '/feeds/apple_ingest'    => 'ingest_feed#apple_ingest',  as: :apple_ingest_feed
   get '/feeds/*feed_path', to: redirect { |params, request| "/#{params[:feed_path]}.xml" }
 
 

--- a/spec/concerns/concern/callbacks/expire_ingest_feed_cache_callback_spec.rb
+++ b/spec/concerns/concern/callbacks/expire_ingest_feed_cache_callback_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Concern::Callbacks::ExpireIngestFeedCacheCallback do
+  context "published content" do
+    it 'clears the cache on update' do
+      story = create :news_story, status: 0
+
+      Rails.cache.write "controller/ingest-feed-controller", "hello world"
+
+      expect(Rails.cache.read("controller/ingest-feed-controller")).to eq "hello world"
+
+      story.update status: 5
+
+      expect(Rails.cache.read("controller/ingest-feed-controller")).to eq nil
+
+    end
+  end
+  context "non-published content" do
+    it 'leaves the cache alone' do
+      story = create :news_story, status: 0
+
+      Rails.cache.write "controller/ingest-feed-controller", "hello world"
+
+      expect(Rails.cache.read("controller/ingest-feed-controller")).to eq "hello world"
+
+      story.update body: "hello wurld"
+
+      expect(Rails.cache.read("controller/ingest-feed-controller")).to eq "hello world"
+
+    end
+  end
+end


### PR DESCRIPTION
#581 

This moves the apple news and instant articles rss ingests to their own controller so that helper methods can be safely overridden.  Since I'm relying on MySQL queries to generate each feed, there is now caching of those queries and a callback added to NewsStories and BlogEntries that expires that cache upon changes to published content.  The apple feed has some improvements taken from their documentation, like adding meta tags that specify an image and an author.