### PR TITLE
Update events listings for when there are no events.

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -6,6 +6,10 @@ a.event-link {
     background: image-url("icons/calendar-icon.png") no-repeat left top;
 }
 
+.events-newsletter.events-newsletter-centered {
+    text-align: center;
+}
+
 span.fake-link {
   color: $linkColor;
   text-decoration: none;

--- a/app/assets/stylesheets/new/_newsletter_appeals.css.scss
+++ b/app/assets/stylesheets/new/_newsletter_appeals.css.scss
@@ -12,6 +12,7 @@
         margin-left: -13.458262350937%;
         padding-left: 13.458262350937%;
     }
+
 }
 
 .appeal-background {

--- a/app/views/events/_events_list.html.erb
+++ b/app/views/events/_events_list.html.erb
@@ -1,9 +1,13 @@
 <% title ||= "" %>
 <% cssClass ||= "" %>
 <% direction ||= :asc %>
-
 <h2><%= title %></h2>
-<%= any_to_list? events, title: title do %>
+<% if params["list"] == "kpcc-in-person" %>
+  <% message = "We'll have more KPCC In Person events scheduled soon. Subscribe to our newsletter and get notified about the next one, straight from your inbox!" %>
+<% else %>
+  <% message = "We'll have more events scheduled soon. Subscribe to our newsletter and get notified about the next one, straight from your inbox!" %>
+<% end %>
+<%= any_to_list? events, title: title, message: message do %>
 <section class="events-list <%= cssClass %>">
 
 <% Event.sorted(events, direction).each do |event| %>
@@ -20,7 +24,6 @@
         <% else %>
           <div class="span24">
         <% end %>
-
 
           <div class="event-details">
             <div class="row-fluid">
@@ -47,3 +50,5 @@
 </section>
 <% end %>
 <%= paginate events %>
+<hr />
+<%= render partial: "shared/widgets/events_subscribe", locals: {klass: "events-newsletter-centered"} %>

--- a/app/views/events/kpcc_in_person.html.erb
+++ b/app/views/events/kpcc_in_person.html.erb
@@ -86,6 +86,10 @@
         <% end %>
         <p><a href="<%= events_path(list: 'kpcc-in-person') %>" class="more">More Upcoming Events</a></p>
       </section> <!-- upcoming-events -->
+      <section class="newsletter-signup">
+        <hr />
+        <%= render partial: "shared/widgets/events_subscribe" %>
+      </section>
     </div> <!-- span -->
 
     <!-- MIDDLE COLUMN (social media) -->

--- a/app/views/shared/widgets/_events_subscribe.html.erb
+++ b/app/views/shared/widgets/_events_subscribe.html.erb
@@ -1,14 +1,18 @@
-<div class="appeal-newsletter events-newsletter ancillary" id="appeal-newsletter">
+<% title   ||= "KPCC IN PERSON NEWSLETTER" %>
+<% caption ||= "Stay up to date with the latest information about our events:" %>
+<% klass   ||= "" %>
+
+<div class="appeal-newsletter events-newsletter ancillary <%= klass %>" id="appeal-newsletter">
   <div class="appeal-background">
     <div class="appeal-content">
-    <h3 class="bound appeal-heading"><strong>Hand-picked SoCal events</strong></h3>
-      <p class="bound">Get our weekly newsletter of cool things happening around LA:</p>
-      <form method="post" name="SCPREventsSignup-20151005" action="https://s1715082578.t.eloqua.com/e/f2" id="form911" class="elq-form" >
+    <h3 class="bound appeal-heading"><strong><%= title %></strong></h3>
+      <p class="bound"><%= caption %></p>
+      <form method="post" name="SCPREventsSignup-20151005" action="https://s1715082578.t.eloqua.com/e/f2" id="form911" class="elq-form">
         <input value="SCPREventsSignup-20151005" type="hidden" name="elqFormName"  />
         <input value="1715082578" type="hidden" name="elqSiteId"   />
         <input name="elqCampaignId" type="hidden"  />
 
-        <input class="newsletter-email" id="field0" name="emailAddress" type="email" placeholder="email@somedomain.com"value="" />
+        <input class="newsletter-email" id="field0" name="emailAddress" type="email" placeholder="email@somedomain.com" value="" />
         <input class="newsletter-hidden-input" name="SCPREvents" type="hidden" value="on"   />
         <button type="submit" class="btn appeal-submit track-event" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="Events Newsletter">Sign Up</button>
       </form>


### PR DESCRIPTION
#719

Implements the AC in that last ticket by changing event signup copy, the copy when there are no events to display, and where the event newsletter signup element appears.