### PR TITLE
Add fields to programs api

### DIFF
--- a/app/views/api/public/v3/programs/_program.json.jbuilder
+++ b/app/views/api/public/v3/programs/_program.json.jbuilder
@@ -1,12 +1,14 @@
 json.cache! [Api::Public::V3::VERSION, "v1", program] do
-  json.title          program.title
-  json.slug           program.slug
-  json.air_status     program.air_status
-  json.twitter_handle program.get_link('twitter') if program.get_link('twitter').present?
+  json.title            program.title
+  json.slug             program.slug
+  json.air_status       program.air_status
+  json.twitter_handle   program.get_link('twitter') if program.get_link('twitter').present?
 
-  json.host         program.host
-  json.airtime      program.airtime
-  json.description  program.description.to_s.html_safe
+  json.host             program.host
+  json.airtime          program.airtime
+  json.description      program.description.to_s.html_safe
+  json.description_text program.description_text
+  json.phone_number     program.phone_number
 
   json.podcast_url(program.podcast_url) if program.podcast_url.present?
   json.rss_url(program.rss_url) if program.rss_url.present?

--- a/app/views/outpost/external_programs/_form_fields.html.erb
+++ b/app/views/outpost/external_programs/_form_fields.html.erb
@@ -3,6 +3,8 @@
   <%= f.section "slug" %>
   <%= f.input :teaser, as: :string, hint: "Shown on summary/list pages that reference the program. Keep it to a sentence or so.", input_html: { class: "wide" } %>
   <%= f.input :description, hint: "Shown on the program's page. Be as descriptive as you like (hosts, topics, staff, etc.)", input_html: { class: "tiny" } %>
+  <%= f.input :description_text, hint: "Shown in the mobile app.  Similar to the teaser, but should not contain any phone numbers or emails.", input_html: { class: "wide" } %>
+  <%= f.input :phone_number, hint: "Shown in the mobile app.  The phone number to contact the show." %>
 <% end %>
 
 <%= form_block "Source" do %>

--- a/app/views/outpost/external_programs/_form_fields.html.erb
+++ b/app/views/outpost/external_programs/_form_fields.html.erb
@@ -4,7 +4,7 @@
   <%= f.input :teaser, as: :string, hint: "Shown on summary/list pages that reference the program. Keep it to a sentence or so.", input_html: { class: "wide" } %>
   <%= f.input :description, hint: "Shown on the program's page. Be as descriptive as you like (hosts, topics, staff, etc.)", input_html: { class: "tiny" } %>
   <%= f.input :description_text, hint: "Shown in the mobile app.  Similar to the teaser, but should not contain any phone numbers or emails.", input_html: { class: "wide" } %>
-  <%= f.input :phone_number, hint: "Shown in the mobile app.  The phone number to contact the show." %>
+  <%= f.input :phone_number, hint: "Shown in the mobile app.  The phone number for listeners to contact the show." %>
 <% end %>
 
 <%= form_block "Source" do %>

--- a/app/views/outpost/kpcc_programs/_form_fields.html.erb
+++ b/app/views/outpost/kpcc_programs/_form_fields.html.erb
@@ -3,6 +3,8 @@
   <%= f.section "slug" %>
   <%= f.input :teaser, as: :string, hint: "Shown on summary/list pages that reference the program. Keep it to a sentence or so.", input_html: { class: "wide" } %>
   <%= f.input :description, hint: "Shown on the program's page. Be as descriptive as you like (hosts, topics, staff, etc.)", input_html: { class: "tiny" } %>
+  <%= f.input :description_text, hint: "Shown in the mobile app.  Similar to the teaser, but should not contain any phone numbers or emails.", input_html: { class: "wide" } %>
+  <%= f.input :phone_number, hint: "Shown in the mobile app.  The phone number to contact the show." %>
 <% end %>
 
 <%= form_block "Who/When" do %>

--- a/app/views/outpost/kpcc_programs/_form_fields.html.erb
+++ b/app/views/outpost/kpcc_programs/_form_fields.html.erb
@@ -4,7 +4,7 @@
   <%= f.input :teaser, as: :string, hint: "Shown on summary/list pages that reference the program. Keep it to a sentence or so.", input_html: { class: "wide" } %>
   <%= f.input :description, hint: "Shown on the program's page. Be as descriptive as you like (hosts, topics, staff, etc.)", input_html: { class: "tiny" } %>
   <%= f.input :description_text, hint: "Shown in the mobile app.  Similar to the teaser, but should not contain any phone numbers or emails.", input_html: { class: "wide" } %>
-  <%= f.input :phone_number, hint: "Shown in the mobile app.  The phone number to contact the show." %>
+  <%= f.input :phone_number, hint: "Shown in the mobile app.  The phone number for listeners to contact the show." %>
 <% end %>
 
 <%= form_block "Who/When" do %>

--- a/db/migrate/20170810193354_add_description_text_and_phone_number_to_programs.rb
+++ b/db/migrate/20170810193354_add_description_text_and_phone_number_to_programs.rb
@@ -1,6 +1,8 @@
 class AddDescriptionTextAndPhoneNumberToPrograms < ActiveRecord::Migration
   def change
     add_column :programs_kpccprogram, :description_text, :text
-    add_column :programs_kpccprogram, :phone_number, :string
+    add_column :programs_kpccprogram, :phone_number,     :string
+    add_column :external_programs,    :description_text, :text
+    add_column :external_programs,    :phone_number,     :string
   end
 end

