### PR TITLE
Add links under Support Us in masthead

### DIFF
--- a/app/assets/stylesheets/better_homepage/application.css.sass
+++ b/app/assets/stylesheets/better_homepage/application.css.sass
@@ -26,6 +26,12 @@
     @media (min-width: $media-tablet)
       margin-right: $gutter
 
+.section-current-members
+  // HACK
+  // We need this one to be a little wider on medium.
+  // This will just go away when I remake the masthead entirely.
+  @media (max-width: $media-desktop)
+    width: 17%
 
 
   li.social-links

--- a/app/assets/stylesheets/better_homepage/application.css.sass
+++ b/app/assets/stylesheets/better_homepage/application.css.sass
@@ -24,9 +24,11 @@
     font-size: 1vw
     @media only screen and (max-width: $media-desktop)
       font-size: 1.5vw
-    @media only screen and (max-width: 544px)
+    @media only screen and (max-width: 895px)
       font-size: 2vw
-    @media only screen and (max-width: $media-tablet)
+    // @media only screen and (max-width: 544px)
+    //   font-size: 2vw
+    @media only screen and (max-width: 570px)
       font-size: 3vw
     // @media(min-width: $media-desktop)
     //   font-size: 1vw

--- a/app/assets/stylesheets/better_homepage/application.css.sass
+++ b/app/assets/stylesheets/better_homepage/application.css.sass
@@ -13,7 +13,28 @@
 .c-nav__dropdown
   box-sizing: border-box
   width: 100%
-  
+
+  .c-btn
+    // HACK
+    // This keeps buttons from messing up their size on smaller screens.
+    // Consider this as part of an effort to canonicalize a way to make
+    // certain texts adaptive.
+    // @media(max-width: $media-tablet)
+    //   font-size: 3vw
+    font-size: 1vw
+    @media only screen and (max-width: $media-desktop)
+      font-size: 1.5vw
+    @media only screen and (max-width: 544px)
+      font-size: 2vw
+    @media only screen and (max-width: $media-tablet)
+      font-size: 3vw
+    // @media(min-width: $media-desktop)
+    //   font-size: 1vw
+    // @media(max-width: $media-tablet)
+    //   font-size: 2vw
+    // @media(max-width: $media-desktop)
+    //   font-size: 1vw
+
 .o-mast
   // For some reason, the masthead creates a
   // margin on sizes smaller than large,
@@ -26,14 +47,6 @@
     @media (min-width: $media-tablet)
       margin-right: $gutter
 
-.section-current-members
-  // HACK
-  // We need this one to be a little wider on medium.
-  // This will just go away when I remake the masthead entirely.
-  @media (max-width: $media-desktop)
-    width: 17%
-
-
   li.social-links
     height: 20px
     a
@@ -41,6 +54,13 @@
       &:last-child
         margin-top: 3px
         margin-left: 17px
+
+.section-current-members
+  // HACK
+  // We need this one to be a little wider on medium.
+  // This will just go away when I remake the masthead entirely.
+  @media (min-width: $media-tablet) and (max-width: $media-desktop)
+    width: 17%
 
 
 .o-header

--- a/app/views/layouts/better_homepage/_header.html.erb
+++ b/app/views/layouts/better_homepage/_header.html.erb
@@ -169,25 +169,44 @@
 
               </div>
 
-              <div class="c-nav__section l-col--lg-2 l-col--med-3 l-col--sm-6">
+              <div class="c-nav__section l-col--lg-4 l-col--med-3 l-col--sm-12">
                 <h6 class="c-nav__section-heading">Ways to Support</h6>
-                <ul class="c-list c-list--vert">
-                  <li>
-                    <a href="/support/sustaining_memberships/">Membership</a>
-                  </li>
-                  <li>
-                    <a href="/support/leadership_circle/">Leadership Circle</a>
-                  </li>
-                  <li>
-                    <a href="/support/foundations">Foundations</a>
-                  </li>
-                  <li>
-                    <a href="/support/underwriting">Corporate Sponsorship</a>
-                  </li>
-                </ul>
+                <div class="l-row l-row--sm-between">
+                  <div class="l-col--sm-6">
+                    <ul class="c-list c-list--vert">
+                      <li>
+                        <a href="/support/sustaining_memberships/">Membership</a>
+                      </li>
+                      <li>
+                        <a href="/support/leadership_circle/">Leadership Circle</a>
+                      </li>
+                      <li>
+                        <a href="/support/foundations">Foundations</a>
+                      </li>
+                      <li>
+                        <a href="/support/underwriting">Corporate Sponsorship</a>
+                      </li>
+                    </ul>
+                  </div>
+
+                  <div class="l-col--sm-6">
+                    <ul class="c-list c-list--vert">
+                      <li>
+                        <a href="/auctiondonation/">Online Auction</a>
+                      </li>
+                      <li>
+                        <a href="/support/planned_giving/">Include KPCC In Your Will</a>
+                      </li>
+                      <li>
+                        <a href="/support/stock_gifts">Make a Gift of Stock</a>
+                      </li>
+                    </ul>
+                  </div>
+
+                </div>
               </div>
 
