### PR TITLE
Press release templates

### DIFF
--- a/app/assets/stylesheets/layouts/flatpage.css.sass
+++ b/app/assets/stylesheets/layouts/flatpage.css.sass
@@ -51,7 +51,7 @@
     margin-right: $gutter + $col + $margin
     width: ($col * 10) + ($gutter * 9)
 
-  .o-flatpage--inherit, .o-flatpage--kpcc_in_person, .o-flatpage__title
+  .o-flatpage--inherit, .o-flatpage--kpcc_in_person
     width: ($col * 6) + ($gutter * 5)
 
   @media (max-width: $media-wide)

--- a/app/cells/flatpage/show.erb
+++ b/app/cells/flatpage/show.erb
@@ -1,3 +1,3 @@
-<div class="o-flatpage o-flatpage--<%= model.template %>" style="order: <%= @options[:order] %>">
-  <%= model.content.html_safe %>
+<div class="o-flatpage o-flatpage--<%= template %>" style="order: <%= @options[:order] %>">
+  <%= model.try(:content).try(:html_safe) || model.try(:body).try(:html_safe) %>
 </div>

--- a/app/cells/flatpage_cell.rb
+++ b/app/cells/flatpage_cell.rb
@@ -3,6 +3,10 @@ class FlatpageCell < Cell::ViewModel
     render
   end
 
+  def template
+    model.try(:template) || "full"
+  end
+
   def render_body options={}
     doc = Nokogiri::HTML(model.content.html_safe)
     order_body doc

--- a/app/views/flatpages/show.html.erb
+++ b/app/views/flatpages/show.html.erb
@@ -31,6 +31,6 @@
   <%= cell(:popular_articles, nil, order: 1000).call(:side_bar) %>
   <%= cell :ad, slot: "c", id: "o-ad--pos-c", order: 1001 %>
 <% end %>
-<h1 class="o-flatpage__title" style="order: 1"><%= @flatpage.title %></h1>
+<h1 class="o-flatpage__title o-flatpage--<%= @flatpage.template %>" style="order: 1"><%= @flatpage.title %></h1>
 <%= cell :flatpage, @flatpage, order: 2, email: false %>
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,7 +1,12 @@
 <% content_for :main_class, "l-flatpage" %>
 <% add_to_page_title "Staff" %>
 
-<h1 class="o-flatpage o-flatpage__title">Staff</h1>
+<%= cell :ad, slot: "a", id: "o-ad--pos-a", attribution: false, order: 1 %>
+<%= cell :ad, slot: "b", id: "o-ad--pos-b", order: 3 %>
+<%= cell(:appeal).call(:breaking_news) %>
+<%= cell(:popular_articles).call(:side_bar) %>
+<%= cell :ad, slot: "c", id: "o-ad--pos-c", order: 1000 %>
+<h1 class="o-flatpage__title o-flatpage--inherit">Staff</h1>
 <div class="o-flatpage o-flatpage--inherit" style="order: 2">
   <p><strong>Southern California Public Radio News Staff</strong></p>
   <p>The hosts, producers and others who make what you hear -- both on air and off.</p>
@@ -18,8 +23,3 @@
   </table>
 </div>
 
-<%= cell :ad, slot: "a", id: "o-ad--pos-a", attribution: false, order: 1 %>
-<%= cell :ad, slot: "b", id: "o-ad--pos-b", order: 3 %>
-<%= cell(:appeal).call(:breaking_news) %>
-<%= cell(:popular_articles).call(:side_bar) %>
-<%= cell :ad, slot: "c", id: "o-ad--pos-c", order: 1000 %>

--- a/app/views/press_releases/index.html.erb
+++ b/app/views/press_releases/index.html.erb
@@ -1,13 +1,24 @@
-<h1><%= add_to_page_title "Press" %></h1>
+<% content_for :main_class, "l-flatpage" %>
+<% add_to_page_title "Press" %>
 
-<table class="table table-striped">
-  <tbody>
-    <% @press_releases.each do |press_release| %>
-        <tr>
-          <td><%= link_to press_release.short_title, press_release.public_path %> (<%= format_date(press_release.created_at) %>)</td>
-        </tr>
-    <% end %>
-  </tbody>
-</table>
+<h1 class="o-flatpage__title o-flatpage--full" style="margin-bottom: 30px;"><%= add_to_page_title "Press" %></h1>
+<div class="o-flatpage o-flatpage--full" style="order: 2">
 
-<%= paginate @press_releases %>
+  <table class="table table-striped">
+    <tbody>
+      <% @press_releases.each do |press_release| %>
+          <tr style="height: 30px;">
+            <td>
+              <ul>
+                <li>
+                  <%= link_to press_release.short_title, press_release.public_path %> (<%= format_date(press_release.created_at) %>)
+                </li>
+              </ul>
+            </td>
+          </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @press_releases %>
+</div>

--- a/app/views/press_releases/show.html.erb
+++ b/app/views/press_releases/show.html.erb
@@ -1,2 +1,20 @@
-<h2><%= add_to_page_title @press_release.title %></h2>
-<%= @press_release.body.html_safe %>
+<% content_for :main_class, "l-flatpage" %>
+
+<% add_to_page_title @press_release.title %>
+
+<% content_for :opengraph do %>
+  <meta property="og:title" content="<%= j @press_release.title %>">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="<%= @press_release.public_url %>"/>
+  <meta property="og:image" content="<%=image_url('meta/facebook.jpg')%>" />
+  <meta name="twitter:card" value="summary">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" value="@kpcc">
+  <meta name="twitter:url" value="<%= @press_release.public_url %>">
+  <meta name="twitter:title" value="<%= j @press_release.title %>">
+  <meta name="twitter:image" content="<%=image_url('meta/twitter.jpg')%>">
+<% end %>
+
+<h1 class="o-flatpage__title o-flatpage--full" style="order: 1"><%= @press_release.title %></h1>
+<%= cell :flatpage, @press_release, order: 2, email: false %>
+


### PR DESCRIPTION
- Applies a full width flatpage structure to press release individual/index pages
- Fixes the way flatpage titles are sized
- Fixes float issues with staff directory page (which is also based on flatpage styling/structure)