### PR TITLE
Aesthetic Unity: Speed revision 01

### DIFF
--- a/app/cells/featured_quote/show.erb
+++ b/app/cells/featured_quote/show.erb
@@ -6,7 +6,7 @@
   <span class="o-featured-quote__source-context"><%= source_context %></span>
   <% if article %>
     <a class="o-featured-quote__article-link b-link b-link--callout" href="<%= article.public_path %>" title="Read this quote's source article">
-      <%= article.short_title %> >
+      <%= article.try(:short_title) || article.try(:short_headline) %> >
     </a>
   <% end %>
 </aside>

--- a/app/cells/featured_story/vertical.erb
+++ b/app/cells/featured_story/vertical.erb
@@ -28,7 +28,7 @@
       <h6 class="o-featured-story__related-list__heading b-heading b-heading--h6 b-heading--uppercase u-text-color--gray">Related</h6>
       <ul class="o-featured-story__related-list c-list c-list--bullet">
         <% related_content[0..1].try(:each) do |article| %>
-          <li><%= link_to article.try(:short_title), article.try(:public_path) %></li>
+          <li><%= link_to article.try(:short_title) || article.try(:short_headline), article.try(:public_path) %></li>
         <% end %>
       </ul>
     <% end %>

--- a/app/cells/related_links_cell.rb
+++ b/app/cells/related_links_cell.rb
@@ -9,12 +9,20 @@ class RelatedLinksCell < Cell::ViewModel
     render if links.any?
   end
 
+  def related_content
+    model.try(:related_content) || []
+  end
+
+  def related_links
+    model.try(:related_links) || []
+  end
+
   def links
     # There's some legacy code here, but I'm keeping it because
     # just having it extracted from the template is an improvement,
     # and who knows if we might want to start using some of these
     # returned attributes again in the future.
-    @links ||= (model.try(:related_content) + model.try(:links)).map do |content|
+    @links ||= (related_content + related_links).map do |content|
       classes     = "track-event"
       url         = nil
       title       = nil
@@ -41,7 +49,7 @@ class RelatedLinksCell < Cell::ViewModel
         end
 
         url     = content.url
-        title   = content.title
+        title   = content.try(:title) || content.try(:headline)
       else
         # hopefully these are content...
         if content.try(:feature).try(:_key).present?
@@ -51,7 +59,7 @@ class RelatedLinksCell < Cell::ViewModel
         end
 
         url     = content.public_path
-        title   = content.short_title
+        title   = content.try(:short_title) || content.try(:short_headline)
 
         descriptor = content.feature.try(:name) || "Article"
       end

--- a/app/cells/resources/show.erb
+++ b/app/cells/resources/show.erb
@@ -9,10 +9,10 @@
   <ul class="o-resources__articles">
     <% articles.try(:each) do |article| %>
       <li>
-        <a href="<%= article.public_path %>">
+        <a href="<%= article.try(:public_url) %>">
           <figure class="o-resources__figure o-figure o-figure--four-by-three">
             <img class="o-figure__img" src="<%= asset_path article %>" style="background-image:url(<%= asset_path article %>);">
-            <figcaption class="o-resources__figure__caption"><%= article.short_title %></figcaption>
+            <figcaption class="o-resources__figure__caption"><%= article.try(:short_title) || article.try(:short_headline) %></figcaption>
           </figure>
         </a>
       </li>

--- a/app/cells/topic_cluster/vertical.erb
+++ b/app/cells/topic_cluster/vertical.erb
@@ -12,7 +12,7 @@
         </figure>
         <div class="o-topic-cluster__content-description">
           <h4 class="o-topic-cluster__headline">
-            <a class="o-media__headline-link" href="<%= feature.public_url %>"><%= feature.short_title %></a>
+            <a class="o-media__headline-link" href="<%= feature.public_url %>"><%= feature.try(:short_title) || feature.try(:short_headline) %></a>
           </h4>
           <div class="o-topic-cluster__byline"><%= byline feature %></div>
           <div class="o-topic-cluster__datetime"><%= feature.public_datetime.try(:strftime, "%B %-d, %Y") %></div>

