### PR TITLE
Tag cluster improvements

### DIFF
--- a/app/views/better_homepage/_tag_cluster.html.erb
+++ b/app/views/better_homepage/_tag_cluster.html.erb
@@ -5,7 +5,7 @@
     <% tag.featured_content(omit).each do |feature| %>
       <div class="o-media o-media--horizontal o-media--sm">
         <div class="o-media__figure o-media__figure--four-by-three">
-          <img class="o-media__img" src="<%= feature.asset.asset.thumb.url %>">
+          <img class="o-media__img" src="<%= begin feature.asset.asset.thumb.url rescue '/static/images/fallback-img-square.png' end %>">
         </div>
         <h4>
           <%= link_to feature.title, feature.public_url %>

--- a/app/views/better_homepage/_tag_cluster.html.erb
+++ b/app/views/better_homepage/_tag_cluster.html.erb
@@ -1,5 +1,5 @@
 <% if tag %>
-  <h6 class="b-heading b-heading--h6 b-heading--uppercase u-text-color--gray b-heading--bold o-media__headline-link"><%= link_to "Learn More About #{tag.title}", topic_url(tag.slug) %></h6>
+  <h6 class="b-heading b-heading--h6 b-heading--uppercase u-text-color--gray b-heading--bold o-media__headline-link"><%= link_to "#{tag.title}", topic_url(tag.slug) %></h6>
   <ul class="c-list c-list--horiz">
     <% omit ||= [] %>
     <% tag.featured_content(omit).each do |feature| %>


### PR DESCRIPTION
#695 
- Tag save triggers homepage cache reload if on that homepage.
- Removes "learn more" from tag clusters.
- Adds bullets back to abstracts on homepage.