### PR TITLE
Add meta_tag template to article cell

### DIFF
--- a/app/cells/article/meta_tags.erb
+++ b/app/cells/article/meta_tags.erb
@@ -1,0 +1,29 @@
+<meta property="og:description" content=<%= strip_tags(model.teaser).to_json %>>
+<meta property="og:title" content=<%= model.short_title.to_json %>>
+<meta property="og:type" content="<%= @OG_TYPE || 'article' %>">
+<meta property="og:url" content="<%= model.public_url %>"/>
+<meta name="twitter:card" value="summary_large_image">
+<meta name="twitter:site" value="@kpcc">
+<meta name="twitter:url" value="<%= model.public_url %>">
+<meta name="twitter:title" value=<%= model.short_title.to_json %>>
+<meta name="twitter:description" value=<%= strip_tags(model.teaser).to_json %>>
+<meta property="article:published_time" content="<%= model.public_datetime %>" />
+<meta property="article:modified_time" content="<%= model.updated_at %>" />
+
+<% if model.category %>
+  <meta property="article:section" content=<% model.category.title.to_json %> />
+<% end %>
+
+<% if model.assets.any? %>
+  <% model.assets.map(&:full).each do |image| %>
+    <meta property="og:image" content="<%=image.url%>" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="<%=image.width%>" />
+    <meta property="og:image:height" content="<%=image.height%>" />
+  <% end %> <%# assets %>
+  <link rel="image_src" href="<%= model.asset.full.url %>" />
+  <meta name="twitter:image" content="<%= https_to_http(model.asset.full.url) || "https://scpr.org/assets/kpcc-twitter-logo.png" %>">
+<% else %>
+  <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
+  <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
+<% end %>

--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -15,12 +15,24 @@ class ArticleCell < Cell::ViewModel
     [model.try(:cache_key), 'v7']
   end
 
+  cache :meta_tags, expires_in: 10.minutes do
+    [model.try(:cache_key), 'v1']
+  end
+
   def show
     render
   end
 
   def audio_nav
     render
+  end
+
+  def meta_tags
+    render
+  end
+
+  def https_to_http url
+    url.try(:gsub, "https:", "http:")
   end
 
   def biographies links=true

--- a/app/views/news/story.html.erb
+++ b/app/views/news/story.html.erb
@@ -1,8 +1,7 @@
 <% add_to_page_title @story.try(:feature).try(:present?) ? "#{@story.try(:feature).try(:name)}: #{@story.try(:headline)}" : @story.try(:headline) %>
 <% content_for :opengraph do %>
-<% content_for :opengraph do %>
   <%= cell(:article, @article).call(:meta_tags) %>
-<% end %><% end %>
+<% end %>
 
 <% content_for :main_class, "o-article" %>
 <%= render 'shared/ads/dfp_script_config', category: @category %>

--- a/app/views/news/story.html.erb
+++ b/app/views/news/story.html.erb
@@ -1,35 +1,8 @@
 <% add_to_page_title @story.try(:feature).try(:present?) ? "#{@story.try(:feature).try(:name)}: #{@story.try(:headline)}" : @story.try(:headline) %>
 <% content_for :opengraph do %>
-  <meta property="og:description" content="<%= h(strip_tags(@article.teaser)) %>">
-  <meta property="og:title" content="<%= h(@article.short_title) %>">
-  <meta property="og:type" content="<%= @OG_TYPE || "@article" %>">
-  <meta property="og:url" content="<%= @article.public_url %>"/>
-  <meta name="twitter:card" value="summary_large_image">
-  <meta name="twitter:site" value="@kpcc">
-  <meta name="twitter:url" value="<%= @article.public_url %>">
-  <meta name="twitter:title" value="<%= h(@article.short_title) %>">
-  <meta name="twitter:description" value="<%= h(strip_tags(@article.teaser)) %>">
-  <meta property="article:published_time" content="<%=@article.public_datetime%>" />
-  <meta property="article:modified_time" content="<%=@article.updated_at%>" />
-
-  <% if @article.category %>
-    <meta property="article:section" content="<%=h(@article.category.title)%>" />
-  <% end %>
-
-  <% if @article.assets.any? %>
-    <% @article.assets.map(&:full).each do |image| %>
-      <meta property="og:image" content="<%=image.url%>" />
-      <meta property="og:image:type" content="image/jpeg" />
-      <meta property="og:image:width" content="<%=image.width%>" />
-      <meta property="og:image:height" content="<%=image.height%>" />
-    <% end %> <%# assets %>
-    <link rel="image_src" href="<%= @article.asset.full.url %>" />
-    <meta name="twitter:image" content="<%= https_to_http(@article.asset.full.url) || "https://scpr.org/assets/kpcc-twitter-logo.png" %>">
-  <% else %>
-    <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
-    <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
-  <% end %>
-<% end %>
+<% content_for :opengraph do %>
+  <%= cell(:article, @article).call(:meta_tags) %>
+<% end %><% end %>
 
 <% content_for :main_class, "o-article" %>
 <%= render 'shared/ads/dfp_script_config', category: @category %>

