### PR TITLE
Switch to a different SVG polyfill

### DIFF
--- a/app/assets/javascripts/better_homepage/application.js
+++ b/app/assets/javascripts/better_homepage/application.js
@@ -12,7 +12,7 @@
 new scpr.adSizer();
 
 jQuery(document).ready(function() {
-  require('svg4everybody')();
+  require('svgxuse');
   require('better_homepage/page-adjuster');
   new scpr.BetterHomepage({el: $('.hp-content')});
 })

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "query-string": "^4.2.2",
     "scpr-style-guide": "^2.2.0",
     "selectivizr": "= 1.0.3",
-    "svg4everybody": "^2.1.0",
+    "svgxuse": "^1.1.22",
     "swfobject": "= 2.2",
     "timeago": "= 1.5.1",
     "underscore": "^1.8.3",


### PR DESCRIPTION
#666 :metal:

This polyfill takes care of both the logo in IE11 as well as the other icons that required `use` tags.

