### PR TITLE
Make newsletter signup more flexible.

### DIFF
--- a/app/models/kpcc_program.rb
+++ b/app/models/kpcc_program.rb
@@ -111,6 +111,29 @@ class KpccProgram < ActiveRecord::Base
     true
   end
 
+  def safe_newsletter_form_caption
+    safe_title = ->(title){
+      if (title || "").match(/^The\s/)
+        title
+      else
+        "the #{title}"
+      end
+    }
+    if newsletter_form_caption && !newsletter_form_caption.empty?
+      newsletter_form_caption
+    else
+      "Catch up with #{safe_title.call(title)} newsletter."
+    end
+  end
+
+  def safe_newsletter_form_heading
+    if newsletter_form_heading && !newsletter_form_heading.empty?
+      newsletter_form_heading
+    else
+      "Like #{title}?"
+    end
+  end
+
   private
 
   def should_reject_quote(attributes)

--- a/app/views/outpost/kpcc_programs/_form_fields.html.erb
+++ b/app/views/outpost/kpcc_programs/_form_fields.html.erb
@@ -20,7 +20,12 @@
   <%= f.input :is_segmented, hint: "Does this program separate its episode into segments?" %>
   <%= f.input :is_featured, hint: "Whether or not this program is featured around the website" %>
   <%= f.input :audio_dir, label: "Audio directory" %>
-  <%= f.input :newsletter_form_name, label: "Newsletter form name" %>
+<% end %>
+
+<%= form_block "Newsletter Form" do %>
+  <%= f.input :newsletter_form_name, label: "Eloqua form name" %>
+  <%= f.input :newsletter_form_heading, label: "Form Heading (optional)" %>
+  <%= f.input :newsletter_form_caption, label: "Form Caption (optional)" %>
 <% end %>
 
 <%= form_block "Featured Content" do %>

--- a/app/views/shared/widgets/_program_newsletter_subscribe.html.erb
+++ b/app/views/shared/widgets/_program_newsletter_subscribe.html.erb
@@ -1,8 +1,8 @@
 <div class="appeal-newsletter short-list ancillary" id="appeal-newsletter">
     <div class="appeal-background">
         <div class="appeal-content">
-            <h3 class="bound appeal-heading">Like <%= program.try(:title) %>?</h3>
-            <p class="bound">Catch up each afternoon with <%= program.try(:title) %> newsletter.</p>
+            <h3 class="bound appeal-heading"><%= program.try(:safe_newsletter_form_heading) %></h3>
+            <p class="bound"><%= program.try(:safe_newsletter_form_caption) %></p>
             <form class="bound" method="post" name="<%= program.try(:newsletter_form_name) %>" action="https://s1715082578.t.eloqua.com/e/f2" id="form-500011" >
                 <input value="<%= program.try(:newsletter_form_name) %>" type="hidden" name="elqFormName"  />
                 <input value="1715082578" type="hidden" name="elqSiteId"  />

--- a/db/migrate/20170223223040_add_newsletter_signup_description_to_programs.rb
+++ b/db/migrate/20170223223040_add_newsletter_signup_description_to_programs.rb
@@ -1,0 +1,5 @@
+class AddNewsletterSignupDescriptionToPrograms < ActiveRecord::Migration
+  def change
+    add_column :programs_kpccprogram, :newsletter_form_caption, :string
+  end
+end

--- a/db/migrate/20170223224858_add_newsletter_form_title.rb
+++ b/db/migrate/20170223224858_add_newsletter_form_title.rb
@@ -1,0 +1,5 @@
+class AddNewsletterFormTitle < ActiveRecord::Migration
+  def change
+    add_column :programs_kpccprogram, :newsletter_form_heading, :string
+  end
+end

--- a/db/migrate/20170223225810_migrate_the_frame_form_text.rb
+++ b/db/migrate/20170223225810_migrate_the_frame_form_text.rb
@@ -1,0 +1,14 @@
+class MigrateTheFrameFormText < ActiveRecord::Migration
+  def up
+    KpccProgram.where(slug: "the-frame").first.update({
+      newsletter_form_heading: "LIKE THE FRAME?",
+      newsletter_form_caption: "Catch up each afternoon with The Frame newsletter."
+    })
+  end
+  def down
+    KpccProgram.where(slug: "the-frame").first.update({
+      newsletter_form_heading: nil,
+      newsletter_form_caption: nil
+    })
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201174631) do
+ActiveRecord::Schema.define(version: 20170223225810) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -733,22 +733,24 @@ ActiveRecord::Schema.define(version: 20170201174631) do
   add_index "program_reporters", ["program_id"], name: "index_program_reporters_on_program_id", using: :btree
 
   create_table "programs_kpccprogram", force: :cascade do |t|
-    t.string   "slug",                 limit: 255,                      null: false
-    t.string   "title",                limit: 255,                      null: false
-    t.text     "teaser",               limit: 16777215
-    t.text     "description",          limit: 16777215
-    t.string   "host",                 limit: 255
-    t.string   "airtime",              limit: 255
-    t.string   "air_status",           limit: 255,                      null: false
-    t.text     "sidebar",              limit: 16777215
-    t.boolean  "is_segmented",                          default: true,  null: false
-    t.integer  "blog_id",              limit: 4
-    t.string   "audio_dir",            limit: 255
-    t.datetime "created_at",                                            null: false
-    t.datetime "updated_at",                                            null: false
-    t.boolean  "is_featured",                           default: false, null: false
-    t.integer  "quote_id",             limit: 4
-    t.string   "newsletter_form_name", limit: 255
+    t.string   "slug",                    limit: 255,                      null: false
+    t.string   "title",                   limit: 255,                      null: false
+    t.text     "teaser",                  limit: 16777215
+    t.text     "description",             limit: 16777215
+    t.string   "host",                    limit: 255
+    t.string   "airtime",                 limit: 255
+    t.string   "air_status",              limit: 255,                      null: false
+    t.text     "sidebar",                 limit: 16777215
+    t.boolean  "is_segmented",                             default: true,  null: false
+    t.integer  "blog_id",                 limit: 4
+    t.string   "audio_dir",               limit: 255
+    t.datetime "created_at",                                               null: false
+    t.datetime "updated_at",                                               null: false
+    t.boolean  "is_featured",                              default: false, null: false
+    t.integer  "quote_id",                limit: 4
+    t.string   "newsletter_form_name",    limit: 255
+    t.string   "newsletter_form_caption", limit: 255
+    t.string   "newsletter_form_heading", limit: 255
   end
 
   add_index "programs_kpccprogram", ["air_status"], name: "index_programs_kpccprogram_on_air_status", using: :btree


### PR DESCRIPTION
Adds fields to KPCC Programs in Outpost to allow for a custom heading and caption for a newsletter signup appeal.

If the heading is left blank, the default is: 
> Like {SHOWNAME}?

If the caption is left blank, the default is:
> Catch up with the {SHOWNAME} newsletter.

The default caption will correct itself if the show name starts with "The".