### PR TITLE
AMP route fix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -457,7 +457,7 @@ module ApplicationHelper
   # include this link tag in HEAD.
   def amp_head_link
     if @amp_enabled
-      tag :link, rel: "amphtml", href: "#{request.original_url}?amp"
+      tag :link, rel: "amphtml", href: "#{request.original_url.split('/').join('/')}.amp"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -457,7 +457,9 @@ module ApplicationHelper
   # include this link tag in HEAD.
   def amp_head_link
     if @amp_enabled
-      tag :link, rel: "amphtml", href: "#{request.original_url.split('/').join('/')}.amp"
+      uri = URI.parse(request.original_url)
+      uri.path = "#{uri.path.split('/').join('/')}.amp"
+      tag :link, rel: "amphtml", href: uri.to_s
     end
   end
 


### PR DESCRIPTION
Our helpful friend Eloqua adds parameters that conflict with the parameter we were using to tell SCPRv4 to load the AMP version of a new story, causing some links in the Short List to go to the AMP version of the page instead of the normal version.  Clearly, this is undesired, especially if the story is being loaded on desktop.

This commit changes the AMP implementation to work from the file type instead of a query parameter, which shouldn't conflict with anything.