### PR TITLE
Fix flatpage overflow

### DIFF
--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -45,6 +45,7 @@
 
   .o-article__body
     color: $color-gray-dark
+    display: inline-block
     font-family: $font-sans-base
     overflow: hidden
     > *

--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -37,7 +37,7 @@
     width: 100%
 
   .o-article__b-rule
-    display: block
+    display: inline-block
 
   .o-article__body a
     // paragraph links

--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -9,6 +9,7 @@
     clear: left
     float: left
     margin-left: $margin
+    position: absolute
     width: $col
 
   .l-column--right

--- a/app/assets/stylesheets/layouts/flatpage.css.sass
+++ b/app/assets/stylesheets/layouts/flatpage.css.sass
@@ -17,6 +17,7 @@
 
   .o-flatpage
     margin-bottom: $margin-in-pixels
+    overflow: hidden
 
   .o-flatpage, .o-flatpage__title
     margin-left: $margin + $col + $gutter

--- a/app/assets/stylesheets/layouts/flatpage.css.sass
+++ b/app/assets/stylesheets/layouts/flatpage.css.sass
@@ -37,6 +37,9 @@
     border-bottom: 1px solid $color-gray-light
     padding-bottom: $margin-in-pixels
 
+  #o-ad--pos-c
+    margin-bottom: $margin-in-pixels
+
   .o-popular-stories-side-bar
     margin-bottom: $margin-in-pixels
     padding-bottom: $margin-in-pixels / 2

--- a/app/assets/stylesheets/layouts/flatpage.css.sass
+++ b/app/assets/stylesheets/layouts/flatpage.css.sass
@@ -16,6 +16,7 @@
     width: $col
 
   .o-flatpage
+    display: inline-block
     margin-bottom: $margin-in-pixels
     overflow: hidden
 


### PR DESCRIPTION
This change overflows the flatpage body so that it doesn't try to follow it's parents flow (which has float right for the sidebar). It also adds proper margins underneath the sidebar for when the sidebar is taller than the body.