### PR TITLE
Fix listen live reporting

### DIFF
--- a/app/cells/listen_live/show.erb
+++ b/app/cells/listen_live/show.erb
@@ -6,7 +6,6 @@
       <?xml version="1.0" encoding="UTF-8"?>
       <svg viewBox="0 0 96 96" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="listen-live-pause">
           <!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch -->
-          <title>Group 2</title>
           <desc>Created with Sketch.</desc>
           <defs></defs>
           <g id="Listen-Live" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -45,7 +44,6 @@
       </metadata>
       <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1440" inkscape:window-height="855" id="namedview30" showgrid="false" inkscape:zoom="5.5813043" inkscape:cx="12.47526" inkscape:cy="49.255509" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="0" inkscape:current-layer="Group-32"></sodipodi:namedview>
       <!-- Generator: Sketch 40.1 (33804) - http://www.bohemiancoding.com/sketch -->
-      <title id="title4">Group 33</title>
       <desc id="desc6">Created with Sketch.</desc>
       <defs id="defs8"></defs>
       <g id="Homepage" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/app/views/listen/index.html.erb
+++ b/app/views/listen/index.html.erb
@@ -3,6 +3,7 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta charset="utf-8">
   <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
+  <title>KPCC Listen Live</title>
   <script src="https://use.typekit.net/cka2qre.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <%= stylesheet_link_tag 'application' %>

--- a/app/views/listen/index.html.erb
+++ b/app/views/listen/index.html.erb
@@ -3,7 +3,7 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta charset="utf-8">
   <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
-  <title>KPCC Listen Live</title>
+  <title>Listen Live</title>
   <script src="https://use.typekit.net/cka2qre.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <%= stylesheet_link_tag 'application' %>


### PR DESCRIPTION
- A `<title>` tag from an svg was changing what was being reported to chartbeat
- Will eventually move these svgs out of here and into `scprsprite.svg`