### PR TITLE
Add comscore tracking to amp analytics.

### DIFF
--- a/app/views/layouts/application.amp.erb
+++ b/app/views/layouts/application.amp.erb
@@ -35,13 +35,34 @@
             "request": "pageview",
             "vars": {
               "title": "<%= content_for :title %>",
-              "ampdocUrl": "<%= content_for :public_url %>?amp"
+              "ampdocUrl": "<%= content_for :public_url %>.amp"
             }
           }
         }
       }
       </script>      
     </amp-analytics>
+
+    <amp-analytics type="comscore" id="analytics2">
+      <script type="application/json">
+      {
+        "vars": {
+          "c2": "6035974"
+        },
+        "triggers": {
+          "trackPageview": {
+            "on": "visible",
+            "request": "pageview",
+            "vars": {
+              "title": "<%= content_for :title %>",
+              "ampdocUrl": "<%= content_for :public_url %>.amp"
+            }
+          }
+        }
+      }
+      </script>      
+    </amp-analytics>
+
     <%= render partial: "layouts/amp/masthead" %>
     <article>
       <%= yield %>


### PR DESCRIPTION
#676

This adds Comscore tracking to AMP pages using the amp-analytics plugin, as described [here](https://www.ampproject.org/docs/reference/components/amp-analytics#comscore).