### PR TITLE
Fix aspects

### DIFF
--- a/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
+++ b/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
@@ -22,6 +22,10 @@
 .o-figure--emphasized .o-figure__img
   border-bottom: 4px solid $color-primary
 
+.o-figure--full
+  .o-figure__img
+    height: auto
+
 .o-figure__img
   display: block
   box-sizing: border-box

--- a/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
+++ b/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
@@ -7,6 +7,9 @@
 .o-figure--widescreen .o-figure__img
   padding-top: (100 / 1.77778) * 1%
 
+.o-figure--classic .o-figure__img
+  padding-top: (100 / 1.5) * 1%
+
 .o-figure--four-by-three .o-figure__img
   padding-top: (100 / 1.33333) * 1%
 

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -60,9 +60,9 @@ class ArticleCell < Cell::ViewModel
       nil
     else
       if model.try(:asset_display) == :slideshow || model.try(:asset_display) == "slideshow"
-        AssetCell.new(asset, article: model, class: figure_class, template: "default/slideshow.html").call(:show)
+        AssetCell.new(asset, article: model, class: figure_class, template: "default/slideshow.html", featured: true).call(:show)
       else
-        AssetCell.new(asset, article: model, class: figure_class).call(:show)
+        AssetCell.new(asset, article: model, class: figure_class, featured: true).call(:show)
       end
     end
   end

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -36,14 +36,14 @@ class AssetCell < Cell::ViewModel
     height = asset.small.height.to_i
     if width < height
       "o-figure--portrait"
-    elsif width / height < 1.33
-      "o-figure--four-by-three"
-    elsif width / height < 1.5
-      "o-figure--classic"
-    elsif width / height < 1.77778
-      "o-figure--widescreen"
-    elsif width / height < 2.35
+    elsif width / height > 1.77778
       "o-figure--cinematic"
+    elsif width / height > 1.5
+      "o-figure--widescreen"
+    elsif width / height > 1.33
+      "o-figure--classic"
+    elsif width / height > 1
+      "o-figure--four-by-three"
     end
   end
 

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -36,14 +36,8 @@ class AssetCell < Cell::ViewModel
     height = asset.small.height.to_i
     if width < height
       "o-figure--portrait"
-    elsif width / height > 1.77778
-      "o-figure--cinematic"
-    elsif width / height > 1.5
-      "o-figure--widescreen"
-    elsif width / height > 1.33
-      "o-figure--classic"
-    elsif width / height > 1
-      "o-figure--four-by-three"
+    else
+      "o-figure--full"
     end
   end
 

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -37,7 +37,11 @@ class AssetCell < Cell::ViewModel
     if width < height
       "o-figure--portrait"
     else
-      "o-figure--full"
+      if @options[:featured]
+        "o-figure--classic"
+      else
+        "o-figure--full"
+      end
     end
   end
 

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -32,10 +32,18 @@ class AssetCell < Cell::ViewModel
   end
 
   def aspect asset=model
-    if asset.small.width.to_i < asset.small.height.to_i
+    width = asset.small.width.to_i
+    height = asset.small.height.to_i
+    if width < height
       "o-figure--portrait"
-    else
+    elsif width / height < 1.33
+      "o-figure--four-by-three"
+    elsif width / height < 1.5
+      "o-figure--classic"
+    elsif width / height < 1.77778
       "o-figure--widescreen"
+    elsif width / height < 2.35
+      "o-figure--cinematic"
     end
   end
 

--- a/app/cells/featured_story/program.erb
+++ b/app/cells/featured_story/program.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="o-featured-story__center">
-    <figure class="o-featured-story__figure o-figure o-figure--widescreen">
+    <figure class="o-featured-story__figure o-figure o-figure--classic">
       <img class="o-figure__img" src="<%= asset_path %>" style="background-image:url(<%= asset_path %>);">
     </figure>
     <div class="o-featured-story__right--inside">


### PR DESCRIPTION
- Imposes an aspect ratio for the featured image at the top of an article
- Goes to the default aspect ratio (100% width) for inline assets
- Fixes the featured image in the Program page to be 1.5:1 (dubbed the `"classic"` aspect)