### PR TITLE
Reroute old links

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -168,7 +168,7 @@ class ProgramsController < ApplicationController
     if !@episode
       flash[:alert] = "There is no #{@program.title} " \
                       "episode for #{@date.strftime('%F')}."
-      redirect_to featured_show_path(@program.slug, anchor: "archive")
+      redirect_to list_path(@program.slug, anchor: "archive")
     else
       redirect_to @episode.public_path
     end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -8,7 +8,7 @@ class ProgramsController < ApplicationController
   include Concern::Controller::ShowEpisodes
   include Concern::Controller::Amp
 
-  before_filter :get_program, only: [:show, :episode, :archive, :featured_program, :featured_show]
+  before_filter :get_program, only: [:show, :episode, :archive, :featured_program, :list]
   before_filter :get_popular_articles, only: [:featured_program, :segment]
 
   respond_to :html, :xml, :rss
@@ -52,7 +52,7 @@ class ProgramsController < ApplicationController
           @episodes = (@current_episode ? @episodes.where.not(id:@current_episode.id) : @episodes).page(params[:page]).per(6)
           render
         else
-          @episodes = @program.episodes.published.page(params[:page]).per(6)
+          @collection = @program.episodes.published.page(params[:page]).per(6)
           render 'standard_program'
         end
       end
@@ -66,6 +66,43 @@ class ProgramsController < ApplicationController
     end
   end
 
+  def list
+    if @program.is_a?(KpccProgram) && @program.is_featured?
+      @view_type = params[:view]
+      @segments = @program.segments.published
+      @episodes = @program.episodes.published
+
+      respond_with do |format|
+        format.html do
+          if @current_episode = @episodes.first
+            @episodes = @episodes.where.not(id: @current_episode.id)
+
+            segments = @current_episode.segments.published.to_a
+            @segments = @segments.where.not(id: segments.map(&:id))
+          end
+
+          @segments = @segments.page(params[:page]).per(10)
+          @episodes = @episodes.page(params[:page]).per(6)
+          if @view_type == "episodes" || @view_type.blank?
+            @collection = @episodes
+          else
+            @collection = @segments
+          end
+          render 'standard_program'
+        end
+
+        format.xml { render 'programs/kpcc/old/show' }
+      end
+
+      return
+    else
+      if @program.public_path
+        redirect_to @program.public_path
+      else
+        redirect_to program_url(@program.slug)
+      end
+    end
+  end
 
   def segment
     @segment = ShowSegment.published.includes(:show).find(params[:id])

--- a/app/views/programs/standard_program.erb
+++ b/app/views/programs/standard_program.erb
@@ -36,8 +36,11 @@
 <%= cell :archive_picker, @program, base_url: "/programs/" + @program.slug + "/archive", header: "Find a specific episode from " + @program.try(:title) + "'s archive", type: "full", order: 6 %>
 <%= cell(:appeal, @program, order: 4).call(:podcast) %>
 <%= cell :ad, slot: "c", id: "o-ad--pos-c", order: 7 %>
-<%= cell :episode_list, @episodes, class: 'o-standard-program__episode-list', program: @program, header: 'Recent episodes', order: 1 %>
-<%= paginate @episodes %>
+<%= cell :episode_list, @collection, class: 'o-standard-program__episode-list', program: @program, header: "Recent #{@view_type || 'episodes'}", order: 1 %>
+<%= paginate @collection %>
+<% if @view_type == "episodes" %>
+  <%= cell :archive_picker, @program, id: 'o-archive-picker__standard-program-episode', base_url: "/programs/" + @program.slug + "/archive", header: "Find a specific episode from " + @program.try(:title) + "'s archive", type: "full", order: 3 %>
+  <% end %>
 <%= cell :featured_programs, @program, order: 11 %>
 <%= cell :popular_articles, @program, class: "o-popular-stories--horiz", order: 1001 %>
 <%= cell :epilogue, @program, order: 1001 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Scprv4::Application.routes.draw do
 
   # Programs / Segments
   get '/programs/:show' => "programs#show"
-  get '/programs/:show/featured' => "programs#show", as: :featured_show
+  get '/programs/:show/featured' => "programs#list"
   # This route is for displaying a clone of the old layout for featured programs for an index of episodes and segments
   # Legacy route for old Episode URLs
   get '/programs/:show/:year/:month/:day/' => "programs#episode", constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Scprv4::Application.routes.draw do
 
   # Programs / Segments
   get '/programs/:show' => "programs#show"
-  get '/programs/:show/featured' => "programs#list"
+  get '/programs/:show/featured' => "programs#list", as: :list
   # This route is for displaying a clone of the old layout for featured programs for an index of episodes and segments
   # Legacy route for old Episode URLs
   get '/programs/:show/:year/:month/:day/' => "programs#episode", constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ }

--- a/spec/controllers/programs_controller_spec.rb
+++ b/spec/controllers/programs_controller_spec.rb
@@ -56,7 +56,7 @@ describe ProgramsController do
           "date(3i)" => "1"
         }
       assigns(:episode).should eq nil
-      expect(response).to redirect_to featured_show_path(program.slug, anchor: "archive")
+      expect(response).to redirect_to list_path(program.slug, anchor: "archive")
     end
   end
 


### PR DESCRIPTION
This kind of page is currently broken in prod: http://www.scpr.org/programs/airtalk/featured?page=1568&view=segments

It's because the #featured_show method was rerouted to the normal #show method. This change re-enables this functionality and hopefully fixes old links that appear in search results (which currently redirect to the program page).