### PR TITLE
Adds fb:pages meta tag site-wide for facebook's link ownership req

### DIFF
--- a/app/views/shared/new/_document_header.html.erb
+++ b/app/views/shared/new/_document_header.html.erb
@@ -19,6 +19,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta property="fb:app_id" content="129848480405753" />
+    <meta property="fb:pages" content="21819923015">
     <link rel="publisher" href="https://plus.google.com/108872361044769229886/" />
 
     <%= tag "meta", name: "keywords", content: meta_information[:keywords] || "KPCC, California, Southern California, Los Angeles, Pasadena, SCPR, Southern California Public Radio" %>


### PR DESCRIPTION
Adds KPCC's specific link ownership meta tag to the global header of the site. This should allow for the ability to overwrite link metadata (i.e. headline, description, image) in the Graph API or in Page composer.

The meta tag was taken from the settings of KPCC's facebook page.