### PR TITLE
Fix ordered lists

### DIFF
--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -129,6 +129,14 @@
       @media (max-width: $media-tablet)
         width: 100% - ($margin * 2) !important
 
+    .group-wrapper
+      clear: both
+
+    .group-right
+      float: right
+
+    .group-left
+      float: left
 
   .o-article__body iframe
     width: 100%

--- a/app/assets/stylesheets/layouts/article.css.sass
+++ b/app/assets/stylesheets/layouts/article.css.sass
@@ -76,6 +76,14 @@
       // paragraph links
       color: $color-secondary
 
+    ol
+      list-style: decimal
+      padding-left: 3em
+      font-size: 0.9em
+      margin-bottom: 27.68px
+      li
+        margin: 1em 0
+
     ul
       list-style: circle
       padding-left: 3em

--- a/app/cells/ad_cell.rb
+++ b/app/cells/ad_cell.rb
@@ -1,7 +1,7 @@
 class AdCell < Cell::ViewModel
   include Orderable
   cache :show do
-    "c-ad #{model[:id]} #{ad_key} #{model[:class]}"
+    ["c-ad", model[:id], ad_key, model[:class], model[:order]]
   end
 
   def show &block

--- a/app/views/programs/standard_program.erb
+++ b/app/views/programs/standard_program.erb
@@ -6,10 +6,10 @@
       <div class="o-prologue__teaser">
         <%= @program.try(:teaser) %>
       </div>
-      <% if @program.try(:host).try(:any?) %>
+      <% if !@program.try(:host).try(:empty?) %>
         <address>Hosted by <%= @program.try(:host) %></address>
         <% end %>
-      <% if @program.try(:airtime).try(:any?) %>
+      <% if !@program.try(:airtime).try(:empty?) %>
         <div class="o-prologue__airtime">
           <div>Airs <%= @program.try(:airtime) %></div>
           <div class="o-prologue__social-icons">


### PR DESCRIPTION
This change fixes styling for ordered lists (numbers weren't showing up). Also updates the cache_key for ad cells to be more specific, and fixes an error in external program pages where airdate and host names were not showing up.