### PR TITLE
Fixes comment section by unwrapping to_json'd strings

### DIFF
--- a/app/cells/comments/show.erb
+++ b/app/cells/comments/show.erb
@@ -6,7 +6,7 @@
         // The following are highly recommended additional parameters. Remove the slashes in front to use.
         var disqus_identifier = '<%= model.try(:get_article).try(:original_object).try(:disqus_identifier) %>';
         var disqus_url = '<%= model.public_url %>';
-        var disqus_title = '<%= model.try(:get_article).try(:title).try(:to_json) %>';
+        var disqus_title = <%= model.try(:get_article).try(:title).try(:to_json) %>;
 
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {


### PR DESCRIPTION
This fixes the comment section in cases where there are single quotes within a headline.
calling .to_json already wraps the string inside quotes, so we can take out the single quotes that are wrapped outside of the variable.

Examples below:

Before (wrapping with ''):
‘“The audacity of ‘woke’”’;

After (taking out ''):
“The audacity of ‘woke’”;