--- a/app/cells/topic_cluster/vertical.erb
+++ b/app/cells/topic_cluster/vertical.erb
@@ -12,7 +12,7 @@
         </figure>
         <div class="o-topic-cluster__content-description">
           <h4 class="o-topic-cluster__headline">
-            <a class="o-media__headline-link" href="<%= feature.public_url %>"><%= feature.try(:short_title) || feature.try(:short_headline) %></a>
+            <a class="o-media__headline-link" href="<%= feature.try(:public_url) || feature.try(:public_path) %>"><%= feature.try(:short_title) || feature.try(:short_headline) %></a>
           </h4>
           <div class="o-topic-cluster__byline"><%= byline feature %></div>
           <div class="o-topic-cluster__datetime"><%= feature.public_datetime.try(:strftime, "%B %-d, %Y") %></div>

--- a/app/concerns/concern/associations/related_content_association.rb
+++ b/app/concerns/concern/associations/related_content_association.rb
@@ -23,7 +23,7 @@ module Concern
         # ^^^
         # Sometimes we use the related content association to relate
         # content to non-content, like Tags and BroadcastContent.  However,
-        # since we need to convert our references to articles here, and 
+        # since we need to convert our references to articles here, and
         # since said non-content does not convert to an article, we need to
         # only include objects that are of content models.
         #
@@ -63,13 +63,13 @@ module Concern
           # Outgoing references: Where `content` is this object
           # So we want to grab `related`
           self.outgoing_references.includes(:related).each do |reference|
-            content.push reference.related.try(:to_article)
+            content.push reference.related
           end
 
           # Incoming references: Where `related` is this object
           # So we want to grab `content`
           self.incoming_references.includes(:content).each do |reference|
-            content.push reference.content.try(:to_article)
+            content.push reference.content
           end
 
           # Compact to make sure no nil records get through - those would

--- a/app/concerns/concern/associations/related_content_association.rb
+++ b/app/concerns/concern/associations/related_content_association.rb
@@ -75,7 +75,13 @@ module Concern
           # Compact to make sure no nil records get through - those would
           # be unpublished content.
           content.compact.uniq
-            .sort { |a, b| b.public_datetime <=> a.public_datetime }
+            .sort { |a, b|
+              if b.try(:public_datetime) && a.try(:public_datetime)
+                b.public_datetime <=> a.public_datetime
+              elsif b.try(:published_at) && a.try(:published_at)
+                b.published_at  <=> a.published_at
+              end
+            }
         end
       end
 

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -22,7 +22,7 @@ class Quote < ActiveRecord::Base
 
 
   def article
-    self.content.try(:to_article)
+    self.content
   end
 
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -47,13 +47,14 @@ class Tag < ActiveRecord::Base
       outgoing_references
         .order("position ASC")
         .where(related_omissions)
+        .limit(3).map(&:related)
     elsif taggings.count > 2
       taggings
         .order("created_at DESC")
         .where(tagging_omissions)
         .limit(10)
         .map(&:taggable)
-        .select{|a| a.respond_to?(:to_article)}
+        .select{|a| a.try(:public_datetime)}
         .first(3)
     else
       []

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -47,7 +47,6 @@ class Tag < ActiveRecord::Base
       outgoing_references
         .order("position ASC")
         .where(related_omissions)
-        .limit(3).map(&:related).map(&:to_article)
     elsif taggings.count > 2
       taggings
         .order("created_at DESC")
@@ -55,8 +54,6 @@ class Tag < ActiveRecord::Base
         .limit(10)
         .map(&:taggable)
         .select{|a| a.respond_to?(:to_article)}
-        .map(&:to_article)
-        .select{|a| a.try(:public_datetime)}
         .first(3)
     else
       []

--- a/app/models/vertical.rb
+++ b/app/models/vertical.rb
@@ -53,7 +53,7 @@ class Vertical < ActiveRecord::Base
   def featured_articles
     @featured_articles ||= self.vertical_articles
       .includes(:article).select(&:article)
-      .map { |a| a.article.to_article }
+      .map { |a| a.article }
   end
 
 

