### PR TITLE
Fixes embeds

### DIFF
--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -46,6 +46,7 @@
   .o-article__body
     color: $color-gray-dark
     font-family: $font-sans-base
+    overflow: hidden
     > *
       line-height: 30px
       margin-bottom: $margin-in-pixels / 2

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -103,7 +103,7 @@ class ArticleCell < Cell::ViewModel
     doc.css("body > *").each_with_index do |element, i|
       element['style'] ||= ""
       unless element['style'].match(/order:\s(.*);/)
-        element['style'] += "order:#{i}; height: 100%;"
+        element['style'] += "order:#{i};"
       end
     end
   end
@@ -119,7 +119,7 @@ class ArticleCell < Cell::ViewModel
   #   end
   #   primaries = bylines.select{|b| (b.role || 0) > -1}.map(&:name).join(" and ")
   #   extras    = bylines.select{|b| (b.role || 0) < 0 }.map(&:name).join(" | ")
-    
+
   #   source    = NewsStory::SOURCES.select{|x| x[1] == model.try(:source)}.flatten[0]
 
   #   [primaries, extras, source].reject{|b| b.blank?}.join(" | ")


### PR DESCRIPTION
Removes unnecessary height property in articles bodies. Also overflows the parent body so that the floats work as expected.