### PR TITLE
Enable article gtm

### DIFF
--- a/app/assets/javascripts/new/single.js
+++ b/app/assets/javascripts/new/single.js
@@ -258,7 +258,8 @@ scpr.Behaviors.Single = {
               elements: ['#appeal-newsletter'],
               percentage: false,
               userTiming: false,
-              pixelDepth: false
+              pixelDepth: false,
+              gtmOverride: true
             });
         }
 

--- a/app/views/shared/new/_document_header.html.erb
+++ b/app/views/shared/new/_document_header.html.erb
@@ -1,13 +1,12 @@
 <head>
-    <!-- <script>
+    <script>
       dataLayer = [{
         'storyId': '<%= @story.try(:id) %>',
         'storyShortHeadline': '<%= @story.try(:short_headline) %>',
         'storyByline': '<%= @story.try(:byline) %>'
       }];
-      console.log('dataLayer', dataLayer);
     </script>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-585PL29');</script> -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-585PL29');</script>
     <% add_to_page_title @TITLE_ELEMENTS.present? ? "89.3 KPCC" : "89.3 KPCC - Southern California Public Radio" %>
 
     <title><%= page_title %></title>


### PR DESCRIPTION
This snippet enables Google Tag Manager in article pages and retains scroll depth functionality.

It was previously disabled because our scroll depth script (which reports when a user's viewport reaches a subscription sign up) would no longer send events if GTM was enabled. However, there was a nice option I found called `gtmOverride` that when set to true will allow you to continue to send the custom scroll events regardless. Was tested for a couple of days last sprint and confirmed to work via @patrickdougall.