### PR TITLE
Fixes breaking news access errors

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -11,6 +11,7 @@
 @import './three-columns'
 @import './audio-player'
 @import './slideshow'
+@import 'better_homepage/breaking-news-dropdown'
 
 $centroid: '*:not(.l-column--boundless):not(.l-column--left):not(.l-column--right)'
 

--- a/app/cells/breaking_news_alert/show.erb
+++ b/app/cells/breaking_news_alert/show.erb
@@ -1,9 +1,9 @@
 <div id="breaking-news">
-    <div class="live-update <%= alert_type %>">
+    <div class="live-update <%= model.try(:alert_type) %>">
       <div class="l-container inner-container">
           <div class="l-row">
             <div class="l-col--sm-12">
-              <strong><%= break_type %></strong><%= link_to headline, alert_url %>
+              <strong><%= model.try(:break_type) %></strong><%= link_to model.try(:headline), model.try(:alert_url) %>
               <a href="http://info.americanpublicmediagroup.org/LP=238" class="newsletter-sign-up">Sign up for alerts</a>
             </div>
           </div>

--- a/app/cells/breaking_news_alert/show.erb
+++ b/app/cells/breaking_news_alert/show.erb
@@ -4,7 +4,7 @@
           <div class="l-row">
             <div class="l-col--sm-12">
               <strong><%= model.try(:break_type) %></strong><%= link_to model.try(:headline), model.try(:alert_url) %>
-              <a href="http://info.americanpublicmediagroup.org/LP=238" class="newsletter-sign-up">Sign up for alerts</a>
+              <a href="http://cloud.connect.scpr.org/kpcc_sub" class="newsletter-sign-up">Sign up for alerts</a>
             </div>
           </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,12 +33,12 @@
 
   <body>
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-585PL29" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    <% if alert = BreakingNewsAlert.latest_visible_alert %>
-      <%= cell :breaking_news_alert, alert %>
-    <% end %>
     <div id="global-pushdown"></div>
     <header class="<%= content_for :header_class %>">
       <%= cell :masthead %>
+      <% if alert = BreakingNewsAlert.latest_visible_alert %>
+        <%= cell :breaking_news_alert, alert %>
+      <% end %>
       <%= content_for :header %>
     </header>
     <main class="<%= content_for :main_class %>">


### PR DESCRIPTION
![screen shot 2017-11-08 at 12 53 58 pm](https://user-images.githubusercontent.com/16679701/32573762-eb3e023e-c483-11e7-8f30-dda155cadebb.png)

The properties in the cell's template weren't being included. By adding `model.try()` to all of the necessary properties, there shouldn't be anymore access errors. Another way to do this would be to put includes at the top of the cell's controller. For now though, I think this way should be sufficient.

This is on me for not ever testing this feature. Since there isn't a mock for this (as far as I know), I'm importing the old stylesheet.
