### PR TITLE
Adds meta tags and correct page title for PIN pages

### DIFF
--- a/app/views/pij_queries/show.html.erb
+++ b/app/views/pij_queries/show.html.erb
@@ -1,3 +1,5 @@
+<% add_to_page_title @query.headline %>
+<% content_for :opengraph do %><%= render_content @query, "opengraph" %><% end %>
 <% content_for :main_class, "l-pin-query" %>
 
 <%= cell :social_tools, @article, display: 'vert' %>


### PR DESCRIPTION
This adds meta tags to PIN pages. Prior to this, it would default to the generic meta tag which includes the page title.

This is an example of a page fed to facebook debugger:
https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Fscprv4-staging.scprdev.org%2Fnetwork%2Fquestions%2Fselena