--- a/app/views/news/story.html.erb
+++ b/app/views/news/story.html.erb
@@ -1,5 +1,36 @@
 <% add_to_page_title @story.try(:feature).try(:present?) ? "#{@story.try(:feature).try(:name)}: #{@story.try(:headline)}" : @story.try(:headline) %>
-<% content_for :opengraph do %><%= render_content @story, "opengraph" %><% end %>
+<% content_for :opengraph do %>
+  <meta property="og:description" content="<%= h(strip_tags(@article.teaser)) %>">
+  <meta property="og:title" content="<%= h(@article.short_title) %>">
+  <meta property="og:type" content="<%= @OG_TYPE || "@article" %>">
+  <meta property="og:url" content="<%= @article.public_url %>"/>
+  <meta name="twitter:card" value="summary_large_image">
+  <meta name="twitter:site" value="@kpcc">
+  <meta name="twitter:url" value="<%= @article.public_url %>">
+  <meta name="twitter:title" value="<%= h(@article.short_title) %>">
+  <meta name="twitter:description" value="<%= h(strip_tags(@article.teaser)) %>">
+  <meta property="article:published_time" content="<%=@article.public_datetime%>" />
+  <meta property="article:modified_time" content="<%=@article.updated_at%>" />
+
+  <% if @article.category %>
+    <meta property="article:section" content="<%=h(@article.category.title)%>" />
+  <% end %>
+
+  <% if @article.assets.any? %>
+    <% @article.assets.map(&:full).each do |image| %>
+      <meta property="og:image" content="<%=image.url%>" />
+      <meta property="og:image:type" content="image/jpeg" />
+      <meta property="og:image:width" content="<%=image.width%>" />
+      <meta property="og:image:height" content="<%=image.height%>" />
+    <% end %> <%# assets %>
+    <link rel="image_src" href="<%= @article.asset.full.url %>" />
+    <meta name="twitter:image" content="<%= https_to_http(@article.asset.full.url) || "https://scpr.org/assets/kpcc-twitter-logo.png" %>">
+  <% else %>
+    <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
+    <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
+  <% end %>
+<% end %>
+
 <% content_for :main_class, "o-article" %>
 <%= render 'shared/ads/dfp_script_config', category: @category %>
 

--- a/app/views/programs/kpcc/segment.html.erb
+++ b/app/views/programs/kpcc/segment.html.erb
@@ -1,6 +1,37 @@
 <% add_to_page_title @program.try(:title) %>
 <% add_to_page_title @segment.feature.present? ? "#{@segment.feature.name}: #{@segment.headline}" : @segment.headline %>