-              <div class="c-nav__section l-col--lg-2 l-col--med-3 l-col--sm-6">
+              <div class="c-nav__section section-current-members l-col--lg-2 l-col--med-2 l-col--sm-6">
                 <h6 class="c-nav__section-heading">Current Members</h6>
                 <ul class="c-list c-list--vert">
                   <li>

--- a/app/views/layouts/better_homepage/_header.html.erb
+++ b/app/views/layouts/better_homepage/_header.html.erb
@@ -132,7 +132,7 @@
       </li>
       <li class="support-section c-nav__item c-nav__item--hover-highlight">
         <a class="c-nav__link" href="/support">Support Us</a>
-        <div class="c-nav__dropdown open text--small">
+        <div class="c-nav__dropdown text--small">
           <div class="l-container">
             <div class="l-row l-row--med-start l-row--sm-between">
               <div class="c-nav__section l-col--lg-4 l-col--med-6 l-col--sm-12">

--- a/app/views/layouts/better_homepage/_header.html.erb
+++ b/app/views/layouts/better_homepage/_header.html.erb
@@ -48,7 +48,7 @@
                   </li>
                 </ul>
               </div>
-              <div class="c-nav__section l-col--sm-4 l-col--lg-3">
+              <div class="c-nav__section l-col--sm-5 l-col--lg-3">
                 <h6 class="c-nav__section-heading">More</h6>
                 <ul class="c-list c-list--vert">
                   <li>
@@ -118,7 +118,7 @@
                   </li>
                 </ul>
               </div>
-              <div class="c-nav__section l-col--lg-3 l-col--sm-4">
+              <div class="c-nav__section l-col--lg-3 l-col--sm-5">
                 <h6 class="c-nav__section-heading">More to do in SoCal</h6>
                 <ul class="c-list c-list--vert">
                   <li>
@@ -132,7 +132,7 @@
       </li>
       <li class="support-section c-nav__item c-nav__item--hover-highlight">
         <a class="c-nav__link" href="/support">Support Us</a>
-        <div class="c-nav__dropdown text--small">
+        <div class="c-nav__dropdown open text--small">
           <div class="l-container">
             <div class="l-row l-row--med-start l-row--sm-between">
               <div class="c-nav__section l-col--lg-4 l-col--med-6 l-col--sm-12">
@@ -154,7 +154,7 @@
                     </ul>
                   </div>
 
-                  <div class="l-col--sm-6">
+                  <div class="l-col--sm-5 l-col--med-6">
                     <ul class="c-list c-list--vert">
                       <li>
                         <a href="https://scprcontribute.publicradio.org/">Renew your membership</a>
@@ -189,7 +189,7 @@
                     </ul>
                   </div>
 
-                  <div class="l-col--sm-6">
+                  <div class="l-col--sm-5 l-col--med-6">
                     <ul class="c-list c-list--vert">
                       <li>
                         <a href="/auctiondonation/">Online Auction</a>
@@ -206,7 +206,7 @@
                 </div>
               </div>
 
-              <div class="c-nav__section section-current-members l-col--lg-2 l-col--med-2 l-col--sm-6">
+              <div class="c-nav__section section-current-members l-col--lg-2 l-col--med-2 l-col--sm-8">
                 <h6 class="c-nav__section-heading">Current Members</h6>
                 <ul class="c-list c-list--vert">
                   <li>
@@ -267,7 +267,7 @@
                   </ul>
                 </div>
               </div>
-              <div class="c-nav__section l-col--med-3 l-col--sm-6">
+              <div class="c-nav__section l-col--med-3 l-col--sm-5">
                 <h6 class="c-nav__section-heading">People</h6>
                 <ul class="c-list c-list--vert">
                   <li>


### PR DESCRIPTION
#726 

I adjusted the widths of the menu columns so they are more aligned on mobile, and had to create a bit of an override on the third column in Support Us in order to prevent it from floating underneath the first two columns.  This could be a good argument for why the dropdown content should be re-implemented without using the flex grid system from the style guide, but I'll be taking a closer look at this during the unification tickets and I may be able to just do away with the override without changing the dropdown columns.

I also am adjusting the size of the text of the support buttons in the masthead so that the text doesn't widow, therefore the buttons stay uniform.