### PR TITLE
Renders image tags in AMP pages, re-applies styling

### DIFF
--- a/app/assets/stylesheets/amp/application.css.sass
+++ b/app/assets/stylesheets/amp/application.css.sass
@@ -23,7 +23,7 @@ amp-img.grey-placeholder
 
 #inline-deps
   display: none
-      
+
 header
   @include amp-center-column
   padding-bottom: 10px
@@ -71,3 +71,55 @@ main
 
 footer
   margin-top: 25px
+
+ul
+  list-style-type: disc
+  list-style-position: inside
+
+ol
+  list-style-type: decimal
+  list-style-position: inside
+
+ul ul, ol ul
+  list-style-type: circle
+  list-style-position: inside
+
+ol ol, ul ol
+  list-style-type: lower-latin
+  list-style-position: inside
+
+.kpcc-table
+  width: 100%
+  th
+    border-top: 1px solid orange
+    background: #f5f5f5
+    text-transform: uppercase
+    border-bottom: 1px solid rgba(0,0,0,0.4)
+    font-weight: 700
+    vertical-align: bottom
+    font-size: 0.6875em
+    padding: 20px 14px 9px 5px
+    line-height: 1
+    color: rgba(0,0,0,0.4)
+    box-shadow: inset 0 -4px 0 #e8e8e8
+
+  td
+    font-size: 0.725em
+    line-height: 1.1
+    padding: 10px 14px 10px 5px
+    vertical-align: top
+    border-bottom: 1px solid rgba(0,0,0,0.3)
+    box-shadow: inset -1px 0 0 rgba(0,0,0,0.07)
+    mark
+      text-transform: uppercase
+      color: orange
+      margin-bottom: 4px
+      font-weight: 700
+      display: none
+
+  tr
+    td:first-child
+      mark
+        display: none
+    td:last-child
+      box-shadow: none

--- a/app/concerns/concern/controller/amp.rb
+++ b/app/concerns/concern/controller/amp.rb
@@ -36,8 +36,8 @@ module Concern
             template: "amp/default",
             layout: "application.amp.erb",
             content_security_policy: [
-              "default-src *", 
-              "script-src *", 
+              "default-src *",
+              "script-src *",
               "style-src * 'unsafe-inline'",
               "img-src * data:",
               "font-src *"
@@ -63,7 +63,7 @@ module Concern
 
         def _expose exposures, ctrlr
           # This allows us to shoehorn variables and methods
-          # from the host controller into locals available 
+          # from the host controller into locals available
           # to the AMP view.
           exposed = {}
           exposures.each do |k, v|
@@ -118,8 +118,8 @@ module Concern
           unless defined? pipeline_filter
             define_method :pipeline_filter do |record|
               pipeline = ::HTML::Pipeline.new([
-                Filter::CleanupFilter, 
-                # Filter::EmbeditorFilter, 
+                Filter::CleanupFilter,
+                # Filter::EmbeditorFilter,
                 Filter::InlineAssetsFilter,
                 Filter::AmpFilter
                 ], content: record)

--- a/app/filters/filter/amp_filter.rb
+++ b/app/filters/filter/amp_filter.rb
@@ -2,12 +2,10 @@ module Filter
   class AmpFilter < HTML::Pipeline::Filter
     TAG_MAPPINGS = {
       'img' => lambda { |img|
-        if img['data-width'] && img['data-height']
+        if img['width'] && img['height']
           img.name = "amp-img"
           img['layout'] = 'responsive'
           img['srcset'] = img['src']
-          img['width']  = img['data-width']
-          img['height'] = img['data-height']
           figstring = "<figure>#{img.to_s}"
           if caption = img.attribute('alt') ? img.attribute('alt').value : nil
             figstring += "<figcaption class='media__caption text--light'>#{caption}</figcaption>"
@@ -44,7 +42,7 @@ module Filter
       },
       'a' => lambda { |node|
         # Twitter embeds use script tags, which is not supported
-        # by AMP.  Thus, they have to be converted to a custom 
+        # by AMP.  Thus, they have to be converted to a custom
         # tag that can be understood by the Twitter AMP plugin.
         if node['class'] == "embed-placeholder"
           case node['data-service']
@@ -84,7 +82,7 @@ module Filter
                   height="400"
                   layout="responsive">
               </amp-instagram>
-            }            
+            }
           end
         end
       }
@@ -107,7 +105,7 @@ module Filter
       @tags = %w(a em p span h1 h2 h3 h4 h5 h6 div strong s u br blockquote)
       doc.traverse do |node|
         scrub node
-      end      
+      end
     end
     def scrub node
       if node.name.in?(TAG_MAPPINGS.keys)


### PR DESCRIPTION
The spec for AMP images have changed from `data-width` and `data-height` to just requiring a `width` and `height` property.

Styles were added to `amp/application.css.sass`