### PR TITLE
GA Event Tracking for Exit Modals

### DIFF
--- a/app/assets/javascripts/event_tracking.js.coffee
+++ b/app/assets/javascripts/event_tracking.js.coffee
@@ -3,7 +3,7 @@ class scpr.EventTracking
     constructor: (@options={})->
         @parseOptions(@options)
         new scpr.EventTrackingLink($(link), @options) for link in $(@chooser)
-        
+
     parseOptions: (opts)->
         for option of opts
             @options[option] = opts[option]
@@ -48,7 +48,7 @@ class scpr.EventTracking
             @_evalString @el.attr(@attributes.label)
 
         _gapush: ->
-            category = @category() 
+            category = @category()
             action   = @action()
             label    = @label()
             # Don't send event unless we have all 3 pieces of data (which could happen if no current category is set)
@@ -74,7 +74,7 @@ class scpr.EventTracking
         constructor: (@options={})->
             @enable()
             # Register the scroll depth position the page loads at.
-            $(window).trigger("scroll.scrollDepth") 
+            $(window).trigger("scroll.scrollDepth")
         enable: ->
             # Only track if we have a category we can use
             if @options.currentCategory

--- a/app/assets/javascripts/exit-modal.js.coffee
+++ b/app/assets/javascripts/exit-modal.js.coffee
@@ -22,6 +22,8 @@ Modal = ->
 Modal.prototype.openModal = ->
   modal = $('#exit-modal')
   if !this.modalVisited
+    gaDataset = modal.data()
+    ga('send', 'event', 'Modal', 'Open Modal', gaDataset.gaModalLabel, {'nonInteraction': true});
     modal.removeClass 'exit-modal--hidden'
     modal.addClass 'exit-modal--shown'
     this.modalVisited = true
@@ -29,6 +31,8 @@ Modal.prototype.openModal = ->
 Modal.prototype.closeModal = (event) ->
   modal = $('#exit-modal')
   if event.type is 'click' or event.keyCode is 27
+    gaDataset = modal.data()
+    ga('send', 'event', 'Modal', 'Close Modal', gaDataset.gaModalLabel, {'nonInteraction': true});
     modal.removeClass 'exit-modal--shown'
     modal.addClass 'exit-modal--hidden'
 

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -96,22 +96,24 @@ class ProgramsController < ApplicationController
     @segment = ShowSegment.published.includes(:show).find(params[:id])
     @program = @kpcc_program = @segment.show
     @featured_programs = KpccProgram.where.not(id: @program.id, is_featured: false).first(4)
+    @url = request.original_url
 
-    is_pledge_time = PledgeDrive.happening?
-    pledge_time_template = view_context.render 'shared/widgets/donate.html.erb'
+    @is_pledge_time = PledgeDrive.happening?
     program_flatpage = Flatpage.visible.find_by path: 'exit-modal/' + @program.slug
     default_flatpage = Flatpage.visible.find_by path: 'exit-modal/default'
 
-    if is_pledge_time
-      @pledge = pledge_time_template
+    if @is_pledge_time
+      @google_analytics_label = 'Modal Type: Pledge Drive | URL: ' + @url
     elsif program_flatpage
       @modal = program_flatpage
       @form_name = @program.newsletter_form_name
       @form_id = 'form-500011'
+      @google_analytics_label = 'Modal Type: ' + @modal.title + ' | URL: ' + @url
     elsif default_flatpage
       @modal = default_flatpage
       @form_name = 'copyOfSCPR20130130BreakingNewsSignUp-1431032392145'
       @form_id = 'form725'
+      @google_analytics_label = 'Modal Type: ' + @modal.title + ' | URL: ' + @url
     end
 
     # check whether this is the correct URL for the segment

--- a/app/views/programs/kpcc/segment.html.erb
+++ b/app/views/programs/kpcc/segment.html.erb
@@ -35,8 +35,8 @@
       articles: @popular_articles.first(4),
       header: 'Popular Now on KPCC' %>
 <% end %>
-<% if @modal || @pledge %>
-  <div id='exit-modal' class='exit-modal--hidden'>
+<% if @modal || @is_pledge_time %>
+  <div id='exit-modal' class='exit-modal--hidden' data-ga-modal-label="<%= @google_analytics_label %>">
     <div class='exit-modal__underlay'></div>
       <div class='exit-modal__modal'>
         <span class='exit-modal__close-button'>X</span>
@@ -44,7 +44,19 @@
           <% if @modal %>
             <%= @modal.content.html_safe %>
           <% end %>
-          <%= @pledge %>
+          <% if @is_pledge_time %>
+            <div class="appeal-newsletter donate-cta ancillary" id="appeal-donate-cta">
+                <div class="appeal-background">
+                    <div class="appeal-content">
+                        <h3 class="bound appeal-heading appeal-heading-adaptive"><span style="display: inline-block;">You care about today's news.</span><span style="display: inline-block;">And you're not alone.</span></h3>
+                        <p class="bound">Join others who support independent journalism.</p>
+                        <p class="bound">
+                            <a class="appeal-link track-event" id="ga-modal__submit" href=" https://scprcontribute.publicradio.org/contribute.php?refId=instoryask&askAmount=20" data-ga-category="Modal" data-ga-action="Click" data-ga-label="<%= @google_analytics_label %>">Give to KPCC</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+          <% end %>
         </div>
         <% if @form_name %>
           <form class="bound exit-modal__form" method="post" name="<%= @form_name %>" action="https://s1715082578.t.eloqua.com/e/f2" id="<%= @form_id %>" >
@@ -54,7 +66,7 @@
 
               <input class="newsletter-email exit-modal__form--center" id="field0" name="emailAddress" type="email" placeholder="email@somedomain.com" value="" />
               <input class="newsletter-hidden-input" type="checkbox" value="on"  />
-              <button type="submit" class="appeal-submit track-event exit-modal__form--center" data-ga-category="Article" data-ga-action="Subscribe" data-ga-label="<%= @program.title %>">Sign Up</button>
+              <button type="submit" id="ga-modal__submit" class="appeal-submit track-event exit-modal__form--center" data-ga-category="Modal" data-ga-action="Subscribe" data-ga-label="<%= @google_analytics_label %> | Subscription: <%= @program.title %>">Sign Up</button>
           </form>
         <% end %>
     </div>


### PR DESCRIPTION
Now sends GA events for the following triggers:
- Open Modal
- Close Modal
- Subscribe (for Short List or Frame modals)
- Click (for Pledge Drive modals)

Each event includes a label with the following format:
`{Modal Type} | {URL} | {optional: Subscription}`

Example events:
Category: `Modal`
Action: `Open Modal`
Label: `Modal Type: The Frame Exit Modal | URL: http://localhost:3000/programs/the-frame/2017/02/18/55164/a-new-study-puts-some-numbers-to-hollywood-s-issue/`

Category: `Modal`
Action: `Subscribe`
Label: `Modal Type: The Frame Exit Modal | URL: http://localhost:3000/programs/the-frame/2017/02/18/55164/a-new-study-puts-some-numbers-to-hollywood-s-issue/ | Subscription: The Frame`

The result on Google Analytics looks like this:
<img src='http://i.imgur.com/Qr8IALT.png' />