### PR TITLE
Add basic GA tracking to Instant Articles.

### DIFF
--- a/app/views/feeds/shared/_instant_article.html.erb
+++ b/app/views/feeds/shared/_instant_article.html.erb
@@ -30,6 +30,7 @@
         <footer>
           <small>&copy; 2016 Southern California Public Radio</small>
         </footer>
+        <%= render partial: "feeds/shared/instant_articles/tracking_scripts", locals: {title: content.headline} %>
       </article>
     </body>
   </html>

--- a/app/views/feeds/shared/instant_articles/_tracking_scripts.html.erb
+++ b/app/views/feeds/shared/instant_articles/_tracking_scripts.html.erb
@@ -1,33 +1,12 @@
 <figure class="op-tracker">
-  <iframe>
-  <script type='text/javascript'>
-      var _sf_async_config = {};
-      /** CONFIGURATION START **/
-      _sf_async_config.uid = 33583; /*CHANGE TO YOUR ACCOUNT NUMBER HERE*/
-      _sf_async_config.domain = 'scpr.org'; /*CHANGE TO YOUR DOMAIN*/
-      _sf_async_config.sections = '';
-      /*OPTIONAL UPDATE WITH YOUR SECTION LOGIC */
-      _sf_async_config.authors = '';
-      /*OPTIONAL UPDATE WITH YOUR AUTHOR LOGIC */
-      _sf_async_config.type = ''; /*OPTIONAL FOR REPORT BUILDER RETURN */
-      _sf_async_config.useCanonical = true;
-      /*AGGREGATES AUDIENCE TRACKING UNDER ONE PAGE TITLE */
-      /** CONFIGURATION END **/
-      window._sf_endpt = (new Date()).getTime();
-  </script>
-  <script defer src="//static.chartbeat.com/js/chartbeat_fia.js"></script>
-  </iframe>
-</figure>
-
-<figure class="op-tracker">
   <iframe hidden>
       <script>
         (function (i,s,o,g,r,a,m) {i['GoogleAnalyticsObject']=r;i[r]=i[r]||function () {(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),                         m=s.getElementsByTagName(o)0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-   analytics.com/analytics.js','ga');
-        ga('create', 'ANALYTICS ID', 'auto');
+        ga('create', 'UA-624724-1', 'auto', {'allowLinker': true});
         ga('require', 'displayfeatures');
         ga('set', 'campaignSource', 'Facebook');
         ga('set', 'campaignMedium', 'Social Instant Article');
-        ga('send', 'pageview', {title: 'POST TITLE'});
+        ga('send', 'pageview', {title: title});
       </script>
   </iframe>
 </figure>


### PR DESCRIPTION
#675 

Adds simple GA pageview tracking to Facebook Instant Articles.  Will work on adding other metrics later, but first we need to verify that this even works at all and what it returns us.