### PR TITLE
Enables listing and linking as it was in pre-AU

### DIFF
--- a/app/cells/archive_tab/blogs.erb
+++ b/app/cells/archive_tab/blogs.erb
@@ -8,7 +8,7 @@
     <h3 class="o-archive-tab__item-heading b-heading--h4 b-heading--serif"><%= link_to model.short_headline, model.public_path, class: 'b-link' %></h3>
     <span class="o-archive-tab__item-category"><%= link_to model.blog.name, blog_path(model.blog.slug), class: 'b-link' %></span>
     <span class="pipe">|</span>
-    <span class="o-archive-tab__item-byline"><%= model.try(:byline) %></span>
+    <span class="o-archive-tab__item-byline"><%= byline %></span>
     <span class="pipe">|</span>
     <span class="o-archive-tab__item-date"><%= model.published_at.strftime('%B %d %Y, %l:%M %p') %></span>
     <p><%= model.teaser.html_safe %></p>

--- a/app/cells/archive_tab/news.erb
+++ b/app/cells/archive_tab/news.erb
@@ -8,7 +8,7 @@
     <h3 class="o-archive-tab__item-heading b-heading--h4 b-heading--serif"><%= link_to model.short_title, model.public_url %></h3>
     <span class="o-archive-tab__item-category"><%= link_to model.try(:category).try(:title), model.try(:category).try(:public_path) %></span>
     <span class="pipe">|</span>
-    <span class="o-archive-tab__item-byline"><%= model.try(:byline) %></span>
+    <span class="o-archive-tab__item-byline"><%= byline %></span>
     <span class="pipe">|</span>
     <span class="o-archive-tab__item-date"><%= model.public_datetime.strftime('%B %d %Y, %l:%M %p') %></span>
     <p><%= model.teaser.html_safe %></p>

--- a/app/cells/archive_tab/programs.erb
+++ b/app/cells/archive_tab/programs.erb
@@ -10,7 +10,7 @@
         <span class="o-archive-tab__item-category"><%= link_to model.category.title, model.category.public_path, class: 'b-link' %></span>
         <span class="pipe">|</span>
       <% end %>
-      <span class="o-archive-tab__item-byline"><%= model.try(:byline) %></span>
+      <span class="o-archive-tab__item-byline"><%= byline %></span>
       <span class="pipe">|</span>
       <span class="o-archive-tab__item-date"><%= model.published_at.strftime('%B %d %Y, %l:%M %p') %></span>
       <p><%= model.teaser.html_safe %></p>

--- a/app/cells/archive_tab_cell.rb
+++ b/app/cells/archive_tab_cell.rb
@@ -15,4 +15,19 @@ class ArchiveTabCell < Cell::ViewModel
     render
   end
 
+  def byline links=true
+    original_object = model.try(:original_object) || model
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if links && byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
+  end
+
 end

--- a/app/cells/article/show.erb
+++ b/app/cells/article/show.erb
@@ -11,7 +11,7 @@
 <%= hero_asset 'o-article__hero-figure' %>
 
 <div class="c-byline">
-  <span class="c-byline__name"><%= model.byline %></span>
+  <span class="c-byline__name"><%= byline %></span>
   <span class="c-byline__pipe">|</span>
   <span class="c-byline__timestamp"><%= timestamp %></span>
 </div>

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -108,24 +108,20 @@ class ArticleCell < Cell::ViewModel
     end
   end
 
-  # def byline links=true
-  #   return "KPCC" if !model.respond_to?(:attributions)
-  #   # The order of priority with ContentByline roles
-  #   # is in ascending order, so we can just do a
-  #   # simple sort.
-  #   bylines   = model.attributions.sort_by{|b| b.role}
-  #   if bylines.empty?
-  #     bylines << Hashie::Mash.new({name: "KPCC", role: -1})
-  #   end
-  #   primaries = bylines.select{|b| (b.role || 0) > -1}.map(&:name).join(" and ")
-  #   extras    = bylines.select{|b| (b.role || 0) < 0 }.map(&:name).join(" | ")
-
-  #   source    = NewsStory::SOURCES.select{|x| x[1] == model.try(:source)}.flatten[0]
-
-  #   [primaries, extras, source].reject{|b| b.blank?}.join(" | ")
-  # rescue NoMethodError
-  #   "KPCC"
-  # end
+  def byline links=true
+    original_object = model.try(:original_object) || model
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if links && byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
+  end
 
   def timestamp
     datetime = model.public_datetime.try(:strftime, "%B %-d, %Y")

