### PR TITLE
Prevent NPR remote articles from being pulled in multiple times

### DIFF
--- a/app/importers/npr_article_importer.rb
+++ b/app/importers/npr_article_importer.rb
@@ -36,8 +36,16 @@ module NprArticleImporter
 
       added = []
 
-      npr_stories.reject { |s|
-        RemoteArticle.exists?(source: SOURCE, article_id: s.id)
+      fetched_story_ids    = npr_stories.map(&:id)
+
+      existing_story_ids   = RemoteArticle.where(article_id: fetched_story_ids, source: SOURCE)
+        .pluck(:article_id)
+        .compact
+        .map(&:to_s)
+
+      npr_stories.reject{ |s| 
+        # Reject the story if the id is already present in our database.
+        existing_story_ids.include?(s.id.to_s)
       }.each do |npr_story|
         cached_article = RemoteArticle.new(
           :source       => SOURCE,


### PR DESCRIPTION
#612 

I have a suspicion that the duplication was being caused by, at some point, the article_id being cast as a different type from the fetched article ID(string being evaluated against an integer).  It's not clear to me why this didn't seem to always happen, but the article_id, when queried from the database, comes back as a string.

So I did two things:

- Convert both the ID in the database and the fetched ID to strings during comparison.
- Fetch existing IDs from the database in bulk as opposed to calling an #exists? query on every article fetched.  This makes the importer much faster.

On staging, we were seeing up to 3 duplicates per story.  After implementing this change, no duplicates come in no matter how many times I run the importer, so I think this is worth deploying to production to see if this issue can be resolved today.