### PR TITLE
Add memory logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'pygments.rb'
 gem 'reverse_markdown', require: false
 gem 'htmlentities', require: false
 gem 'honeybadger', '~> 2.0'
-
+gem 'oink', '~> 0.10.1'
 
 ## HTTP
 gem "faraday", "~> 0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
     hashdiff (0.3.0)
     hashie (1.2.0)
     hike (1.2.3)
+    hodel_3000_compliant_logger (0.1.1)
     honeybadger (2.7.0)
     html-pipeline (2.4.2)
       activesupport (>= 2)
@@ -322,6 +323,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
+    oink (0.10.1)
+      activerecord
+      hodel_3000_compliant_logger
     one_signal (1.2.0)
     open_uri_redirections (0.2.1)
     outpost-publishing (1.0.1)
@@ -570,6 +574,7 @@ DEPENDENCIES
   newrelic_rpm (~> 3.16)
   npr (~> 3.0)!
   oauth2 (~> 0.8)
+  oink (~> 0.10.1)
   one_signal
   open_uri_redirections
   outpost-aggregator!

--- a/config/initializers/memory_logger.rb
+++ b/config/initializers/memory_logger.rb
@@ -1,0 +1,1 @@
+Rails.application.middleware.use( Oink::Middleware, :logger => Rails.logger )

--- a/config/initializers/memory_logger.rb
+++ b/config/initializers/memory_logger.rb
@@ -1,1 +1,1 @@
-Rails.application.middleware.use( Oink::Middleware, :logger => Rails.logger )
+Scprv4::Application.config.middleware.use Oink::Middleware

--- a/config/initializers/memory_logger.rb
+++ b/config/initializers/memory_logger.rb
@@ -1,1 +1,1 @@
-Scprv4::Application.config.middleware.use Oink::Middleware
+Scprv4::Application.config.middleware.use( Oink::Middleware, :logger => Rails.logger )


### PR DESCRIPTION
The changes add Oink, a memory logger, to the environment logger.

Running `bundle exec oink log/production.log` should give a rundown of the worst culprits when it comes to memory usage / active record calls.