--- a/app/cells/biography/show.erb
+++ b/app/cells/biography/show.erb
@@ -5,7 +5,7 @@
       <div class="o-biography__story">
         <h3 class="o-biography__story-heading b-heading--h4 b-heading--serif"><%= link_to byline.short_title, byline.public_url %></h3>
         <div class="c-byline">
-          <span class="c-byline__name"><%= byline.try(:byline) %></span>
+          <span class="c-byline__name"><%= byline_link byline %></span>
           <span class="c-byline__pipe">|</span>
           <span class="c-byline__timestamp"><%= byline.public_datetime.strftime('%B %d %Y, %l:%M %p') %></span>
         </div>

--- a/app/cells/biography_cell.rb
+++ b/app/cells/biography_cell.rb
@@ -15,4 +15,19 @@ class BiographyCell < Cell::ViewModel
     @options[:bylines]
   end
 
+  def byline_link object
+    original_object = object.try(:original_object) || object
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
+  end
+
 end

--- a/app/cells/blog_entry_cell.rb
+++ b/app/cells/blog_entry_cell.rb
@@ -8,8 +8,9 @@ class BlogEntryCell < Cell::ViewModel
   end
 
   def byline links=true
-    return "KPCC" if !model.respond_to?(:joined_bylines)
-    elements = model.joined_bylines do |bylines|
+    original_object = model.try(:original_object) || model
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
       bylines.map do |byline|
         if links && byline.user.try(:is_public)
           link_to byline.display_name, byline.user.public_path

--- a/app/cells/featured_interactive/show.erb
+++ b/app/cells/featured_interactive/show.erb
@@ -2,6 +2,6 @@
 <aside class="o-featured-interactive" style="order: <%= @options[:order] %>">
   <h6 class="o-featured-interactive__heading b-heading b-heading--h6 b-heading--uppercase u-text-color--gray b-heading--bold">Featured Interactive</h6>
   <h2 class="o-featured-interactive__headline b-heading b-heading--h2 b-heading--serif"><%= link_to model.try(:short_title), model.try(:public_path), class: 'b-link' %></h2>
-  <span class="o-featured-interactive__byline"><%= model.try(:byline) %></span>
+  <span class="o-featured-interactive__byline"><%= byline %></span>
 </aside>
 <% end %>

--- a/app/cells/featured_interactive_cell.rb
+++ b/app/cells/featured_interactive_cell.rb
@@ -7,4 +7,19 @@ class FeaturedInteractiveCell < Cell::ViewModel
     render
   end
 
+  def byline links=true
+    original_object = model.try(:original_object) || model
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if links && byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
+  end
+
 end

--- a/app/cells/featured_story/category_view.erb
+++ b/app/cells/featured_story/category_view.erb
@@ -12,7 +12,7 @@
   </figure>
 
   <div class="o-featured-story__description">
-    <span class="o-story-list__item-byline"><%= byline %></span>
+    <span class="o-story-list__item-byline"><%= byline model %></span>
     <span class="o-story-list__item-pipe">|</span>
     <time class="o-story-list__item-timestamp"><%= model.try(:public_datetime).try(:strftime, "%B %d, %I:%M %p") %></time>
     <span class="o-story-list__item-teaser"><%= teaser %></span>

--- a/app/cells/featured_story/vertical.erb
+++ b/app/cells/featured_story/vertical.erb
@@ -8,7 +8,7 @@
   <div class="o-featured-story__left">
     <div class="o-featured-story__description">
       <%= teaser %>
-      <span class="o-featured-story__byline"><%= byline %></span>
+      <span class="o-featured-story__byline"><%= byline model %></span>
     </div>
     <% if tag && topic_articles.any? %>
       <h6 class="o-featured-story__related-list__heading b-heading b-heading--h6 b-heading--uppercase u-text-color--gray">More from <%= link_to tag.title, topic_path(tag.slug) %></h6>
@@ -53,7 +53,7 @@
         <% blog_content.try(:each) do |content| %>
         <li class="o-featured-story__related-list__item">
           <a href="<%= content.try(:public_path) %>"><%= content.try(:short_headline) %></a>
