### PR TITLE
Enforce uniqueness of remote articles at the database level.

### DIFF
--- a/app/importers/npr_article_importer.rb
+++ b/app/importers/npr_article_importer.rb
@@ -57,13 +57,18 @@ module NprArticleImporter
           :is_new       => true
         )
 
-        if cached_article.save
-          added.push cached_article
-          log "Saved NPR Story ##{npr_story.id} as " \
-              "RemoteArticle ##{cached_article.id}"
-        else
-          log "Couldn't save NPR Story ##{npr_story.id}"
+        begin
+          if cached_article.save
+            added.push cached_article
+            log "Saved NPR Story ##{npr_story.id} as " \
+                "RemoteArticle ##{cached_article.id}"
+          else
+            log "Couldn't save NPR Story ##{npr_story.id}"
+          end
+        rescue ActiveRecord::RecordNotUnique
+          log "NPR Story ##{npr_story.id} already exists"
         end
+
       end # each
 
       added

--- a/app/models/remote_article.rb
+++ b/app/models/remote_article.rb
@@ -22,6 +22,10 @@ class RemoteArticle < ActiveRecord::Base
     "pmp" => "PmpArticleImporter"
   }
 
+  scope :duplicates, -> { 
+    where.not(id: select("MAX(id) as id").group([:source, :article_id]).pluck(:id))
+  }
+
   #---------------
 
   class << self

--- a/db/migrate/20160816202513_make_remote_articles_unique.rb
+++ b/db/migrate/20160816202513_make_remote_articles_unique.rb
@@ -1,0 +1,11 @@
+class MakeRemoteArticlesUnique < ActiveRecord::Migration
+  def up
+    RemoteArticle.duplicates.delete_all
+    remove_index "remote_articles", ["article_id", "source"]
+    add_index "remote_articles", ["article_id", "source"], name: "index_remote_articles_on_article_id_and_source", using: :btree, unique: true
+  end
+  def down
+    remove_index "remote_articles", ["article_id", "source"]
+    add_index "remote_articles", ["article_id", "source"], name: "index_remote_articles_on_article_id_and_source", using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727220239) do
+ActiveRecord::Schema.define(version: 20160816202513) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -29,6 +29,18 @@ ActiveRecord::Schema.define(version: 20160727220239) do
   add_index "abstracts", ["category_id"], name: "index_abstracts_on_category_id", using: :btree
   add_index "abstracts", ["source"], name: "index_abstracts_on_source", using: :btree
   add_index "abstracts", ["updated_at"], name: "index_abstracts_on_updated_at", using: :btree
+
+  create_table "apple_news_articles", force: :cascade do |t|
+    t.integer  "record_id",   limit: 4
+    t.string   "record_type", limit: 255
+    t.string   "uuid",        limit: 255
+    t.string   "revision",    limit: 255
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  add_index "apple_news_articles", ["record_id"], name: "index_apple_news_articles_on_record_id", using: :btree
+  add_index "apple_news_articles", ["record_type"], name: "index_apple_news_articles_on_record_type", using: :btree
 
   create_table "assethost_contentasset", force: :cascade do |t|
     t.integer "content_id",   limit: 4
@@ -799,7 +811,7 @@ ActiveRecord::Schema.define(version: 20160727220239) do
     t.string   "news_agency",  limit: 255
   end
 
-  add_index "remote_articles", ["article_id", "source"], name: "index_remote_articles_on_article_id_and_source", using: :btree
+  add_index "remote_articles", ["article_id", "source"], name: "index_remote_articles_on_article_id_and_source", unique: true, using: :btree
   add_index "remote_articles", ["published_at"], name: "index_remote_articles_on_published_at", using: :btree
   add_index "remote_articles", ["source"], name: "index_remote_articles_on_source", using: :btree
 

--- a/spec/controllers/outpost/remote_articles_controller_spec.rb
+++ b/spec/controllers/outpost/remote_articles_controller_spec.rb
@@ -59,7 +59,7 @@ describe Outpost::RemoteArticlesController do
       end
 
       it "only gets new records" do
-        oldrecord = create :npr_article, is_new: false
+        oldrecord = create :npr_article, is_new: false, article_id: (RemoteArticle.last.article_id.to_i + 1)
         get :index
         assigns(:records).should_not include oldrecord
       end


### PR DESCRIPTION
#613 

This is to prevent Remote articles from the NPR importer from creating duplicate records, which may be happening due to competing processes.