### PR TITLE
Updates vulnerable gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem "recaptcha", require: "recaptcha/rails"
 gem "yajl-ruby", "~> 1.3.1" # Faster JSON parsing
 gem "rack-utf8_sanitizer"
 gem "rufus-scheduler"
-gem 'rubyzip', require: false
+gem 'rubyzip', "~> 1.2.1", require: false
 gem 'pygments.rb', "~> 1.1.0"
 gem 'reverse_markdown', require: false
 gem 'htmlentities', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -50,11 +50,11 @@ gem "carrierwave", "~> 0.6"
 gem "ruby-mp3info", '~> 0.8.2', require: 'mp3info'
 gem "ice_cube", "~> 0.11.0"
 gem "recaptcha", require: "recaptcha/rails"
-gem "yajl-ruby" # Faster JSON parsing
+gem "yajl-ruby", "~> 1.3.1" # Faster JSON parsing
 gem "rack-utf8_sanitizer"
 gem "rufus-scheduler"
 gem 'rubyzip', require: false
-gem 'pygments.rb'
+gem 'pygments.rb', "~> 1.1.0"
 gem 'reverse_markdown', require: false
 gem 'htmlentities', require: false
 gem 'honeybadger', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,7 +596,7 @@ DEPENDENCIES
   rspec_junit_formatter!
   ruby-mp3info (~> 0.8.2)
   ruby-prof
-  rubyzip
+  rubyzip (~> 1.2.1)
   rufus-scheduler
   sanitize (~> 2.0)
   sass-rails (= 5.0.0beta1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,7 +335,6 @@ GEM
       multi_json
       oauth2
       uri_template
-    posix-spawn (0.3.11)
     postmark (1.1.2)
       json
       rake
@@ -346,9 +345,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
+    pygments.rb (1.1.2)
+      multi_json (>= 1.0.0)
     rack (1.6.8)
     rack-protection (1.5.3)
       rack
@@ -445,7 +443,7 @@ GEM
     rspec-support (3.2.2)
     ruby-mp3info (0.8.4)
     ruby-prof (0.15.2)
-    rubyzip (1.1.7)
+    rubyzip (1.2.1)
     rufus-scheduler (3.0.9)
       tzinfo
     safe_yaml (1.0.4)
@@ -516,7 +514,7 @@ GEM
       hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.2.0)
+    yajl-ruby (1.3.1)
 
 PLATFORMS
   ruby
@@ -582,7 +580,7 @@ DEPENDENCIES
   pmp (= 0.5.6)
   postmark-rails (~> 0.6.0)
   pry
-  pygments.rb
+  pygments.rb (~> 1.1.0)
   rack-utf8_sanitizer
   rails (~> 4.2.0)
   rb-fsevent (~> 0.9)
@@ -613,7 +611,7 @@ DEPENDENCIES
   twitter-text (~> 1.5)
   uglifier (>= 1.3)
   webmock
-  yajl-ruby
+  yajl-ruby (~> 1.3.1)
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
This updates `yajl-ruby` and `rubyzip`. `pygments.rb` relied on `yajl-ruby` v. 1.2.0, so I had to update that to the nearest version that didn't require that version anymore.