--- a/app/views/better_homepage/_tag_cluster.html.erb
+++ b/app/views/better_homepage/_tag_cluster.html.erb
@@ -8,7 +8,7 @@
           <img class="o-media__img" src="<%= begin feature.asset.asset.thumb.url rescue '/static/images/fallback-img-square.png' end %>">
         </div>
         <h4>
-          <%= link_to feature.title, feature.public_url %>
+          <%= link_to feature.try(:title) || feature.try(:headline), feature.try(:public_url) || feature.try(:public_path) %>
         </h4>
       </div>
     <% end %>

--- a/app/views/better_homepage/_tag_cluster.html.erb
+++ b/app/views/better_homepage/_tag_cluster.html.erb
@@ -8,7 +8,7 @@
           <img class="o-media__img" src="<%= begin feature.asset.asset.thumb.url rescue '/static/images/fallback-img-square.png' end %>">
         </div>
         <h4>
-          <%= link_to feature.try(:title) || feature.try(:headline), feature.try(:public_url) || feature.try(:public_path) %>
+          <%= link_to feature.try(:headline), feature.try(:public_url) %>
         </h4>
       </div>
     <% end %>

--- a/app/views/blogs/entry.html.erb
+++ b/app/views/blogs/entry.html.erb
@@ -49,7 +49,7 @@ end %>
 
 <hr class="o-article__rule--ending b-rule b-rule--primary-lightest b-rule--padded" style="order: 998;" />
 
-<%= cell :related_links, @article, order: 998 %>
+<%= cell :related_links, @entry, order: 998 %>
 
 <%= cell :social_tools, @article, display: 'horiz', order: 998 %>
 

--- a/app/views/news/story.html.erb
+++ b/app/views/news/story.html.erb
@@ -35,7 +35,7 @@ end %>
 
 <hr class="o-article__rule--ending b-rule b-rule--primary-lightest", style="order: 992;" />
 
-<%= cell :related_links, @article, order: 993 %>
+<%= cell :related_links, @story, order: 993 %>
 
 <%= cell :social_tools, @article, display: 'horiz', order: 994 %>
 

