### PR TITLE
Fix event date

### DIFF
--- a/app/cells/event/show.erb
+++ b/app/cells/event/show.erb
@@ -35,7 +35,9 @@
 </figure>
 <% end %>
 
-<%= render_body %>
+<div class="o-event__body">
+  <%= render_body %>
+</div>
 
 <script>
   var locationName = "<%= model.try(:location_name) %>";

--- a/app/cells/event/style.sass
+++ b/app/cells/event/style.sass
@@ -1,15 +1,64 @@
-.l-event
-  p
-    margin-bottom: $margin-in-pixels / 4
-    a
-      color: $color-link
-  p:last-of-type
-    margin-bottom: $margin-in-pixels
-
 .o-event__body
   display: inline-block
   font-size: 18px
   line-height: 30px
+
+  > *
+    line-height: 30px
+    margin-bottom: $margin-in-pixels / 2
+
+  p a
+    // paragraph links
+    color: $color-secondary
+
+  ul
+    list-style: circle
+    padding-left: 3em
+    font-size: 0.9em
+    margin-bottom: 27.68px
+    li
+      margin: 1em 0
+
+  h2
+    font-size: 22px
+    font-weight: 400
+
+  h3:not(.o-article__title)
+    font-size: 18px
+    font-weight: 600
+    text-transform: uppercase
+
+  h6
+    @extend .b-heading, .b-heading--h6, .b-heading--uppercase, .u-text-color--gray-warm, .b-heading--book
+    margin-bottom: 0
+
+  p:first-of-type
+    font-size: 22px
+    line-height: 30px
+    @media (max-width: $media-tablet)
+      font-size: 20px
+
+  p:last-of-type
+    margin-bottom: 60px
+å
+  blockquote
+    p
+      border-left: 6px solid $color-primary
+      padding-bottom: $margin-in-pixels / 2
+      margin-left: percentage(31/642)
+      padding-left: percentage(31/642)
+    p:last-of-type
+      padding-bottom: 0px
+
+  > img
+    @media (max-width: $media-tablet)
+      width: 100% - ($margin * 2) !important
+
+  iframe
+    width: 100%
+
+
+
 
 .o-event__figure
   font-size: 0.8em

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -60,7 +60,7 @@ class EventCell < Cell::ViewModel
     starts_at = event.try(:starts_at)
     ends_at = event.try(:ends_at)
     ends_at_strftime = "- %A, %B %e, %l:%M%P"
-    if ends_at - starts_at < 1.day
+    if starts_at.try(:yday) == ends_at.try(:yday) && starts_at.try(:year) == ends_at.try(:year)
       ends_at_strftime = "- %l:%M%P"
     end
 

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -9,7 +9,13 @@ class EventCell < Cell::ViewModel
     starts_at = model.try(:starts_at)
     ends_at = model.try(:ends_at)
 
-    if ends_at.try(:past?)
+    if ends_at
+      original_time = ends_at
+    else
+      original_time = starts_at
+    end
+
+    if original_time.try(:past?) && !model.try(:archive_description).try(:empty?)
       doc = Nokogiri::HTML(model.archive_description.html_safe)
     else
       doc = Nokogiri::HTML(model.body.html_safe)

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -74,6 +74,8 @@ class EventCell < Cell::ViewModel
       starts_at.try(:strftime, "%A, %B %e")
     elsif ends_at
       "#{starts_at.try(:strftime, "%A, %B %e, %l:%M%P")} #{ends_at.try(:strftime, ends_at_strftime)}"
+    else
+      starts_at.try(:strftime, "%A, %B %e, %l:%M%P")
     end
   end
 end

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -7,8 +7,9 @@ class EventCell < Cell::ViewModel
 
   def render_body options={}
     starts_at = model.try(:starts_at)
+    ends_at = model.try(:ends_at)
 
-    if starts_at.try(:past?)
+    if ends_at.try(:past?)
       doc = Nokogiri::HTML(model.archive_description.html_safe)
     else
       doc = Nokogiri::HTML(model.body.html_safe)
@@ -58,13 +59,15 @@ class EventCell < Cell::ViewModel
   def date(event)
     starts_at = event.try(:starts_at)
     ends_at = event.try(:ends_at)
+    ends_at_strftime = "- %A, %B %e, %l:%M%P"
+    if ends_at - starts_at < 1.day
+      ends_at_strftime = "- %l:%M%P"
+    end
 
     if event.try(:is_all_day)
       starts_at.try(:strftime, "%A, %B %e")
     elsif ends_at
-      "#{starts_at.try(:strftime, "%A, %B %e, %l:%M%P")} - #{ends_at.try(:strftime, "%l:%M%P")}"
-    else
-      starts_at.try(:strftime, "%A, %B %e, %l:%M%P")
+      "#{starts_at.try(:strftime, "%A, %B %e, %l:%M%P")} #{ends_at.try(:strftime, ends_at_strftime)}"
     end
   end
 end

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -27,7 +27,7 @@ class EventCell < Cell::ViewModel
       element['style'] ||= ""
       unless element['style'].scan(/order:\s(.*);/).any?
         element['style'] = "#{element['style']}order:#{i + 4};"
-        element['class'] = "#{element['class']} o-event__body"
+        element['class'] = "#{element['class']}"
       end
     end
   end


### PR DESCRIPTION
- Fixes it so that the end datetime is displayed if the event spans multiple days
  - Also checks if its the same day, and if it is, renders in a more readable format (e.g. Monday, November 6, 1:00pm - 4:00pm)
- Applies same style rules as article pages