### PR TITLE
Push breaking news alerts to OneSignal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ gem 'asset_host_client', github:"scpr/asset_host_client", tag:"v2.0.0"
 gem 'audio_vision', '~> 1.0'
 gem 'slack-notifier'
 gem 'aws-sdk', '~> 2'
+gem 'one_signal'
 
 ## Assets
 gem "eco", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
+    one_signal (1.2.0)
     outpost-publishing (1.0.1)
     patron (0.4.18)
     pmp (0.5.6)
@@ -525,6 +526,7 @@ DEPENDENCIES
   newrelic_rpm (~> 3.16)
   npr (~> 3.0)!
   oauth2 (~> 0.8)
+  one_signal
   outpost-aggregator!
   outpost-asset_host!
   outpost-cms!

--- a/app/models/breaking_news_alert.rb
+++ b/app/models/breaking_news_alert.rb
@@ -141,9 +141,9 @@ class BreakingNewsAlert < ActiveRecord::Base
         alert: alert_subject.to_s,
         alert_id: self.id.to_s
       },
-      ios_badgeType: badge
+      ios_badgeType: badge,
+      included_segments: ["Active Users"]
     }
-    params[:included_segments] = self.alert_type == "audio" ? ["iPhone Users", "iPad Users"] : ["iPad Users"]
     OneSignal::Notification.create(params: params)
   end
 

--- a/app/models/breaking_news_alert.rb
+++ b/app/models/breaking_news_alert.rb
@@ -112,13 +112,13 @@ class BreakingNewsAlert < ActiveRecord::Base
   # Publish a mobile notification
   def publish_mobile_notification
     return false if !should_send_mobile_notification?
-    parse_push
-    one_signal_push
+    parse_push  # Since we are going to move to OneSignal, we're not going to worry much about whether this succeeds.
+    result = one_signal_push 
 
-    if result["result"] == true
+    if result.code == "201" || result.code == "200"
       self.update_column(:mobile_notification_sent, true)
     else
-      # TODO: Handle errors from Parse
+      # TODO: Handle errors from OneSignal
     end
   end
 

--- a/app/models/breaking_news_alert.rb
+++ b/app/models/breaking_news_alert.rb
@@ -112,7 +112,17 @@ class BreakingNewsAlert < ActiveRecord::Base
   # Publish a mobile notification
   def publish_mobile_notification
     return false if !should_send_mobile_notification?
+    parse_push
+    one_signal_push
 
+    if result["result"] == true
+      self.update_column(:mobile_notification_sent, true)
+    else
+      # TODO: Handle errors from Parse
+    end
+  end
+
+  def parse_push
     push = Parse::Push.new({
       :title      => "KPCC - #{self.break_type}",
       :alert      => alert_subject,
@@ -121,12 +131,20 @@ class BreakingNewsAlert < ActiveRecord::Base
     })
     push.channels = self.alert_type == "audio" ? [IPHONE_CHANNEL,IPAD_CHANNEL] : [IPAD_CHANNEL]
     result = push.save
+  end
 
-    if result["result"] == true
-      self.update_column(:mobile_notification_sent, true)
-    else
-      # TODO: Handle errors from Parse
-    end
+  def one_signal_push
+    params = {
+      app_id:     Rails.application.secrets.api['one_signal']['app_id'],
+      contents: {
+        title: "KPCC - #{self.break_type}",
+        alert: alert_subject.to_s,
+        alert_id: self.id.to_s
+      },
+      ios_badgeType: badge
+    }
+    params[:included_segments] = self.alert_type == "audio" ? ["iPhone Users", "iPad Users"] : ["iPad Users"]
+    OneSignal::Notification.create(params: params)
   end
 
   add_transaction_tracer :publish_mobile_notification, category: :task

--- a/config/initializers/one_signal.rb
+++ b/config/initializers/one_signal.rb
@@ -1,0 +1,1 @@
+OneSignal::OneSignal.api_key = Rails.application.secrets.api["one_signal"]["api_key"]

--- a/config/templates/secrets.yml.ci
+++ b/config/templates/secrets.yml.ci
@@ -104,7 +104,11 @@ test:
       s3:
         buckets:
           versions: xxx
-      
+
+    one_signal:
+      user_auth_key: xxx
+      app_id: xxx
+      api_key: xxx 
 
   emails:
     digital_broadcast_ops: xxx

--- a/spec/jobs/job/send_mobile_notification_spec.rb
+++ b/spec/jobs/job/send_mobile_notification_spec.rb
@@ -5,7 +5,7 @@ describe Job::SendMobileNotification do
   it { subject.queue.should eq Job::QUEUES[:mid_priority] }
 
   before :each do
-    stub_request(:post, %r|api\.parse\.com|)
+    stub_request(:post, /(api\.parse\.com)|(onesignal.com)/)
     .to_return(body: { result: true }.to_json)
   end
 

--- a/spec/models/breaking_news_alert_spec.rb
+++ b/spec/models/breaking_news_alert_spec.rb
@@ -27,7 +27,7 @@ describe BreakingNewsAlert do
 
   describe '#publish_mobile_notification' do
     before :each do
-      stub_request(:post, %r|api\.parse\.com|)
+      stub_request(:post, /(api\.parse\.com)|(onesignal\.com)/)
       .to_return(body: { result: true }.to_json)
     end
 


### PR DESCRIPTION
#645 

Breaking news alerts now get pushed both to OneSignal and Parse.