### PR TITLE
Change protocol for disqus script import

### DIFF
--- a/app/views/shared/cwidgets/_comments.html.erb
+++ b/app/views/shared/cwidgets/_comments.html.erb
@@ -15,7 +15,7 @@
                 /* * * DON'T EDIT BELOW THIS LINE * * */
                 (function() {
                     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                    dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                 })();
             </script>


### PR DESCRIPTION
Quick fix that re-enables Disqus comments for post pages

Would it have been better to use '//' instead of explicitly stating the protocol 'https://'?

Examples:
- Broken: https://www.scpr.org/programs/take-two/2016/02/05/46208/do-female-democrats-feel-torn-between-clinton-and/
- Fixed: https://scprv4-staging.scprdev.org/programs/take-two/2016/02/05/46208/do-female-democrats-feel-torn-between-clinton-and/