--- a/app/views/outpost/verticals/_form_fields.html.erb
+++ b/app/views/outpost/verticals/_form_fields.html.erb
@@ -98,7 +98,7 @@
           {
             el: "#aggregator_quote_content",
             inputEl: "#quote_content_json",
-            collection: <%= render_json("api/private/v2/articles/collection", articles: Array(qf.object.article)) %>,
+            collection: <%= render_json("api/private/v2/articles/collection", articles: Array(qf.object.article.try(:to_article))) %>,
             apiType: "private",
             view: {
               dropMaxLimit: 1,

--- a/app/views/programs/kpcc/_segment_preview.html.erb
+++ b/app/views/programs/kpcc/_segment_preview.html.erb
@@ -48,7 +48,7 @@ end %>
 
 <hr class="o-article__rule--ending b-rule b-rule--primary-lightest b-rule--padded" style="order: 999;" />
 
-<%= cell :related_links, @article, order: 999 %>
+<%= cell :related_links, @segment, order: 999 %>
 
 <%= cell :more_from_episode, @episode, order: 999 %>
 

--- a/app/views/programs/kpcc/segment.html.erb
+++ b/app/views/programs/kpcc/segment.html.erb
@@ -70,7 +70,7 @@ end %>
 
 <hr class="o-article__rule--ending b-rule b-rule--primary-lightest b-rule--padded" style="order: 999;" />
 
-<%= cell :related_links, @article, order: 999 %>
+<%= cell :related_links, @segment, order: 999 %>
 
 <%= cell :more_from_episode, @episode, order: 999 %>
 

--- a/app/views/shared/new/_single_preview.html.erb
+++ b/app/views/shared/new/_single_preview.html.erb
@@ -25,7 +25,7 @@ end %>
 
 <hr class="o-article__rule--ending b-rule b-rule--primary-lightest", style="order: 992;" />
 
-<%= cell :related_links, @entry.get_article, order: 993, preview: true %>
+<%= cell :related_links, @entry, order: 993, preview: true %>
 
 <%= cell :social_tools, @entry, display: 'horiz', order: 994 %>
 

--- a/spec/concerns/concern/associations/quote_association_spec.rb
+++ b/spec/concerns/concern/associations/quote_association_spec.rb
@@ -8,7 +8,7 @@ describe Concern::Associations::QuoteAssociation do
   end
 
   it "#article is the content.to_article" do
-    @quote.article.should eq @post.to_article
+    @quote.article.should eq @post
   end
 
   it "destroys the join record on destroy" do

--- a/spec/concerns/concern/associations/related_content_association_spec.rb
+++ b/spec/concerns/concern/associations/related_content_association_spec.rb
@@ -74,11 +74,11 @@ describe Concern::Associations::RelatedContentAssociation do
     end
 
     it "doesn't return unpublished content" do
-      @object.related_content.should_not include @post.to_article
+      @object.related_content.should_not include @post
     end
 
     it "Returns all the related records and sorted by published_at desc" do
-      @object.related_content.should eq [@segment, @shell, @story].map(&:to_article)
+      @object.related_content.should eq [@segment, @shell, @story]
     end
 
     it "doesn't return duplicate content" do

--- a/spec/features/vertical_spec.rb
+++ b/spec/features/vertical_spec.rb
@@ -71,7 +71,7 @@ describe "Vertical page", :indexing do
       within(".o-featured-story__related-list") do
         # make sure top story doesn't show up in the promoted
         # 'more from this topic' section
-        page.should_not have_content vertical.featured_articles.first.short_title
+        page.should_not have_content vertical.featured_articles.first.short_headline
       end
 
       # within("aside.o-vertical-topics") do

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -22,12 +22,4 @@ describe Quote do
       quote.content(true).should be_nil
     end
   end
-
-  describe '#article' do
-    it "is the content to_article" do
-      story = build :news_story, :published
-      quote = build :quote, content: story
-      quote.article.should eq story.to_article
-    end
-  end
 end

--- a/spec/models/vertical_spec.rb
+++ b/spec/models/vertical_spec.rb
@@ -20,7 +20,7 @@ describe Vertical do
       story = create :news_story
       vertical_article = create :vertical_article, vertical: vertical, article: story
 
-      vertical.featured_articles.map(&:class).uniq.should eq [Article]
+      vertical.featured_articles.map(&:class).uniq.should eq [NewsStory]
     end
 
     it "only gets published articles" do
@@ -31,7 +31,7 @@ describe Vertical do
       vertical.vertical_articles.create(article: story_published)
       vertical.vertical_articles.create(article: story_unpublished)
 
-      vertical.featured_articles.should eq [story_published].map(&:to_article)
+      vertical.featured_articles.should eq [story_published]
     end
   end
 


### PR DESCRIPTION
These changes are in response to memory bloat issues that have been occurring recently. After some investigation, I recognized that active record transactions were really long. For verticals, it would average +20 seconds. The newest changes in this branch bring that down to around 80ms without caching.

There's another branch that has further optimizations site-wide that improves performance of news stories and segments down to 10ms range per request (https://github.com/SCPR/SCPRv4/tree/reduce-activerecord-usage), but it diverged so much (66 file changes) that I thought I would start over and create a branch with the most important changes first, then slowly add the rest of the optimizations later.

The general idea is that `to_article` is a bit too expensive, and being called too often in conjunction with many maps. The general process is to reduce the use of it wherever possible.

Here's an overview of the changes by folder:

### Cells
A few cells have been altered to become more flexible (as in they allow for both Article models and native models such as NewsStories, Segments, etc.). Whenever there was a call for `short_title`, there's also a call for a `short_headline` (the native equivalent).

### Concerns
The change in this file offered the biggest speedup. If I'm understanding correctly, removing `to_article` basically stopped it from calling `related_content` in outgoing and incoming references as well.

### Models
These changes mainly affect vertical pages and give a substantial boost as `to_article` doesn't have to be run for every item in the collection anymore.

### Views
Because `related_content` can now be different types of models, it'll need to be conformed back to an Article model in outpost for it to work with the outpost_aggregator.

### Specs
The specs were updated to reflect the above changes.

### Compare
Branch in staging: https://scprv4-staging.scprdev.org/health
Production: https://scpr.org/health
