### PR TITLE
Allow embed placeholder links to persist

### DIFF
--- a/lib/instant_articles_helper.rb
+++ b/lib/instant_articles_helper.rb
@@ -2,7 +2,7 @@ module InstantArticlesHelper
 
   def render_asset(content, options={})
     asset = options[:asset] || nil
-    return if options[:kpcc_only] && asset && !asset.owner.try(:include?, "KPCC")
+    # return if options[:kpcc_only] && asset && !asset.owner.try(:include?, "KPCC")
     if options[:asset_display]
       asset_display = options[:asset_display]
     else 
@@ -61,7 +61,6 @@ module InstantArticlesHelper
     doc.css(cssPath).each do |placeholder|
       asset_id = placeholder.attribute('data-asset-id').value
       asset = content.original_object.assets.find_by(asset_id:asset_id)
-      ## If kpcc_only is true, only render if the owner of the asset is KPCC
       if asset
         rendered_asset = render_asset content, context: context, display: display, asset:asset
         placeholder.replace Nokogiri::HTML::DocumentFragment.parse(rendered_asset)

--- a/lib/instant_articles_helper.rb
+++ b/lib/instant_articles_helper.rb
@@ -22,12 +22,22 @@ module InstantArticlesHelper
   end
 
   def render_body content
-    strip_comments remove_empty_tags strip_embeds insert_inline_assets content
+    strip_comments remove_empty_paragraphs strip_embed_placeholders insert_inline_assets content
   end
 
-  def strip_embeds body
+  def strip_embed_placeholders body
     process_markup body, ".embed-placeholder, .embed-wrapper" do |placeholder|
-      placeholder.remove
+      unless placeholder.name == "a"
+        placeholder.remove
+      end
+    end
+  end
+
+  def process_iframes body
+    process_markup body, 'iframe' do |iframe|
+      figure = Nokogiri::HTML::DocumentFragment.parse("<figure class='op-interactive'></figure>")
+      figure.children << iframe
+      iframe.replace figure
     end
   end
 
@@ -37,7 +47,7 @@ module InstantArticlesHelper
     doc.css("body").children.to_s.html_safe
   end
 
-  def remove_empty_tags body
+  def remove_empty_paragraphs body
     process_markup body, "p" do |tag|
       tag.remove if tag.content.strip.empty?
     end


### PR DESCRIPTION
Sometimes we have embeds where the author referenced it in a paragraph above.  Yet, if we remove these links, it leaves the reader with nothing and it's confusing.  That may have been the reason behind Facebook's last cryptic complaint about our articles.  So I'm going to merge this, wipe our existing articles out, and try again for acceptance.