### PR TITLE
Add context parameter to AMP audio.

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -82,6 +82,18 @@ class Article
     end
   end
 
+  def context
+    # Normally, we would use this as a "context" parameter
+    # that we provide with our audio URLs to know within
+    # what context they are being served.
+    if slug = (show || blog).try(:slug)
+      return slug
+    end
+    if original_object.class.to_s == "NewsStory"
+      "news"
+    end
+  end
+
   def to_article
     self
   end

--- a/app/views/amp/audio.html.erb
+++ b/app/views/amp/audio.html.erb
@@ -15,7 +15,7 @@
 
     <% if audio = @amp_record.audio.first %>
 
-      <% url = url_with_params(audio.url, via: 'website') %>
+      <% url = url_with_params(audio.url, via: 'website', context: @amp_record.to_article.context) %>
       <aside class="audio">
         <amp-audio width="400" height="50" src="<%= url.gsub('http:', '') %>">
           <div fallback>


### PR DESCRIPTION
Adds context query parameter to audio URLs that get played on AMP pages.  Will return "news" for news stories, or the slug for anything that has a slug like segments.