### PR TITLE
Add some new endpoints for settings and members.

### DIFF
--- a/app/controllers/api/public/v3/members_controller.rb
+++ b/app/controllers/api/public/v3/members_controller.rb
@@ -1,0 +1,12 @@
+module Api::Public::V3
+  class MembersController < BaseController
+    def show
+      if !params[:id] || !(@member = Member.where(pledge_token: params[:id]).first)
+        render_not_found and return false
+      end
+
+      respond_with @member
+    end
+  end
+end
+

--- a/app/controllers/api/public/v3/settings_controller.rb
+++ b/app/controllers/api/public/v3/settings_controller.rb
@@ -1,0 +1,19 @@
+module Api::Public::V3
+  class SettingsController < BaseController
+
+    before_filter :get_context, only: [:index]
+
+    def index
+      @settings = Setting.where(context: @context).where.not(context: nil)
+      if @context == "global"
+        @pledge_drive = PledgeDrive.happening.order("starts_at DESC").first
+      end
+      respond_with @settings
+    end
+
+  private
+    def get_context
+      @context = params[:context] || "global"
+    end
+  end
+end

--- a/app/controllers/api/public/v3/settings_controller.rb
+++ b/app/controllers/api/public/v3/settings_controller.rb
@@ -1,19 +1,11 @@
 module Api::Public::V3
   class SettingsController < BaseController
 
-    before_filter :get_context, only: [:index]
-
     def index
-      @settings = Setting.where(context: @context).where.not(context: nil)
-      if @context == "global"
-        @pledge_drive = PledgeDrive.happening.order("starts_at DESC").first
-      end
+      @settings = Setting.where(context: [params[:context], 'global']).where.not(context: nil)
+      @pledge_drive = PledgeDrive.happening.order("starts_at DESC").first
       respond_with @settings
     end
-
-  private
-    def get_context
-      @context = params[:context] || "global"
-    end
+    
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,3 @@
+class Member < ActiveRecord::Base
+  validates :pledge_token, presence: true
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,3 @@
+class Setting < ActiveRecord::Base
+  serialize :value, JSON
+end

--- a/app/views/api/public/v3/members/_member.json.jbuilder
+++ b/app/views/api/public/v3/members/_member.json.jbuilder
@@ -1,0 +1,16 @@
+json.cache! [Api::Public::V3::VERSION, "v1", member] do
+  # json.email          member.email
+  # json.email_sent     member.email_sent
+  # json.first_name     member.first_name
+  # json.last_name      member.last_name
+  json.member_id      member.member_id
+  # json.name           member.name
+  json.pfs_selected   member.pfs_selected
+  # json.pledge_amount  member.pledge_amount
+  json.pledge_id      member.pledge_id
+  json.pledge_token   member.pledge_token
+  # json.pledge_type    member.pledge_type
+  # json.record_source  member.record_source
+  json.views_left     member.views_left
+end
+

--- a/app/views/api/public/v3/members/show.json.jbuilder
+++ b/app/views/api/public/v3/members/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! api_view_path("shared", "meta")
+
+json.member do
+  json.partial! api_view_path("members", "member"), member: @member
+end

--- a/app/views/api/public/v3/settings/index.json.jbuilder
+++ b/app/views/api/public/v3/settings/index.json.jbuilder
@@ -1,0 +1,13 @@
+json.partial! api_view_path("shared", "meta")
+
+json.settings do
+  @settings.each do |setting|
+    json.set! setting.key, setting.value
+  end
+  if @pledge_drive
+    json.pledge_drive do
+      json.starts_at @pledge_drive.starts_at
+      json.ends_at @pledge_drive.ends_at
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ Scprv4::Application.routes.draw do
         resources :editions, only: [:index, :show]
         resources :categories, only: [:index, :show]
         resources :events, only: [:index, :show]
+        resources :members, only: [:show]
         resources :programs, only: [:index, :show]
         resources :buckets, only: [:index, :show]
         resources :episodes, only: [:index, :show]
@@ -198,6 +199,9 @@ Scprv4::Application.routes.draw do
         resources :data_points, only: [:index, :show]
         resources :tags, only: [:index, :show]
         resources :lists, only: [:index, :show]
