### PR TITLE
Floating assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dalli'
 ## Outpost
 gem 'outpost-cms', github: "SCPR/outpost", tag: "v0.3.1"
 gem 'outpost-publishing'
-gem 'outpost-asset_host', github: "SCPR/outpost-asset_host", branch: "inline_assets"
+gem 'outpost-asset_host', github: "SCPR/outpost-asset_host"
 gem 'outpost-aggregator', github: "SCPR/outpost-aggregator", tag: "v2.1.0"
 gem 'outpost-secretary', github:"SCPR/outpost-secretary", tag:"v0.1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,7 @@ GIT
 
 GIT
   remote: git://github.com/SCPR/outpost-asset_host.git
-  revision: e11c1b929a113f6e618fc8f1950af4cfb4408a29
-  branch: inline_assets
+  revision: a2c500592bb8a3942585240763a69fc55b1479ee
   specs:
     outpost-asset_host (1.1.1)
 

--- a/app/assets/javascripts/outpost/asset_host/assethostbase.js.coffee.erb
+++ b/app/assets/javascripts/outpost/asset_host/assethostbase.js.coffee.erb
@@ -3,5 +3,5 @@
 # Setup window.assethost and grab info
 # from the Rails config
 window.assethost =
-    SERVER:      "<%= Rails.configuration.x.assethost.protocol %>://<%= Rails.configuration.x.assethost.server %>"
+    SERVER:      "<%= Rails.configuration.x.assethost.protocol || 'https'%>://<%= Rails.configuration.x.assethost.server %>"
     TOKEN:       "<%= Rails.configuration.x.assethost.read_only_token %>"

--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -81,9 +81,6 @@
     @media (max-width: $media-tablet)
       width: 100% - ($margin * 2) !important
 
-  .o-article__body .o-figure__img
-    padding-top: 100%
-
   .o-article__body iframe
     width: 100%
 

--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -27,59 +27,74 @@
   .o-article__b-rule
     display: block
 
-  p a
-    // paragraph links
-    color: $color-secondary
-
-  > ul
-    list-style: circle
-    padding-left: 3em
-    font-size: 0.9em
-    margin-bottom: 27.68px
-    li
-      margin: 1em 0
-
-  > h2
-    font-size: 22px
-    font-weight: 400
-
-  > h3:not(.o-article__title)
-    font-size: 18px
-    font-weight: 600
-    text-transform: uppercase
-
-  > h6
-    @extend .b-heading, .b-heading--h6, .b-heading--uppercase, .u-text-color--gray-warm, .b-heading--book
-    margin-bottom: 0
-
-  > .o-article__body
+  .o-article__body
     color: $color-gray-dark
     font-family: $font-sans-base
-    line-height: 30px
-    margin-bottom: $margin-in-pixels / 2
+    > *
+      line-height: 30px
+      margin-bottom: $margin-in-pixels / 2
 
-  > p:first-of-type
-    font-size: 22px
-    line-height: 30px
-    @media (max-width: $media-tablet)
-      font-size: 20px
+  .o-article__body--float-right
+    float: right
+    width: 40%
+    margin-left: 45px
+    margin-top: 45px
 
-  > p:last-of-type
-    @media (max-width: $media-tablet)
-      margin-bottom: 60px
+  .o-article__body
+    color: $color-gray-dark
+    font-family: $font-sans-base
+    > *
+      line-height: 30px
+      margin-bottom: $margin-in-pixels / 2
 
-  > blockquote
-    p
-      border-left: 6px solid $color-primary
-      padding-bottom: $margin-in-pixels / 2
-      margin-left: percentage(31/642)
-      padding-left: percentage(31/642)
+    p a
+      // paragraph links
+      color: $color-secondary
+
+    ul
+      list-style: circle
+      padding-left: 3em
+      font-size: 0.9em
+      margin-bottom: 27.68px
+      li
+        margin: 1em 0
+
+    h2
+      font-size: 22px
+      font-weight: 400
+
+    h3:not(.o-article__title)
+      font-size: 18px
+      font-weight: 600
+      text-transform: uppercase
+
+    h6
+      @extend .b-heading, .b-heading--h6, .b-heading--uppercase, .u-text-color--gray-warm, .b-heading--book
+      margin-bottom: 0
+
+    p:first-of-type
+      font-size: 22px
+      line-height: 30px
+      @media (max-width: $media-tablet)
+        font-size: 20px
+
     p:last-of-type
-      padding-bottom: 0px
+      @media (max-width: $media-tablet)
+        margin-bottom: 60px
 
-  > img.o-article__body
-    @media (max-width: $media-tablet)
-      width: 100% - ($margin * 2) !important
+    blockquote
+      p
+        border-left: 6px solid $color-primary
+        padding-bottom: $margin-in-pixels / 2
+        margin-left: percentage(31/642)
+        padding-left: percentage(31/642)
+      p:last-of-type
+        padding-bottom: 0px
+
+    > img
+      @media (max-width: $media-tablet)
+        width: 100% - ($margin * 2) !important
+
 
   .o-article__body iframe
     width: 100%
@@ -137,6 +152,9 @@
       margin-left: $margin
       margin-right: $margin
 
+    .o-article__body--float-right
+      margin-right: 10%
+
     .c-audio--horiz
       display: flex
       display: -ms-flex-box
