### PR TITLE
Convert references to iTunes to Apple Podcasts.

### DIFF
--- a/app/views/listen/index.html.erb
+++ b/app/views/listen/index.html.erb
@@ -19,7 +19,7 @@
             More ways to listen:&nbsp;&nbsp;
             <a href="http://www.scpr.org/iphone/" target="_blank">KPCC iPhone app</a>
             <span class="pipe">|</span>
-            <a href="http://live.scpr.org/listen.pls">MP3/iTunes</a>
+            <a href="http://live.scpr.org/listen.pls">MP3/Apple Podcasts</a>
             <span class="pipe">|</span>
             <a href="mms://kpcclive1.publicradio.org">Windows Media</a>
           </span>

--- a/app/views/outpost/external_programs/_form_fields.html.erb
+++ b/app/views/outpost/external_programs/_form_fields.html.erb
@@ -8,7 +8,7 @@
 <%= form_block "Source" do %>
   <%= f.input :source, collection: ExternalProgram::IMPORTERS.keys %>
   <%= f.input :external_id, label: "External ID", hint: ("For <a href='http://www.npr.org/api/mappingCodes.php'>NPR API</a>, for example. Leave BLANK for RSS sources.").html_safe, input_html: { class: "tiny" } %>
-  <%= f.input :podcast_url, hint: "The XML feed for the podcast. iTunes URLs will not work.", input_html: { class: "wide" } %>
+  <%= f.input :podcast_url, hint: "The XML feed for the podcast. iTunes or Apple Podcasts URLs will not work.", input_html: { class: "wide" } %>
 <% end %>
 
 <%= form_block "Who/When" do %>

--- a/app/views/outpost/podcasts/_form_fields.html.erb
+++ b/app/views/outpost/podcasts/_form_fields.html.erb
@@ -16,7 +16,7 @@
 <%= form_block "URLs" do %>
   <%= f.input :url, hint: "The URL to the supplemental material for this Podcast." %>
   <%= f.input :podcast_url, hint: "The URL to this podcast feed on the web." %>
-  <%= f.input :itunes_url, hint: "The URL to this podcast feed on iTunes." %>
+  <%= f.input :itunes_url, hint: "The URL to this podcast feed on Apple Podcasts." %>
 <% end %>
 
 <%= form_block "Content" do %>

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -20,7 +20,7 @@
           <ul>
             <% if p.itunes_url.present? %>
               <li>
-                <a href="<%= p.itunes_url %>">Subscribe via iTunes&trade;</a>
+                <a href="<%= p.itunes_url %>">Subscribe via Apple Podcasts&trade;</a>
               </li>
             <% end %>
 

--- a/app/views/programs/kpcc/_recent_episodes.html.erb
+++ b/app/views/programs/kpcc/_recent_episodes.html.erb
@@ -36,7 +36,7 @@
       <div class="prose">
         <h1>Subscribe to <%= program.title %>’s podcast, and receive every new episode, automatically, as soon as it’s released. Listen on your own time, your own way.</h1>
         <ul class="clearfix">
-          <li class="itunes"><a href="https://itunes.apple.com/us/podcast/the-frame/id911090618"><span>Subscribe via iTunes</span></a></li>
+          <li class="itunes"><a href="https://itunes.apple.com/us/podcast/the-frame/id911090618"><span>Subscribe via Apple Podcasts</span></a></li>
           <li class="any"><a href="http://www.scpr.org/podcasts/<%= program.slug %>"><span>Any podcast app (XML)</span></a></li>
         </ul>
       </div>

--- a/app/views/programs/kpcc/_recent_segments.html.erb
+++ b/app/views/programs/kpcc/_recent_segments.html.erb
@@ -36,7 +36,7 @@
         <div class="prose">
           <h1>Subscribe to <%= program.title %>’s podcast, and receive every new episode, automatically, as soon as it’s released. Listen on your own time, your own way.</h1>
           <ul class="clearfix">
-            <li class="itunes"><a href="<%= program.get_link('podcast') %>"><span>Subscribe via iTunes</span></a></li>
+            <li class="itunes"><a href="<%= program.get_link('podcast') %>"><span>Subscribe via Apple Podcasts</span></a></li>
             <li class="any"><a href="http://www.scpr.org/podcasts/<%= program.slug %>"><span>Any podcast app (XML)</span></a></li>
           </ul>
         </div>


### PR DESCRIPTION
Public strings referring to iTunes will now read as "Apple Podcasts".