### PR TITLE
Only tries to regex if node['src'] is a string

### DIFF
--- a/app/filters/filter/amp_filter.rb
+++ b/app/filters/filter/amp_filter.rb
@@ -36,8 +36,9 @@ module Filter
         node['async'] = true
         # protocol-less urls are now an anti-pattern
         # and need to have an explicit protocol
-        if node['src'].match(/^\/\//)
-          node['src'] = "http:#{node['src']}"
+
+        if node['src'].try(:match, /^\/\//)
+          node['src'] = "https:#{node['src']}"
         end
       },
       'a' => lambda { |node|


### PR DESCRIPTION
This should fix the 500 error for the behest amp page. Some scripts are inline scripts (which would have no `src`), so rails would raise an error that `.match` wasn't a method. In this implementation, it would only try to match if there's an actual `src`