### PR TITLE
Instant articles updates

### DIFF
--- a/app/views/feeds/shared/instant_articles/_default.html.erb
+++ b/app/views/feeds/shared/instant_articles/_default.html.erb
@@ -2,6 +2,8 @@
 <% unless (asset.title || "").include?("Asset Unavailable") %>
   <figure>
     <img src="<%= asset.full.url %>" />
-    <figcaption><%= asset.caption %></figcaption>
+    <% if asset.caption %>
+      <figcaption><%= asset.caption %></figcaption>
+    <% end %>
   </figure>
 <% end %>

--- a/lib/instant_articles_helper.rb
+++ b/lib/instant_articles_helper.rb
@@ -22,7 +22,9 @@ module InstantArticlesHelper
   end
 
   def render_body content
-    strip_comments remove_empty_paragraphs strip_embed_placeholders insert_inline_assets content
+    # This contains the pipeline for filtering
+    # the HTML body of the article.
+    translate_headings strip_comments remove_empty_paragraphs strip_embed_placeholders insert_inline_assets content
   end
 
   def strip_embed_placeholders body
@@ -50,6 +52,18 @@ module InstantArticlesHelper
   def remove_empty_paragraphs body
     process_markup body, "p" do |tag|
       tag.remove if tag.content.strip.empty?
+    end
+  end
+
+  def translate_headings body
+    # For whatever reason, Facebook only allows h1 and h2 tags.
+    # H3 is reserved for "kickers", but it's unclear why others
+    # are not permitted.  
+    # While they will automatically translate h(n>2) tags to
+    # h2, a warning is still displayed next to each story.
+    # We will translate the tags here to prevent that warning.
+    process_markup body, "h3, h4, h5, h6" do |heading|
+      heading.name = "em"
     end
   end
 

--- a/lib/instant_articles_helper.rb
+++ b/lib/instant_articles_helper.rb
@@ -62,8 +62,11 @@ module InstantArticlesHelper
     # While they will automatically translate h(n>2) tags to
     # h2, a warning is still displayed next to each story.
     # We will translate the tags here to prevent that warning.
-    process_markup body, "h3, h4, h5, h6" do |heading|
-      heading.name = "em"
+    process_markup body, "h1, h2, h3, h4, h5, h6" do |heading|
+      heading.inner_html = heading.text # Headings shouldn't contain other tags.
+      unless ['h1', 'h2'].include?(heading.name.downcase)
+        heading.name = "em"
+      end
     end
   end
 


### PR DESCRIPTION
A few changes were made to how we are translating our articles into Instant Articles, so as to better comply with Facebook's format and prevent relatively harmless warnings from cluttering up the article management interface(warnings should be for more serious issues if they occur).  In part because only recent articles are accepted, I am deploying this to production so that new stories can regularly be added and previewed.