### PR TITLE
Implement in-article donate CTA

### DIFF
--- a/app/assets/stylesheets/new/_newsletter_appeals.css.scss
+++ b/app/assets/stylesheets/new/_newsletter_appeals.css.scss
@@ -157,3 +157,13 @@
         margin: 14px 0 0;
     }
 }
+
+a.appeal-link {
+    @extend .appeal-submit;
+    box-sizing: border-box;
+    color: white !important;
+    display: inline-block;
+    line-height: 40px;
+    vertical-align: bottom;
+    text-align: center;
+}

--- a/app/assets/stylesheets/new/_newsletter_appeals.css.scss
+++ b/app/assets/stylesheets/new/_newsletter_appeals.css.scss
@@ -161,7 +161,7 @@
 a.appeal-link {
     @extend .appeal-submit;
     box-sizing: border-box;
-    color: white !important;
+    color: white !important; // hrm
     display: inline-block;
     line-height: 40px;
     vertical-align: bottom;
@@ -169,4 +169,44 @@ a.appeal-link {
     width: initial;
     padding-left: 15px;
     padding-right: 15px;
+}
+
+.segment .appeal-content h3.appeal-heading.appeal-heading-adaptive {
+    // display: inline-table;
+    font-size: 2.0rem;
+    span {
+        white-space: nowrap;
+    }
+    @media (max-width: 1294px) {
+        display: inline-table;
+        transform: scale(0.9, 0.9) translateX(-6%);
+    }
+    @media (max-width: 1232px) {
+        display: inline-table;
+        transform: scale(0.8, 0.8) translateX(-9%);
+    }
+    @media (max-width: 1109px) {
+        display: inline-table;
+        transform: scale(0.8, 0.8) translateX(-3.5%);
+    }
+    @media (max-width: 870px) {
+        display: inline-table;
+        transform: scale(0.8, 0.8) translateX(0%);
+    }
+    @media (max-width: 562px) {
+        display: inline-table;
+        transform: scale(0.7, 0.7) translateX(-16%);
+    }
+    @media (max-width: 488px) {
+        // display: inline-table;
+        transform: scale(0.6, 0.6) translateX(-27%);
+    }
+
+}
+
+.appeal-newsletter.donate-cta.ancillary {
+    .appeal-heading, .bound {
+        // padding: 0;
+        // margin: 0;
+    }
 }

--- a/app/assets/stylesheets/new/_newsletter_appeals.css.scss
+++ b/app/assets/stylesheets/new/_newsletter_appeals.css.scss
@@ -166,4 +166,7 @@ a.appeal-link {
     line-height: 40px;
     vertical-align: bottom;
     text-align: center;
+    width: initial;
+    padding-left: 15px;
+    padding-right: 15px;
 }

--- a/app/assets/stylesheets/new/_newsletter_appeals.css.scss
+++ b/app/assets/stylesheets/new/_newsletter_appeals.css.scss
@@ -203,10 +203,3 @@ a.appeal-link {
     }
 
 }
-
-.appeal-newsletter.donate-cta.ancillary {
-    .appeal-heading, .bound {
-        // padding: 0;
-        // margin: 0;
-    }
-}

--- a/app/views/programs/kpcc/_segment.html.erb
+++ b/app/views/programs/kpcc/_segment.html.erb
@@ -37,7 +37,7 @@
               <% if article.try(:show).try(:slug) == "the-frame" %>
                 <%= render 'shared/widgets/the_frame_subscribe' %>
               <% else %>
-                <%= render 'shared/widgets/short_list_subscribe' %>
+                <%= render 'shared/widgets/donate' %>
               <% end %>
 
               <%= render 'shared/cwidgets/related_links', content: article.get_article %>

--- a/app/views/shared/new/_single.html.erb
+++ b/app/views/shared/new/_single.html.erb
@@ -44,7 +44,7 @@
             <% if article.try(:show).try(:slug) == "the-frame" %>
               <%= render 'shared/widgets/the_frame_subscribe' %>
             <% else %>
-              <%= render 'shared/widgets/short_list_subscribe' %>
+              <%= render 'shared/widgets/donate' %>
             <% end %>
 
             <%= render 'shared/cwidgets/related_links', content: article %>

--- a/app/views/shared/new/_single_blog.html.erb
+++ b/app/views/shared/new/_single_blog.html.erb
@@ -46,10 +46,10 @@
             <% if article.try(:show).try(:slug) == "the-frame" %>
               <%= render 'shared/widgets/the_frame_subscribe' %>
             <% else %>
