### PR TITLE
Fixes cache key to be more specific for recent content

### DIFF
--- a/app/cells/recent_content_cell.rb
+++ b/app/cells/recent_content_cell.rb
@@ -2,7 +2,7 @@ class RecentContentCell < Cell::ViewModel
   include Orderable
 
   cache :show do
-    model.try(:cache_key)
+    "#{model.try(:cache_key)} #{@options[:class]}"
   end
 
   property :title


### PR DESCRIPTION
Fixes this bug: 

![image](https://user-images.githubusercontent.com/16679701/32526580-eee4b52c-c3de-11e7-9d90-f636abeb6559.png)

- Includes the class inside the cache_key to make sure these cells don't display without their necessary classnames