### PR TITLE
Escape character that was raising warning in a regex matcher.

### DIFF
--- a/app/filters/filter/amp_filter.rb
+++ b/app/filters/filter/amp_filter.rb
@@ -75,7 +75,7 @@ module Filter
               </amp-youtube>
             }
           when 'instagram'
-            id_matcher = /(?:(?:http|https):\/\/)?(?:www.)?(?:instagram.com|instagr.am)\/p\/(?<shortcode>[A-Za-z0-9-_]+)/i
+            id_matcher = /(?:(?:http|https):\/\/)?(?:www.)?(?:instagram.com|instagr.am)\/p\/(?<shortcode>[A-Za-z0-9\-_]+)/i
             shortcode    = (node['href'] || "").match(id_matcher).try(:[], :shortcode)
             node.replace construct_tag  %{
               <amp-instagram


### PR DESCRIPTION
Fixes this minor issue:

```
/scpr/scprv4_production/releases/20170425174000/app/filters/filter/amp_filter.rb:78: warning: character class has '-' without escape
```