### PR TITLE
Bump cache key

### DIFF
--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -12,7 +12,7 @@ class ArticleCell < Cell::ViewModel
   property :category
 
   cache :show do
-    model.try(:cache_key)
+    [model.try(:cache_key), 'v2']
   end
 
   def show

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -12,7 +12,7 @@ class ArticleCell < Cell::ViewModel
   property :category
 
   cache :show do
-    [model.try(:cache_key), 'v2']
+    [model.try(:cache_key), 'v3']
   end
 
   def show


### PR DESCRIPTION
Assigns an arbitrary string (in this case an incrementing version number) to create a new cache key.

Currently in "Can't automatically merge". I'll resolve the conflicts before trying to push