### PR TITLE
Relaxed_sanitize doesn't need to happen on show titles.

### DIFF
--- a/app/views/programs/external/show.html.erb
+++ b/app/views/programs/external/show.html.erb
@@ -26,7 +26,7 @@
         <div class="span18">
           <div class="info">
             <header>
-              <h3><%= link_to relaxed_sanitize(episode.title), episode.public_path %></h3>
+              <h3><%= link_to episode.title, episode.public_path %></h3>
               <span class="byline">
                 <%= timestamp(episode.air_date) %>
               </span>


### PR DESCRIPTION
This fixes the issue with HTML entities appearing in external show titles on external program index pages.  They're not HTML, so the sanitization doesn't need to happen.