--- a/db/migrate/20170810193354_add_description_text_and_phone_number_to_programs.rb
+++ b/db/migrate/20170810193354_add_description_text_and_phone_number_to_programs.rb
@@ -1,8 +1,8 @@
 class AddDescriptionTextAndPhoneNumberToPrograms < ActiveRecord::Migration
   def change
-    add_column :programs_kpccprogram, :description_text, :text
+    add_column :programs_kpccprogram, :description_text, :string
     add_column :programs_kpccprogram, :phone_number,     :string
-    add_column :external_programs,    :description_text, :text
+    add_column :external_programs,    :description_text, :string
     add_column :external_programs,    :phone_number,     :string
   end
 end

--- a/db/migrate/20170810193354_add_description_text_and_phone_number_to_programs.rb
+++ b/db/migrate/20170810193354_add_description_text_and_phone_number_to_programs.rb
@@ -1,0 +1,6 @@
+class AddDescriptionTextAndPhoneNumberToPrograms < ActiveRecord::Migration
+  def change
+    add_column :programs_kpccprogram, :description_text, :text
+    add_column :programs_kpccprogram, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -456,7 +456,7 @@ ActiveRecord::Schema.define(version: 20170810193354) do
     t.string   "source",           limit: 255
     t.integer  "external_id",      limit: 4
     t.integer  "days_to_expiry",   limit: 4
-    t.text     "description_text", limit: 65535
+    t.string   "description_text", limit: 255
     t.string   "phone_number",     limit: 255
   end
 
@@ -810,7 +810,7 @@ ActiveRecord::Schema.define(version: 20170810193354) do
     t.string   "newsletter_form_name",    limit: 255
     t.string   "newsletter_form_caption", limit: 255
     t.string   "newsletter_form_heading", limit: 255
-    t.text     "description_text",        limit: 65535
+    t.string   "description_text",        limit: 255
     t.string   "phone_number",            limit: 255
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721211001) do
+ActiveRecord::Schema.define(version: 20170810193354) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -441,21 +441,23 @@ ActiveRecord::Schema.define(version: 20170721211001) do
   add_index "external_episodes", ["external_program_id", "external_id"], name: "index_external_episodes_on_external_program_id_and_external_id", using: :btree
 
   create_table "external_programs", force: :cascade do |t|
-    t.string   "slug",           limit: 255,      null: false
-    t.string   "title",          limit: 255,      null: false
-    t.text     "teaser",         limit: 16777215
-    t.text     "description",    limit: 16777215
-    t.string   "host",           limit: 255
-    t.string   "organization",   limit: 50
-    t.string   "airtime",        limit: 255
-    t.string   "air_status",     limit: 255,      null: false
-    t.string   "podcast_url",    limit: 255
-    t.text     "sidebar",        limit: 16777215
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "source",         limit: 255
-    t.integer  "external_id",    limit: 4
-    t.integer  "days_to_expiry", limit: 4
+    t.string   "slug",             limit: 255,      null: false
+    t.string   "title",            limit: 255,      null: false
+    t.text     "teaser",           limit: 16777215
+    t.text     "description",      limit: 16777215
+    t.string   "host",             limit: 255
+    t.string   "organization",     limit: 50
+    t.string   "airtime",          limit: 255
+    t.string   "air_status",       limit: 255,      null: false
+    t.string   "podcast_url",      limit: 255
+    t.text     "sidebar",          limit: 16777215
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.string   "source",           limit: 255
+    t.integer  "external_id",      limit: 4
+    t.integer  "days_to_expiry",   limit: 4
+    t.text     "description_text", limit: 65535
+    t.string   "phone_number",     limit: 255
   end
 
   add_index "external_programs", ["air_status"], name: "index_external_programs_on_air_status", using: :btree
@@ -808,6 +810,8 @@ ActiveRecord::Schema.define(version: 20170721211001) do
     t.string   "newsletter_form_name",    limit: 255
     t.string   "newsletter_form_caption", limit: 255
     t.string   "newsletter_form_heading", limit: 255
+    t.text     "description_text",        limit: 65535
+    t.string   "phone_number",            limit: 255
   end
 
   add_index "programs_kpccprogram", ["air_status"], name: "index_programs_kpccprogram_on_air_status", using: :btree

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     ports:
       - 9200:9200/tcp
       - 9300:9300/tcp
+      - 9250:9250/tcp
     volumes:
       - elasticsearch-data:/var/lib/elasticsearch
     networks:

--- a/spec/controllers/api/public/v3/programs_controller_spec.rb
+++ b/spec/controllers/api/public/v3/programs_controller_spec.rb
@@ -15,6 +15,27 @@ describe Api::Public::V3::ProgramsController do
       response.should render_template "show"
     end
 
+    it "should return description_text if that has been provided" do
+      description_text = 'bloop bloop bleep bleep'
+      program = create :kpcc_program,
+                       slug: 'hello',
+                       description: 'long description here',
+                       description_text: description_text
+
+      get :show, { id: program.slug }.merge(request_params)
+      JSON.parse(response.body)["program"]["description_text"].should eq description_text
+    end
+
+    it "should return a phone number if that has been provided" do
+      number = '5555551234'
+      program = create :kpcc_program,
+                       slug: 'hello',
+                       phone_number: number
+
+      get :show, { id: program.slug }.merge(request_params)
+      JSON.parse(response.body)["program"]["phone_number"].should eq number
+    end
+
     it "returns a 404 status if it does not exist" do
       get :show, { id: "nonono" }.merge(request_params)
       response.response_code.should eq 404


### PR DESCRIPTION
Adds `description_text` and `phone_number` to KPCC programs and external programs in the API and Outpost.