### PR TITLE
Remove GA script and event_tracking script

### DIFF
--- a/app/assets/javascripts/aplicayshun.js
+++ b/app/assets/javascripts/aplicayshun.js
@@ -44,13 +44,3 @@
 require('./nuevo/popup');
 var adSizer = require('./nuevo/ad-sizer');
 new adSizer();
-
-$(document).ready(function() {
-  $.scrollDepth({
-      elements: ['.o-newsletter-appeal'],
-      percentage: false,
-      userTiming: false,
-      pixelDepth: false,
-      gtmOverride: true
-    });
-});

--- a/app/assets/javascripts/aplicayshun.js
+++ b/app/assets/javascripts/aplicayshun.js
@@ -1,7 +1,6 @@
 //= require shared
 //= require page_mapping
 //= require jquery.scrolldepth
-//= require event_tracking
 //= require jplayer/dist/jplayer/jquery.jplayer.min
 //= require audio
 //= require utilities

--- a/app/assets/javascripts/audio.js.coffee
+++ b/app/assets/javascripts/audio.js.coffee
@@ -15,7 +15,7 @@ class scpr.Audio
             supplied: "mp3"
             wmode:    "window"
             play: (e) =>
-                if @state?.started != true
+                if @state.started != true
                     @state = {}
                     @sendEvent
                         action: 'start'
@@ -43,6 +43,7 @@ class scpr.Audio
                     @state.started = false
             loadstart: () =>
                 @state = {}
+                @state.started = true
 
 
         @audiobar = $(@options.audioBar)

--- a/app/cells/article/show.erb
+++ b/app/cells/article/show.erb
@@ -41,8 +41,6 @@
 <%= pij_source %>
 
 <script>
-    scpr.Behaviors.loadBehaviors(['Layout', 'Single']);
-
     // Load In-Article Membership Appeal from AdHost
     scpr.VisualCampaign.enqueue('article-appeal', $('#article-membership-appeal'));
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-585PL29');</script>
     <!-- Use title if it's in the page YAML frontmatter -->
     <% add_to_page_title @TITLE_ELEMENTS.present? ? "89.3 KPCC" : "89.3 KPCC - Southern California Public Radio" %>
     <title><%= page_title %></title>

--- a/app/views/shared/footer/_tracking_scripts.html.erb
+++ b/app/views/shared/footer/_tracking_scripts.html.erb
@@ -64,40 +64,6 @@ el.parentNode.insertBefore(s, el);
 </script>
 <!-- /ChartBeat -->
 
-<!-- Google Analytics -->
-<script>
-
-  // Set the pageType to push to GA
-  var _gaq_pageType = _.find(scpr.GA_PAGE_MAPPING, function(v, k) {
-      return window.location.pathname.match(new RegExp(k)) !== null;
-  });
-
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  // Tracker for SCPR GA Account
-  ga('create', 'UA-624724-1', 'auto', {'allowLinker': true});
-  // Tracker for NPR Digital Services Station Analytics
-  ga('create', 'UA-18188937-11', 'auto', {'name': 'nprDsTracker'}, {'allowLinker': true});
-
-  ga('require', 'linker'); // require plugin for cross-domain tracking
-  ga('require', 'displayfeatures'); // require plugin for Doubleclick Display Ad features
-  ga('linker:autoLink', ['scprcontribute.publicradio.org']); //set linked domain
-  if(document.cookie.indexOf("beta_opt_in") > -1){
-    ga('set', 'dimension5', 'Homepage Beta');
-  } else {
-    ga('set', 'dimension5', 'Homepage Classic');
-  }
-  ga('set', 'dimension6', 'Southern California Public Radio');
-  ga('set', 'dimension7', _gaq_pageType);
-  ga('send', 'pageview');
-  ga('nprDsTracker.send', 'pageview');
-
-</script>
-<!-- /Google Analytics -->
-
 <!-- Mogo Pixel -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Major changes:
- Removed the GA script from the footer and added exact copy of it to GTM (labeled 'Legacy GA Script'). This script will run first in priority
- Removed the `event_tracking` script from application.js ('aplicayshun.js') and added the transpiled JS to GTM (labeled 'Legacy Event Tracking Script'). This script will run after the GA script mentioned above.
- Fixed an issue with the way quartiles are being reported

Minor adjacent change:
- Removed unused behavior functionality from articles