### PR TITLE
Require scroll tracker plugin for facebook GA.

### DIFF
--- a/app/views/feeds/shared/instant_articles/_tracking_scripts.html.erb
+++ b/app/views/feeds/shared/instant_articles/_tracking_scripts.html.erb
@@ -7,6 +7,9 @@
         ga('set', 'campaignSource', 'Facebook');
         ga('set', 'campaignMedium', 'Social Instant Article');
         ga('send', 'pageview', {title: title});
+
+        ga('require', 'scrollDepthTracker');
       </script>
+      <script async src="https://cdn.rawgit.com/chrisgoddard/GAScrollTrackingPlugin/master/scroll-depth-tracker.js"></script>
   </iframe>
 </figure>


### PR DESCRIPTION
#699 

This adds scroll tracking to Instant Articles analytics code.