### PR TITLE
Fixes program related bugs, outpost, and meta images

### DIFF
--- a/app/cells/episode/show.erb
+++ b/app/cells/episode/show.erb
@@ -6,8 +6,8 @@
   <%= cell(:article_audio, model, type: 'episode').call(:horizontal) %>
 </section>
 <div class="o-featured-episode__center" style="order: 3">
-  <h6 class="o-featured-episode__list-heading b-heading--h6 b-heading--uppercase u-text-color--gray">From this episode</h6>
   <% if related_content.any? %>
+  <h6 class="o-featured-episode__list-heading b-heading--h6 b-heading--uppercase u-text-color--gray">From this episode</h6>
     <% related_content.each do |segment| %>
     <div class="o-featured-episode__segment">
       <figure class="o-featured-episode__segment-figure"><img src="<%= asset_path segment %>" style="background-image:url(<%= asset_path segment %>);"></figure>
@@ -33,6 +33,5 @@
       </div>
     </div>
     <% end %>
-  </ul>
   <% end %>
 </div>

--- a/app/cells/more_from_episode_cell.rb
+++ b/app/cells/more_from_episode_cell.rb
@@ -1,8 +1,8 @@
 class MoreFromEpisodeCell < Cell::ViewModel
   include Orderable
 
-  cache :show do
-    model.try(:cache_key)
+  cache :show, expires_in: 10.minutes, :if => lambda { !@options[:preview] }  do
+    [model.try(:cache_key), 'v2']
   end
 
   property :show
@@ -10,7 +10,7 @@ class MoreFromEpisodeCell < Cell::ViewModel
   property :public_path
 
   def show
-    render
+    render if model.try(:present?)
   end
 
   def headline
@@ -31,7 +31,6 @@ class MoreFromEpisodeCell < Cell::ViewModel
 
   def episode_content
     @episode_content ||= model.try(:to_article).try(:related_content) || []
-    # model.segments
   end
 
 end

--- a/app/views/programs/kpcc/_segment_preview.html.erb
+++ b/app/views/programs/kpcc/_segment_preview.html.erb
@@ -19,7 +19,7 @@
 
 <!-- LEFT ASIDE -->
 <aside class="l-column--left l--centerize" style="order: -1;">
-  <%= cell :article_audio, @article %>
+  <%= cell :article_audio, @article, preview: true %>
   <%= cell :social_tools, @article, display: 'vert' %>
 </aside>
 
@@ -42,7 +42,7 @@ end %>
 <%= cell :ad, slot: "c", class: "l-column--right", order: 1001 %>
 
 <!-- CENTER CONTENT-->
-<%= cell :article, @article, type: 'story', headline: false, preview: true %>
+<%= cell :article, @segment, type: 'story', headline: false, preview: true %>
 
 <%= cell :newsletter_appeal, @article, order: 999 %>
 

--- a/app/views/shared/content/default/_opengraph.html.erb
+++ b/app/views/shared/content/default/_opengraph.html.erb
@@ -18,7 +18,7 @@
     <meta property="article:section" content="<%=h(article.category.title)%>" />
   <% end %>
 
-  <% if article.assets.present? %>
+  <% if article.assets.any? %>
     <% article.assets.map(&:full).each do |image| %>
       <meta property="og:image" content="<%=image.url%>" />
       <meta property="og:image:type" content="image/jpeg" />
@@ -27,6 +27,11 @@
     <% end %> <%# assets %>
     <link rel="image_src" href="<%= article.asset.full.url %>" />
     <meta name="twitter:image" content="<%= https_to_http(article.asset.full.url) || "https://scpr.org/assets/kpcc-twitter-logo.png" %>">
+  <% else %>
+    <meta name="twitter:card" content="summary"/>
+    <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
   <% end %>
 
 <% end %>


### PR DESCRIPTION
- Only shows "More from episode" cell if there is an actual episode attached to the segment
- Shows the header for the segment list in the episode page only if there are any segments
- Fixes outpost previews for show_segments by giving it the original object (Outpost object)
- Defaults to general meta image for articles with no assets