-<% content_for :opengraph do %><%= render_content @segment, "opengraph" %><% end %>
+<% content_for :opengraph do %>
+  <meta property="og:description" content="<%= h(strip_tags(@article.teaser)) %>">
+  <meta property="og:title" content="<%= h(@article.short_title) %>">
+  <meta property="og:type" content="<%= @OG_TYPE || "@article" %>">
+  <meta property="og:url" content="<%= @article.public_url %>"/>
+  <meta name="twitter:card" value="summary_large_image">
+  <meta name="twitter:site" value="@kpcc">
+  <meta name="twitter:url" value="<%= @article.public_url %>">
+  <meta name="twitter:title" value="<%= h(@article.short_title) %>">
+  <meta name="twitter:description" value="<%= h(strip_tags(@article.teaser)) %>">
+  <meta property="article:published_time" content="<%=@article.public_datetime%>" />
+  <meta property="article:modified_time" content="<%=@article.updated_at%>" />
+
+  <% if @article.category %>
+    <meta property="article:section" content="<%=h(@article.category.title)%>" />
+  <% end %>
+
+  <% if @article.assets.any? %>
+    <% @article.assets.map(&:full).each do |image| %>
+      <meta property="og:image" content="<%=image.url%>" />
+      <meta property="og:image:type" content="image/jpeg" />
+      <meta property="og:image:width" content="<%=image.width%>" />
+      <meta property="og:image:height" content="<%=image.height%>" />
+    <% end %> <%# assets %>
+    <link rel="image_src" href="<%= @article.asset.full.url %>" />
+    <meta name="twitter:image" content="<%= https_to_http(@article.asset.full.url) || "https://scpr.org/assets/kpcc-twitter-logo.png" %>">
+  <% else %>
+    <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
+    <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
+  <% end %>
+<% end %>
+
 <% content_for :main_class, "o-article o-article--segment" %>
 <%= render 'shared/ads/dfp_script_config', category: @category %>
 

--- a/app/views/programs/kpcc/segment.html.erb
+++ b/app/views/programs/kpcc/segment.html.erb
@@ -1,35 +1,7 @@
 <% add_to_page_title @program.try(:title) %>
 <% add_to_page_title @segment.feature.present? ? "#{@segment.feature.name}: #{@segment.headline}" : @segment.headline %>
 <% content_for :opengraph do %>
-  <meta property="og:description" content="<%= h(strip_tags(@article.teaser)) %>">
-  <meta property="og:title" content="<%= h(@article.short_title) %>">
-  <meta property="og:type" content="<%= @OG_TYPE || "@article" %>">
-  <meta property="og:url" content="<%= @article.public_url %>"/>
-  <meta name="twitter:card" value="summary_large_image">
-  <meta name="twitter:site" value="@kpcc">
-  <meta name="twitter:url" value="<%= @article.public_url %>">
-  <meta name="twitter:title" value="<%= h(@article.short_title) %>">
-  <meta name="twitter:description" value="<%= h(strip_tags(@article.teaser)) %>">
-  <meta property="article:published_time" content="<%=@article.public_datetime%>" />
-  <meta property="article:modified_time" content="<%=@article.updated_at%>" />
-
-  <% if @article.category %>
-    <meta property="article:section" content="<%=h(@article.category.title)%>" />
-  <% end %>
-
-  <% if @article.assets.any? %>
-    <% @article.assets.map(&:full).each do |image| %>
-      <meta property="og:image" content="<%=image.url%>" />
-      <meta property="og:image:type" content="image/jpeg" />
-      <meta property="og:image:width" content="<%=image.width%>" />
-      <meta property="og:image:height" content="<%=image.height%>" />
-    <% end %> <%# assets %>
-    <link rel="image_src" href="<%= @article.asset.full.url %>" />
-    <meta name="twitter:image" content="<%= https_to_http(@article.asset.full.url) || "https://scpr.org/assets/kpcc-twitter-logo.png" %>">
-  <% else %>
-    <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
-    <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
-  <% end %>
+  <%= cell(:article, @article).call(:meta_tags) %>
 <% end %>
 
 <% content_for :main_class, "o-article o-article--segment" %>


### PR DESCRIPTION
Rather than use the method `render_content` to render the meta tags, I figured it would make sense to include that template as a method to the article cell. We can then use cell caching to cache the tags. 

Prior to this, `render_content` would check if there was a cache for a particular story, and if not, call `to_article` again on the input model to get it ready for the opengraph template. Since the model is usually in the correct shape by the time it reaches the article_cell, we wouldn't need to re-call `to_article` in the new implementation.

Also, rather than using `h()` to escape html tags, I elected to use `.to_json` like in the comment cell. Doing so meant removing the quotes that wrapped around the variables (ie `content=<%= strip_tags(model.teaser).to_json %>` instead of `content="<%= strip_tags(model.teaser).to_json %>"`)