### PR TITLE
Add flash briefing endpoint for homepage content.

### DIFF
--- a/app/jobs/job/better_homepage_cache.rb
+++ b/app/jobs/job/better_homepage_cache.rb
@@ -6,10 +6,14 @@ module Job
 
       def perform
         homepage  = ::BetterHomepage.current.last
+        cache_articles homepage
         cache_contents homepage
         cache_right_asides homepage
       end
     private
+      def cache_articles homepage
+        Rails.cache.write "homepage/articles", homepage.content_articles
+      end
       def cache_contents homepage
         @homepage = homepage
         return if !homepage

--- a/app/models/better_homepage.rb
+++ b/app/models/better_homepage.rb
@@ -68,7 +68,7 @@ class BetterHomepage < ActiveRecord::Base
     ## This converts homepage content to 
     ## articles and includes the asset display
     ## scheme with it.
-    content.includes(:content).map do |c| 
+    @content_articles ||= content.includes(:content).map do |c| 
       article               = c.content.get_article
       article.asset_scheme  = c.asset_scheme
       article

--- a/app/views/feeds/flash_briefing.json.jbuilder
+++ b/app/views/feeds/flash_briefing.json.jbuilder
@@ -1,6 +1,6 @@
 json.array! @content do |content|
   json.uid  content.public_url
-  json.updateDate Time.zone.now
+  json.updateDate content.public_datetime
   json.titleText content.title
   json.mainText content.teaser
   if audio = (content.audio || []).first

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Scprv4::Application.routes.draw do
   get '/feeds/all_news'        => 'feeds#all_news',    as: :all_news_feed
   get '/feeds/take_two'        => 'feeds#take_two',    as: :take_two_feed # Deprecated, delete once replaced with npr_ingest
   get '/feeds/npr_ingest'      => 'feeds#npr_ingest',  as: :npr_ingest_feed
+  get '/feeds/flash_briefing'  => 'feeds#flash_briefing'
   get '/feeds/flash_briefing/:category' => 'feeds#flash_briefing'
   get '/feeds/*feed_path', to: redirect { |params, request| "/#{params[:feed_path]}.xml" }
 


### PR DESCRIPTION
This will allow the flash briefing to be derived from homepage content.  For now, I will leave the category endpoints in place.