### PR TITLE
Renders video meta tag to articles with video content

### DIFF
--- a/app/views/shared/media/components/_meta.html.erb
+++ b/app/views/shared/media/components/_meta.html.erb
@@ -1,7 +1,7 @@
 <div class="o-media__meta">
   <span class="o-media__timestamp"><%= smart_date_js public_datetime, "data-window" => "8h", "data-relative" => "2h" %></span>
   <% feature_name = feature.try(:name) %>
-  <% if ["Audio", "Slideshow"].include?(feature_name) %>
+  <% if ["Audio", "Slideshow", "Video"].include?(feature_name) %>
     <span class="o-media__label" data-media-label="<%= feature_name %>">
       <svg class="icon icon--size-sm">
         <use class="icon--line icon--color-primary" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon_line-<%= feature_name.downcase %>"></use>


### PR DESCRIPTION
- The icon lives in `public/static/images/icon_line-video.svg`
- Adding the "Video" string to the array concatenates to the path to the svg