### PR TITLE
Fix slideshows

### DIFF
--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -56,7 +56,7 @@ class ArticleCell < Cell::ViewModel
   end
 
   def hero_asset(figure_class)
-    if model.try(:asset_display) == :hidden || assets.try(:empty?)
+    if model.try(:asset_display) == :hidden || model.try(:asset_display) == "hidden" || assets.try(:empty?)
       nil
     else
       if model.try(:asset_display) == :slideshow

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -59,7 +59,7 @@ class ArticleCell < Cell::ViewModel
     if model.try(:asset_display) == :hidden || model.try(:asset_display) == "hidden" || assets.try(:empty?)
       nil
     else
-      if model.try(:asset_display) == :slideshow
+      if model.try(:asset_display) == :slideshow || model.try(:asset_display) == "slideshow"
         AssetCell.new(asset, article: model, class: figure_class, template: "default/slideshow.html").call(:show)
       else
         AssetCell.new(asset, article: model, class: figure_class).call(:show)

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -60,7 +60,7 @@ class ArticleCell < Cell::ViewModel
       nil
     else
       if model.try(:asset_display) == :slideshow
-        AssetCell.new(asset, article: model, class: figure_class, template: "default/#{model.try(:asset_display)}.html").call(:show)
+        AssetCell.new(asset, article: model, class: figure_class, template: "default/slideshow.html").call(:show)
       else
         AssetCell.new(asset, article: model, class: figure_class).call(:show)
       end
@@ -77,10 +77,13 @@ class ArticleCell < Cell::ViewModel
       asset_id = asset_id ? asset_id.to_i : nil
       next if asset_id.nil?
 
-      # we have to fall back to original_object here to get the full list of
-      # assets. in any case where we're rendering a body, we'll already have
-      # the original object loaded, so that's ok
-      asset = model.try(:inline_assets).try(:select) {|a| a.asset_id == asset_id}[0]
+      if @options[:preview] == true
+        asset_collection = model.try(:assets)
+      else
+        asset_collection = model.try(:inline_assets)
+      end
+
+      asset = asset_collection.try(:select) {|a| a.asset_id == asset_id}[0]
 
       ## If kpcc_only is true, only render if the owner of the asset is KPCC
       if asset && (!options[:kpcc_only] || asset.owner.try(:include?, "KPCC"))

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -12,7 +12,7 @@ class ArticleCell < Cell::ViewModel
   property :category
 
   cache :show, expires_in: 10.minutes, :if => lambda { !@options[:preview] }  do
-    [model.try(:cache_key), 'v6']
+    [model.try(:cache_key), 'v7']
   end
 
   def show

--- a/app/cells/asset/default/slideshow.html.erb
+++ b/app/cells/asset/default/slideshow.html.erb
@@ -3,7 +3,7 @@
 <div id="asset_slideshow_<%=html_safe_id%>" class="<%= @options[:class] %> slideview">
 
   <div class="static-slides">
-  <% assets.each do |asset| %>
+  <% slideshow_assets.each do |asset| %>
     <figure class="slide o-figure <%= aspect asset %>">
       <img
         class="o-figure__img"

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -39,6 +39,10 @@ class AssetCell < Cell::ViewModel
     end
   end
 
+  def slideshow_assets
+    assets.try(:select) {|a| a.inline == false }
+  end
+
   def article
     @options[:article]
   end

--- a/app/views/shared/new/_single_preview.html.erb
+++ b/app/views/shared/new/_single_preview.html.erb
@@ -19,7 +19,7 @@ end %>
 <%= cell :ad, slot: "c", class: "l-column--right", order: 1000 %>
 
 <!-- ARTICLE BODY -->
-<%= cell :article, @entry, type: 'story', preview: true %>
+<%= cell :article, @entry.get_article, type: 'story', preview: true %>
 
 <!-- MOAR STUFF -->
 <%= cell :newsletter_appeal, @entry, order: 991 %>

--- a/app/views/shared/new/_single_preview.html.erb
+++ b/app/views/shared/new/_single_preview.html.erb
@@ -1,4 +1,3 @@
-<% article = @entry.get_article %>
 <% content_for :main_class, "o-article" %>
 
 <!-- LEFT ASIDE -->
@@ -19,14 +18,14 @@ end %>
 <%= cell :ad, slot: "c", class: "l-column--right", order: 1000 %>
 
 <!-- ARTICLE BODY -->
-<%= cell :article, @entry.get_article, type: 'story', preview: true %>
+<%= cell :article, @entry, type: 'story', preview: true %>
 
 <!-- MOAR STUFF -->
 <%= cell :newsletter_appeal, @entry, order: 991 %>
 
 <hr class="o-article__rule--ending b-rule b-rule--primary-lightest", style="order: 992;" />
 
-<%= cell :related_links, article, order: 993, preview: true %>
+<%= cell :related_links, @entry.get_article, order: 993, preview: true %>
 
 <%= cell :social_tools, @entry, display: 'horiz', order: 994 %>
 


### PR DESCRIPTION
Changelog:

- Adds cases to access the `asset_display` properties, `hidden` and `slideshow`, for if the model is either a NewsStory of Article (this is because for preview to work, the @entry is actually a NewsStory, and calling get_article will revert to a cached version of the article)
- Ensures that slideshows do not take from `inline_assets`
- bumps the cache_key