-              <%= render 'shared/widgets/short_list_subscribe' %>
+              <%= render 'shared/widgets/donate' %>
             <% end %>
 
-            <%= render 'shared/widgets/short_list_subscribe' %>
+            <%= render 'shared/widgets/donate' %>
 
             <%= render 'shared/cwidgets/related_links', content: article %>
 

--- a/app/views/shared/widgets/_donate.html.erb
+++ b/app/views/shared/widgets/_donate.html.erb
@@ -1,10 +1,10 @@
 <div class="appeal-newsletter short-list ancillary" id="appeal-newsletter">
     <div class="appeal-background">
         <div class="appeal-content">
-            <h3 class="bound appeal-heading">You're an essential part of the conversation — and we can't do it without you.</h3>
-            <p class="bound">Support KPCC for another year of honest reporting and <span style="display: inline-block;">civil discourse.</span></p>
+            <h3 class="bound appeal-heading">You care about today's news.  And you're not alone.</h3>
+            <p class="bound">Join others who support independent journalism.</p>
             <p class="bound">
-                <a class="appeal-link track-event" href=" https://scprcontribute.publicradio.org/contribute.php?refId=instoryask&askAmount=20" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="Donate CTA">Give now</a>
+                <a class="appeal-link track-event" href=" https://scprcontribute.publicradio.org/contribute.php?refId=instoryask&askAmount=20" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="Donate CTA">Give to KPCC</a>
             </p>
         </div>
     </div>

--- a/app/views/shared/widgets/_donate.html.erb
+++ b/app/views/shared/widgets/_donate.html.erb
@@ -1,0 +1,11 @@
+<div class="appeal-newsletter short-list ancillary" id="appeal-newsletter">
+    <div class="appeal-background">
+        <div class="appeal-content">
+            <h3 class="bound appeal-heading">You're an essential part of the conversation — and we can't do it without you.</h3>
+            <p class="bound">Support KPCC for another year of honest reporting and <span style="display: inline-block;">civil discourse.</span></p>
+            <p class="bound">
+                <a class="appeal-link track-event" href=" https://scprcontribute.publicradio.org/contribute.php?refId=instoryask&askAmount=20" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="Donate CTA">Give now</a>
+            </p>
+        </div>
+    </div>
+</div>

--- a/app/views/shared/widgets/_donate.html.erb
+++ b/app/views/shared/widgets/_donate.html.erb
@@ -1,7 +1,7 @@
-<div class="appeal-newsletter short-list ancillary" id="appeal-newsletter">
+<div class="appeal-newsletter donate-cta ancillary" id="appeal-donate-cta">
     <div class="appeal-background">
         <div class="appeal-content">
-            <h3 class="bound appeal-heading">You care about today's news.  And you're not alone.</h3>
+            <h3 class="bound appeal-heading appeal-heading-adaptive"><span style="display: inline-block;">You care about today's news.</span><span style="display: inline-block;">And you're not alone.</span></h3>
             <p class="bound">Join others who support independent journalism.</p>
             <p class="bound">
                 <a class="appeal-link track-event" href=" https://scprcontribute.publicradio.org/contribute.php?refId=instoryask&askAmount=20" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="Donate CTA">Give to KPCC</a>

--- a/app/views/shared/widgets/_short_list_subscribe.html.erb
+++ b/app/views/shared/widgets/_short_list_subscribe.html.erb
@@ -8,7 +8,7 @@
                 <input value="1715082578" type="hidden" name="elqSiteId"  />
                 <input name="elqCampaignId" type="hidden"  />
 
-                <input class="newsletter-email" id="field0" name="emailAddress" type="email" placeholder="email@somedomain.com"value="" />
+                <input class="newsletter-email" id="field0" name="emailAddress" type="email" placeholder="email@somedomain.com" value="" />
                 <input class="newsletter-hidden-input" name="SCPRShortList" type="checkbox" value="on"  />
                 <button type="submit" class="appeal-submit track-event" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="Short List Newsletter">Sign Up</button>
             </form>


### PR DESCRIPTION
#722 

Some CSS was added to make the CTA headline scale with the width of the page.  It would be a good idea to consider adding a convention to the style guide for accomplishing this with other headlines.  Preferably with vw units or calc(), which has an amazing amount of support now.
http://caniuse.com/#feat=calc