### PR TITLE
Make PijQuery homepage-compatible.

### DIFF
--- a/app/models/pij_query.rb
+++ b/app/models/pij_query.rb
@@ -63,6 +63,16 @@ class PijQuery < ActiveRecord::Base
 
   scope :with_article_includes, ->() { includes(:assets) }
 
+  alias_attribute :public_datetime, :published_at
+
+  def short_headline
+    "KPCC Asks: " + self.headline
+  end
+
+  def feature
+    nil # this model doesn't have features
+  end
+
   def publish
     self.update_attributes(status: self.class.status_id(:live))
   end


### PR DESCRIPTION
This makes PijQueries compatible with the homepage.  A few attributes needed to be aliased, as they don't completely match other ContentBase-type models.