### PR TITLE
Fixes contributing bylines by checking if theres an original_object

### DIFF
--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -24,7 +24,8 @@ class ArticleCell < Cell::ViewModel
   end
 
   def biographies links=true
-    elements = model.try(:joined_bylines) do |bylines|
+    original_object = model.try(:original_object) || model
+    elements = original_object.try(:joined_bylines) do |bylines|
       bylines.map do |byline|
         if links && byline.user.try(:is_public)
           link_to byline.display_name, byline.user.public_path


### PR DESCRIPTION
Sometimes the current model doesn't have a `joined_bylines` property. In that case, check if there's an `original_object` property and use the `joined_bylines` from there instead.