### PR TITLE
Fixes missing comments

### DIFF
--- a/app/cells/comments/show.erb
+++ b/app/cells/comments/show.erb
@@ -2,11 +2,11 @@
     <div id="disqus_thread" class="<%= options[:cssClass] %>"></div>
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = '<%= model.try(:to_article).try(:original_object).try(:disqus_shortname) %>'; // required: replace example with your forum shortname
+        var disqus_shortname = '<%= model.try(:get_article).try(:original_object).try(:disqus_shortname) %>'; // required: replace example with your forum shortname
         // The following are highly recommended additional parameters. Remove the slashes in front to use.
-        var disqus_identifier = '<%= model.try(:to_article).try(:original_object).try(:disqus_identifier) %>';
+        var disqus_identifier = '<%= model.try(:get_article).try(:original_object).try(:disqus_identifier) %>';
         var disqus_url = '<%= model.public_url %>';
-        var disqus_title = '<%= model.try(:to_article).try(:title).try(:to_json) %>';
+        var disqus_title = '<%= model.try(:get_article).try(:title).try(:to_json) %>';
 
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {

--- a/app/cells/comments/show.erb
+++ b/app/cells/comments/show.erb
@@ -2,11 +2,11 @@
     <div id="disqus_thread" class="<%= options[:cssClass] %>"></div>
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = '<%= model.try(:disqus_shortname) %>'; // required: replace example with your forum shortname
+        var disqus_shortname = '<%= model.try(:to_article).try(:original_object).try(:disqus_shortname) %>'; // required: replace example with your forum shortname
         // The following are highly recommended additional parameters. Remove the slashes in front to use.
-        var disqus_identifier = '<%= model.try(:disqus_identifier) %>';
+        var disqus_identifier = '<%= model.try(:to_article).try(:original_object).try(:disqus_identifier) %>';
         var disqus_url = '<%= model.public_url %>';
-        var disqus_title = '<%= model.try(:headline).try(:to_json) %>';
+        var disqus_title = '<%= model.try(:to_article).try(:title).try(:to_json) %>';
 
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {


### PR DESCRIPTION
This reverts back to the way this disqus snippet was written before, except instead of calling `to_article`, we call `get_article` (which checks the ES first I believe). I initially took out `to_article` for performance reasons, but that proved to be a problem for any other model that wasn't a vanilla NewsStory.