+
+        get "settings" => "settings#index"
+        get "settings/:context" => "settings#index"
 
         get "programs/:id/episodes/archive/:year/:month" => "archive_browser#index"
         get "programs/:id/histogram"                => "programs#histogram"

--- a/db/migrate/20170522185650_create_members.rb
+++ b/db/migrate/20170522185650_create_members.rb
@@ -1,0 +1,21 @@
+class CreateMembers < ActiveRecord::Migration
+  def change
+    create_table :members do |t|
+      t.string :email, index: true
+      t.boolean :email_sent
+      t.string :first_name
+      t.string :last_name
+      t.string :name
+      t.boolean :pfs_selected
+      t.integer :pledge_amount
+      t.string :pledge_id
+      t.string :pledge_token, index: true
+      t.string :pledge_type
+      t.string :record_source
+      t.integer :views_left
+      t.string :member_id, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170522202220_create_settings.rb
+++ b/db/migrate/20170522202220_create_settings.rb
@@ -1,0 +1,11 @@
+class CreateSettings < ActiveRecord::Migration
+  def change
+    create_table :settings do |t|
+      t.string :key
+      t.string :context
+      t.string :value
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170414235404) do
+ActiveRecord::Schema.define(version: 20170522202220) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -624,6 +624,28 @@ ActiveRecord::Schema.define(version: 20170414235404) do
   add_index "media_related", ["content_id", "content_type"], name: "index_media_related_on_content_id_and_content_type", using: :btree
   add_index "media_related", ["related_id", "related_type"], name: "index_media_related_on_related_id_and_related_type", using: :btree
 
+  create_table "members", force: :cascade do |t|
+    t.string   "email",         limit: 255
+    t.boolean  "email_sent"
+    t.string   "first_name",    limit: 255
+    t.string   "last_name",     limit: 255
+    t.string   "name",          limit: 255
+    t.boolean  "pfs_selected"
+    t.integer  "pledge_amount", limit: 4
+    t.string   "pledge_id",     limit: 255
+    t.string   "pledge_token",  limit: 255
+    t.string   "pledge_type",   limit: 255
+    t.string   "record_source", limit: 255
+    t.integer  "views_left",    limit: 4
+    t.string   "member_id",     limit: 255
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "members", ["email"], name: "index_members_on_email", using: :btree
+  add_index "members", ["member_id"], name: "index_members_on_member_id", using: :btree
+  add_index "members", ["pledge_token"], name: "index_members_on_pledge_token", using: :btree
+
   create_table "news_story", force: :cascade do |t|
     t.string   "headline",         limit: 255
     t.string   "slug",             limit: 255
@@ -868,6 +890,14 @@ ActiveRecord::Schema.define(version: 20170414235404) do
   add_index "schedule_occurrences", ["starts_at", "ends_at"], name: "index_schedule_occurrences_on_starts_at_and_ends_at", using: :btree
   add_index "schedule_occurrences", ["starts_at"], name: "index_schedule_occurrences_on_starts_at", using: :btree
   add_index "schedule_occurrences", ["updated_at"], name: "index_schedule_occurrences_on_updated_at", using: :btree
+
+  create_table "settings", force: :cascade do |t|
+    t.string   "key",        limit: 255
+    t.string   "context",    limit: 255
+    t.string   "value",      limit: 255
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+  end
 
   create_table "shows_episode", force: :cascade do |t|
     t.integer  "show_id",             limit: 4,                          null: false


### PR DESCRIPTION
The concepts of **settings** and **members** have been added to SCPRv4.  The member table schema reflects that of what we currently store in Parse, although the column names are snake-case.  

Settings have a **key**, **value**, and **context**.  Context can be used to store settings for specific environments like iOS.  The default context is **global**.  The value is always JSON.

`/api/v3/settings` Returns global settings.  This will also include information about the current pledge drive if there is one.
`/api/v3/settings/:context` Returns a settings object for a specific context.


`/api/v3/members/:token` Returns a single member for the provided token.  Currently returns very limited information for an existing member, or a 404 response if a member is not found.