### PR TITLE
Fixes event listings

### DIFF
--- a/app/cells/event/show.erb
+++ b/app/cells/event/show.erb
@@ -1,7 +1,7 @@
 <h4 class="o-event__type" style="order: 0">EVENTS</h4>
 <h1 class="o-event__headline" style="order: 1"><%= model.headline %></h1>
 
-<div class='o-event__RSVP' style="order: 2; flex-direction: <%= flex_direction %>">
+<div class='o-event__RSVP <%= orientation %>' style="order: 2;">
   <div class='o-event__RSVP-date'>
     <span class="o-event__RSVP-datetime"><%= date model %></span>
     <% if !model.try(:rsvp_url).try(:empty?) && !model.try(:starts_at).try(:past?) %>
@@ -35,7 +35,7 @@
 </figure>
 <% end %>
 
-<div class="o-event__body">
+<div class="o-event__body" style="order: 4">
   <%= render_body %>
 </div>
 

--- a/app/cells/event/style.sass
+++ b/app/cells/event/style.sass
@@ -169,3 +169,10 @@
     padding-left: 0.75em
     padding-right: 0.75em
     padding-top: 0.5rem
+
+.o-event__RSVP--column
+  flex-direction: column
+  width: percentage(642/1440)
+
+  .o-event__RSVP-date, .o-event__RSVP-address
+    width: 100%

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -38,14 +38,6 @@ class EventCell < Cell::ViewModel
     end
   end
 
-  def flex_direction
-    if model.try(:rsvp_url)
-      return "row"
-    else
-      return "column"
-    end
-  end
-
   def start_date
     if !model.try(:starts_at)
       return ''
@@ -84,6 +76,14 @@ class EventCell < Cell::ViewModel
       "#{starts_at.try(:strftime, "%A, %B %e, %l:%M%P")} #{ends_at.try(:strftime, ends_at_strftime)}"
     else
       starts_at.try(:strftime, "%A, %B %e, %l:%M%P")
+    end
+  end
+
+  def orientation
+    if model.try(:rsvp_url).try(:empty?)
+      'o-event__RSVP--column'
+    else
+      'o-event__RSVP--row'
     end
   end
 end

--- a/app/cells/upcoming_events_list_cell.rb
+++ b/app/cells/upcoming_events_list_cell.rb
@@ -22,17 +22,33 @@ class UpcomingEventsListCell < Cell::ViewModel
   def date(event)
     starts_at = event.try(:starts_at)
     ends_at = event.try(:ends_at)
+    ends_at_strftime = "- %B %e, %l:%M%P"
+    same_day = false
+    if starts_at.try(:yday) == ends_at.try(:yday) && starts_at.try(:year) == ends_at.try(:year)
+      ends_at_strftime = "- %l:%M%P"
+      same_day = true
+    end
 
-    if starts_at.try(:past?)
-      'Past Event'
-    else
-      if event.try(:is_all_day)
-        starts_at.try(:strftime, "%A, %B %e")
-      elsif ends_at
-        "#{starts_at.try(:strftime, "%A, %B %e, %l:%M%P")} - #{ends_at.try(:strftime, "%l:%M%P")}"
-      else
-        starts_at.try(:strftime, "%A, %B %e, %l:%M%P")
+    if ends_at
+      if ends_at.try(:past?)
+        return 'Past Event'
       end
+    elsif starts_at.try(:past?) && !event.try(:is_all_day)
+      return 'Past Event'
+    end
+
+    if event.try(:is_all_day)
+      if same_day == true
+        starts_at.try(:strftime, "%B %e")
+      elsif ends_at
+        "#{starts_at.try(:strftime, "%B %e")} #{ends_at.try(:strftime, "- %B %e")}"
+      else
+        starts_at.try(:strftime, "%B %e")
+      end
+    elsif ends_at
+      "#{starts_at.try(:strftime, "%B %e, %l:%M%P")} #{ends_at.try(:strftime, ends_at_strftime)}"
+    else
+      starts_at.try(:strftime, "%B %e, %l:%M%P")
     end
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,9 +60,9 @@ class EventsController < ApplicationController
     end
 
     # Instance variable for three tabs
-    @all_upcoming_events = Event.published.upcoming.page(upcoming_page).per(10)
-    @kpcc_in_person_events = Event.kpcc_in_person.upcoming.page(kpcc_in_person_page).per(10)
-    @sponsored_events = Event.sponsored.upcoming.page(sponsored_page).per(10)
+    @all_upcoming_events = Event.published.upcoming_and_current.page(upcoming_page).per(10)
+    @kpcc_in_person_events = Event.kpcc_in_person.upcoming_and_current.page(kpcc_in_person_page).per(10)
+    @sponsored_events = Event.sponsored.upcoming_and_current.page(sponsored_page).per(10)
 
     # Instance variable that populates the "Recent Events" side bar
     @past_events     = Event.kpcc_in_person.past.limit(5)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -3,27 +3,29 @@
 <% add_to_page_title "Events" %>
 
 <% content_for :header do %>
