### PR TITLE
Remove old parse push notification code from breaking news alerts.

### DIFF
--- a/spec/models/breaking_news_alert_spec.rb
+++ b/spec/models/breaking_news_alert_spec.rb
@@ -27,7 +27,7 @@ describe BreakingNewsAlert do
 
   describe '#publish_mobile_notification' do
     before :each do
-      stub_request(:post, /(api\.parse\.com)|(onesignal\.com)/)
+      stub_request(:post, /(onesignal\.com)/)
       .to_return(body: { result: true }.to_json)
     end
 


### PR DESCRIPTION
Removes the Parse push notification code and handles OneSignal errors.