-          <span class="o-featured-story__related-list__byline"><%= content.try(:byline) %></span>
+          <span class="o-featured-story__related-list__byline"><%= byline content %></span>
         </li>
         <% end %>
       </ul>

--- a/app/cells/featured_story_cell.rb
+++ b/app/cells/featured_story_cell.rb
@@ -22,8 +22,19 @@ class FeaturedStoryCell < Cell::ViewModel
     @options[:order] || "1"
   end
 
-  def byline
-    model.try(:byline)
+  def byline object
+    original_object = object.try(:original_object) || object
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
   end
 
   def teaser

--- a/app/cells/latest_news/categories.erb
+++ b/app/cells/latest_news/categories.erb
@@ -6,7 +6,7 @@
     <section class="o-latest-news__category-description">
       <h3 class="o-latest-news__category_featured-title"><%= link_to section.articles.first.short_title, section.articles.first.public_path, "data-ga-category" => '@currentCategory', "data-ga-action" => "Article", "data-ga-label" => '@scrollDepth', class: "track-event" %></h3>
       <p class="c-byline">
-        <span class="c-byline__name"><%= section.articles.first.try(:byline) %></span>
+        <span class="c-byline__name"><%= byline section.articles.first %></span>
         <span class="c-byline__pipe">|</span>
         <time class="c-byline__timestamp"><%= section.articles.first.public_datetime %></time>
       </p>

--- a/app/cells/latest_news/featured.erb
+++ b/app/cells/latest_news/featured.erb
@@ -14,7 +14,7 @@
     </div>
     <section class="o-latest-news__featured-description">
       <p class="c-byline">
-        <span class="c-byline__name"><%= model.try(:byline) %></span>
+        <span class="c-byline__name"><%= byline model %></span>
         <span class="c-byline__pipe">|</span>
         <time class="c-byline__timestamp"><%= model.try(:public_datetime) %></time>
       </p>

--- a/app/cells/latest_news_cell.rb
+++ b/app/cells/latest_news_cell.rb
@@ -27,4 +27,19 @@ class LatestNewsCell < Cell::ViewModel
     resource.try(:asset).try(:small).try(:url) || "/static/images/fallback-img-rect.png"
   end
 
+  def byline object
+    original_object = object.try(:original_object) || object
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
+  end
+
 end

--- a/app/cells/topic_cluster/vertical.erb
+++ b/app/cells/topic_cluster/vertical.erb
@@ -14,7 +14,7 @@
           <h4 class="o-topic-cluster__headline">
             <a class="o-media__headline-link" href="<%= feature.public_url %>"><%= feature.short_title %></a>
           </h4>
-          <div class="o-topic-cluster__byline"><%= feature.try(:byline) %></div>
+          <div class="o-topic-cluster__byline"><%= byline feature %></div>
           <div class="o-topic-cluster__datetime"><%= feature.public_datetime.try(:strftime, "%B %-d, %Y") %></div>
         </div>
       </li>

--- a/app/cells/topic_cluster_cell.rb
+++ b/app/cells/topic_cluster_cell.rb
@@ -32,4 +32,19 @@ class TopicClusterCell < Cell::ViewModel
     tag.try(:featured_content)[1..2]
   end
 
+  def byline object
+    original_object = object.try(:original_object) || object
+    return "KPCC" if !original_object.respond_to?(:joined_bylines)
+    elements = original_object.joined_bylines do |bylines|
+      bylines.map do |byline|
+        if byline.user.try(:is_public)
+          link_to byline.display_name, byline.user.public_path
+        else
+          byline.display_name
+        end
+      end
+    end
+    ContentByline.digest(elements).html_safe
+  end
+
 end


### PR DESCRIPTION
Sorry for all the file changes! Had to add the method to every cell that needed it.

The new method first checks if there is an `original_object` from the input object, and uses that first. Otherwise, it uses the input object directly. This handles both cases where the data might not be in the right shape (might not be an article). Inside the code block, it checks whether that bio `is_public`, and if it is, creates a link, or else it just displays the `display_name`

Example: https://scprv4-staging.scprdev.org/news/2017/11/03/77364/amber-alert-chevy-truck-fort-tejon-gomes/