-<section id="o-prologue--in-person__event" class="o-prologue o-prologue--in-person">
-  <a class="o-prologue__logo" href="/events/kpcc-in-person"><%= image_tag "event-headers/kpcc-in-person-logo.svg" %></a>
-  <span class="o-prologue__description">
-    <div class="o-prologue__teaser">
-      <%= @landing_page.try(:description) %>
-    </div>
-    <span class="o-prologue__pipe">|</span>
-    <div class="o-prologue__social-icons">
-      <a class="o-prologue__social-icon" href="https://www.facebook.com/KPCCInPerson">
-        <svg class="b-icon b-icon--size-sm b-icon--left">
-          <use class="b-icon--line" xlink:href="/static/images/scpr-sprite.svg#icon_line-facebook" />
-        </svg>
-      </a>
-      <a class="o-prologue__social-icon" href="https://twitter.com/KPCCInPerson">
-        <svg class="b-icon b-icon--size-sm b-icon--left">
-          <use class="b-icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-twitter" />
-        </svg>
-      </a>
-    </div>
-  </span>
-</section>
+  <% if @event.try(:is_kpcc_in_person_event?) %>
+    <section id="o-prologue--in-person__event" class="o-prologue o-prologue--in-person">
+      <a class="o-prologue__logo" href="/events/kpcc-in-person"><%= image_tag "event-headers/kpcc-in-person-logo.svg" %></a>
+      <span class="o-prologue__description">
+        <div class="o-prologue__teaser">
+          <%= @landing_page.try(:description) %>
+        </div>
+        <span class="o-prologue__pipe">|</span>
+        <div class="o-prologue__social-icons">
+          <a class="o-prologue__social-icon" href="https://www.facebook.com/KPCCInPerson">
+            <svg class="b-icon b-icon--size-sm b-icon--left">
+              <use class="b-icon--line" xlink:href="/static/images/scpr-sprite.svg#icon_line-facebook" />
+            </svg>
+          </a>
+          <a class="o-prologue__social-icon" href="https://twitter.com/KPCCInPerson">
+            <svg class="b-icon b-icon--size-sm b-icon--left">
+              <use class="b-icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-twitter" />
+            </svg>
+          </a>
+        </div>
+      </span>
+    </section>
+  <% end %>
 <% end %>
 
 <%= cell :social_tools, @event, display: 'vert' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,10 +73,9 @@ Scprv4::Application.routes.draw do
   get '/events/kpcc-in-person/:subtype'            => 'events#kpcc_in_person'
   get '/events/kpcc-in-person/'                    => 'events#kpcc_in_person',      as: :kpcc_in_person_events
 
-  get '/events/sponsored/'                => 'events#index',      as: :sponsored_events,      defaults: { list: "sponsored" }
+  get '/events/sponsored/'                => redirect('/events/kpcc-in-person/sponsored/')
   get '/events/:year/:month/:day/:id/:slug/'  => 'events#show',   as: :event,                 constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/, id: /\d+/, slug: /[\w_-]+/ }
-  get '/events/(list/:list)'              => 'events#kpcc_in_person',      as: :events,                defaults: { list: "all" }
-
+  get '/events/(list/:list)'              => redirect('/events/kpcc-in-person/list/')
   # Short List
   post '/short-list/archive'                     => "editions#archive"
   get '/short-list/:year/:month/:day'            => "editions#latest", constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ }

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,52 +1,6 @@
 require "spec_helper"
 
 describe EventsController do
-  describe "GET /index" do
-    describe "view" do
-      render_views
-
-      it "renders the view" do
-        get :index
-      end
-    end
-
-    describe "controller" do
-      it "assigns @events using upcoming_and_current scope" do
-        past    = create :event, :published, :past
-        current = create :event, :published, :current
-        future  = create :event, :published, :future
-        get :index
-        assigns(:events).should eq [current, future]
-      end
-
-      describe "scoping" do
-        before :each do
-          @forum = create :event, :published, :future, event_type: "comm"
-          @spon  = create :event, :published, :future, event_type: "spon"
-        end
-
-        it "scopes by kpcc_in_person if requested" do
-          get :index, list: "kpcc-in-person"
-          assigns(:scoped_events).should eq [@forum]
-        end
-
-        it "scoped by sponsored if requested" do
-          get :index, list: "sponsored"
-          assigns(:scoped_events).should eq [@spon]
-        end
-
-        it "does not scope by event_type if nothing requested" do
-          get :index
-          scoped_events = assigns(:scoped_events)
-          scoped_events.should include @forum
-          scoped_events.should include @spon
-        end
-      end
-    end
-  end
-
-  #-----------------
-
   describe "GET /kpcc_in_person" do
     describe "view" do
       render_views
@@ -62,7 +16,7 @@ describe EventsController do
         current_event = create :event, :published, starts_at: 2.hours.ago, ends_at: 2.hours.from_now, event_type: 'comm'
         future_event  = create :event, :published, starts_at: 2.hours.from_now, ends_at: 3.hours.from_now, event_type: 'comm'
         get :kpcc_in_person
-        assigns(:all_upcoming_events).should eq [future_event]
+        assigns(:all_upcoming_events).should eq [current_event, future_event]
       end
     end
   end


### PR DESCRIPTION
Changes the events listed in the KPCC In Person Landing Page from upcoming to `upcoming_and_current`. Also doesn't display the KPCC In Person prologue header for sponsored events.