@@ -160,3 +178,11 @@
   @media all and (max-width: $media-mobile)
     .o-featured-blogs__blog
       width: 100%
+    .o-article__body--float-right
+      float: none
+      margin: 0 auto
+      margin-bottom: 25px
+      width: 75%
+
+
+

--- a/app/cells/article/show.erb
+++ b/app/cells/article/show.erb
@@ -30,7 +30,9 @@
 </aside>
 <% end %>
 
-<%= render_body %>
+<div class="o-article__body">
+  <%= render_body %>
+</div>
 
 <footer class="contributor" style="order: 989">
   <p><%= contributing_byline %></p>

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -72,7 +72,8 @@ class ArticleCell < Cell::ViewModel
 
       ## If kpcc_only is true, only render if the owner of the asset is KPCC
       if asset && (!options[:kpcc_only] || asset.owner.try(:include?, "KPCC"))
-        rendered_asset = AssetCell.new(asset, context: context, display: display, article: model).call(:show)
+        positioning    = (asset.small.width.to_i < asset.small.height.to_i) ? "o-article__body--float-right" : ''
+        rendered_asset = AssetCell.new(asset, context: context, display: display, article: model, class: positioning).call(:show)
         placeholder.replace Nokogiri::HTML::DocumentFragment.parse(rendered_asset)
       else
         # FIXME: I'm sure there's a cleaner "delete"
@@ -84,14 +85,13 @@ class ArticleCell < Cell::ViewModel
   end
 
   def order_body doc
-    i   = 0
-    doc.css("body > *").each do |element|
+    doc.css("body > *").each_with_index do |element, i|
       element['style'] ||= ""
-      unless element['style'].scan(/order:\s(.*);/).any?
+      element['class'] ||= ""
+      unless element['style'].match(/order:\s(.*);/)# || element['class'].split(/\s+/g).include?('o-article__body')
         element['style'] = "#{element['style']}order:#{i}; height: 100%;"
-        element['class'] = 'o-article__body'
+        # element['class'] += ' o-article__body'
       end
-      i += 1
     end
   end
 

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -33,7 +33,7 @@ class AssetCell < Cell::ViewModel
 
   def aspect
     if model.small.width.to_i < model.small.height.to_i
-      "o-figure--four-by-three"
+      "o-figure--portrait"
     else
       "o-figure--widescreen"
     end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -24,7 +24,7 @@ class NewsController < ApplicationController
       redirect_to @story.public_path and return
     end
 
-    @article = @story.to_article
+    @article = @story.get_article
 
     respond_with template: "news/story"
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Scprv4::Application.configure do
   config.x.scpr.elasticsearch_host    = ENV["SCPRV4_ELASTICSEARCH_HOST"]    || "127.0.0.1:9200"
   config.x.scpr.elasticsearch_prefix  = ENV["SCPRV4_ELASTICSEARCH_PREFIX"]  || "scprv4"
 
-  default_url_options[:host]   ||= config.x.scpr.host
+  default_url_options[:host]   ||= 'localhost'
+  default_url_options[:port]   ||= 3000
   default_url_options[:protocol] = config.x.scpr.protocol = 'http'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -596,9 +596,9 @@ ActiveRecord::Schema.define(version: 20171031210028) do
     t.datetime "updated_at",                           null: false
   end
 
-  add_index "lists", ["ends_at"], name: "index_lists_on_end_time", using: :btree
+  add_index "lists", ["ends_at"], name: "index_lists_on_ends_at", using: :btree
   add_index "lists", ["published_at"], name: "index_lists_on_published_at", using: :btree
-  add_index "lists", ["starts_at"], name: "index_lists_on_start_time", using: :btree
+  add_index "lists", ["starts_at"], name: "index_lists_on_starts_at", using: :btree
   add_index "lists", ["status"], name: "index_lists_on_status", using: :btree
 
   create_table "media_audio", force: :cascade do |t|


### PR DESCRIPTION
I've tried to address the problem with portrait-shaped assets and floating them within the article body.

What I've decided to do is abandon the idea of having paragraph nodes at the same level as the rest of the main elements, and instead wrapping the article body/paragraphs within one container to maintain their size.  I chose this because, without such a container, and due to using percentages to maintain sizes, floating items in the body becomes haphazard and unpredictably shifts underneath the right-hand column at some screen sizes no matter how much finesse I add to its positioning.

The downside is that it prevents us from interleaving sidebar items within the article body, but it's a fine tradeoff because we end up with essentially the same advertisement positioning we have in the old design but we get to have better looking assets.

Here's a screenshot:
![image](https://user-images.githubusercontent.com/5193330/32399222-8938dbac-c0b1-11e7-933a-ec9ac4a3c04a.png)

On mobile:
![image](https://user-images.githubusercontent.com/5193330/32399211-7b80540e-c0b1-11e7-846f-6e83e4593efc.png)

☝️ Note that the asset is actually centered, though the white background for this preview image gives the illusion it's to the right.

What I've not addressed is the cropping caused by our figure elements being styled the way they are.  We should probably not render inline assets with the same figure styling as the lead asset and content cluster thumbnails(which need said cropping), but I first wanted to address the sizing and positioning.
