### PR TITLE
Fix donation tracking

### DIFF
--- a/app/assets/javascripts/better_homepage/better_homepage.js.coffee
+++ b/app/assets/javascripts/better_homepage/better_homepage.js.coffee
@@ -1,5 +1,4 @@
 scpr.Framework      = require 'framework'
-scpr.EventTracking  = require 'event_tracking'
 SmarterTime         = require './smarter-time'
 
 class scpr.BetterHomepage extends scpr.Framework
@@ -45,8 +44,3 @@ class scpr.BetterHomepage extends scpr.Framework
       # feedback element
       feedback: new (require('./lib/feedback-component'))
         el: $('#feedback-block')
-
-    @eventTracking     = new scpr.EventTracking
-      trackScrollDepth: true
-      currentCategory: 'Homepage'
-      scrollDepthContainer: @$el

--- a/app/cells/footer/show.erb
+++ b/app/cells/footer/show.erb
@@ -9,7 +9,7 @@
       <span class="o-footer__tagline b-text b-text--semibold u-text-color--gray">The Voice of Southern California</span>
     </div>
     <div class="o-footer__donate l-col l-end l-center@media-desktop">
-      <a href="https://scprcontribute.publicradio.org/contribute.php" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate">
+      <a href="https://scprcontribute.publicradio.org/contribute.php" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %>">
         <svg class="b-icon b-icon--size-med b-icon--left">
           <use class="b-icon--line b-icon--color-white" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/cells/footer/show.erb
+++ b/app/cells/footer/show.erb
@@ -9,7 +9,7 @@
       <span class="o-footer__tagline b-text b-text--semibold u-text-color--gray">The Voice of Southern California</span>
     </div>
     <div class="o-footer__donate l-col l-end l-center@media-desktop">
-      <a href="https://scprcontribute.publicradio.org/contribute.php">
+      <a href="https://scprcontribute.publicradio.org/contribute.php" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate">
         <svg class="b-icon b-icon--size-med b-icon--left">
           <use class="b-icon--line b-icon--color-white" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/cells/masthead/show.erb
+++ b/app/cells/masthead/show.erb
@@ -292,7 +292,7 @@
   </div>
 
   <div class="o-mast__action o-mast__donate">
-    <a class="o-mast__donate-link" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732" data-ga-category="Menu" data-ga-action="Clickthrough" data-ga-label="Donate">
+    <a class="o-mast__donate-link" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %>">
       <svg class="b-icon b-icon--size-med b-icon--left">
         <use class="b-icon--line b-icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
       </svg>

--- a/app/cells/masthead_cell.rb
+++ b/app/cells/masthead_cell.rb
@@ -1,6 +1,6 @@
 class MastheadCell < Cell::ViewModel
   cache :show, expires_in: 12.hours do
-    ["masthead", "v2"]
+    ["masthead", "v2", model.try(:cache_key) || request.path]
   end
 
   def show

--- a/app/cells/masthead_cell.rb
+++ b/app/cells/masthead_cell.rb
@@ -1,8 +1,4 @@
 class MastheadCell < Cell::ViewModel
-  cache :show, expires_in: 12.hours do
-    ["masthead", "v2", model.try(:cache_key) || request.path]
-  end
-
   def show
     render
   end

--- a/app/cells/masthead_cell.rb
+++ b/app/cells/masthead_cell.rb
@@ -1,6 +1,6 @@
 class MastheadCell < Cell::ViewModel
   cache :show, expires_in: 12.hours do
-    ["masthead", "v1"]
+    ["masthead", "v2"]
   end
 
   def show

--- a/app/views/layouts/amp/_footer.html.erb
+++ b/app/views/layouts/amp/_footer.html.erb
@@ -9,7 +9,7 @@
       <span class="o-footer__tagline text text--semibold u-text-color--gray">The Voice of Southern California</span>
     </div>
     <div class="l-col l-end l-center@media-desktop">
-      <a href="https://scprcontribute.scpr.org/">
+      <a href="https://scprcontribute.scpr.org/" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate">
         <svg class="icon icon--size-med icon--left">
           <use class="icon--line icon--color-white" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/views/layouts/amp/_footer.html.erb
+++ b/app/views/layouts/amp/_footer.html.erb
@@ -9,7 +9,7 @@
       <span class="o-footer__tagline text text--semibold u-text-color--gray">The Voice of Southern California</span>
     </div>
     <div class="l-col l-end l-center@media-desktop">
-      <a href="https://scprcontribute.scpr.org/" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate">
+      <a href="https://scprcontribute.scpr.org/" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %>">
         <svg class="icon icon--size-med icon--left">
           <use class="icon--line icon--color-white" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,8 +34,7 @@
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-585PL29" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     <div id="global-pushdown"></div>
     <header class="<%= content_for :header_class %>">
-      <% current_model = @story || @segment || @entry || @event || @flatpage || @episode || @program || nil %>
-      <%= cell :masthead, current_model %>
+      <%= cell :masthead %>
       <% if alert = BreakingNewsAlert.latest_visible_alert %>
         <%= cell :breaking_news_alert, alert %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,8 @@
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-585PL29" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     <div id="global-pushdown"></div>
     <header class="<%= content_for :header_class %>">
-      <%= cell :masthead %>
+      <% current_model = @story || @segment || @entry || @event || @flatpage || @episode || @program || nil %>
+      <%= cell :masthead, current_model %>
       <% if alert = BreakingNewsAlert.latest_visible_alert %>
         <%= cell :breaking_news_alert, alert %>
       <% end %>

--- a/app/views/layouts/better_homepage/_footer.html.erb
+++ b/app/views/layouts/better_homepage/_footer.html.erb
@@ -9,7 +9,7 @@
       <span class="o-footer__tagline text text--semibold u-text-color--gray">The Voice of Southern California</span>
     </div>
     <div class="l-col l-end l-center@media-desktop">
-      <a href="https://scprcontribute.publicradio.org/contribute.php" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate">
+      <a href="https://scprcontribute.publicradio.org/contribute.php" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %>">
         <svg class="icon icon--size-med icon--left">
           <use class="icon--line icon--color-white" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/views/layouts/better_homepage/_footer.html.erb
+++ b/app/views/layouts/better_homepage/_footer.html.erb
@@ -9,7 +9,7 @@
       <span class="o-footer__tagline text text--semibold u-text-color--gray">The Voice of Southern California</span>
     </div>
     <div class="l-col l-end l-center@media-desktop">
-      <a href="https://scprcontribute.publicradio.org/contribute.php">
+      <a href="https://scprcontribute.publicradio.org/contribute.php" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate">
         <svg class="icon icon--size-med icon--left">
           <use class="icon--line icon--color-white" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/views/layouts/better_homepage/_header.html.erb
+++ b/app/views/layouts/better_homepage/_header.html.erb
@@ -328,7 +328,7 @@
         </div>
       </li>
       <li class="c-nav__item o-mast__donate">
-        <a class="o-mast__donate-link c-nav__link c-nav__link--action" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732">
+        <a class="o-mast__donate-link c-nav__link c-nav__link--action" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732">
           <svg class="icon icon--size-med icon--left">
             <use class="icon--line icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
           </svg>

--- a/app/views/layouts/better_homepage/_header.html.erb
+++ b/app/views/layouts/better_homepage/_header.html.erb
@@ -328,7 +328,7 @@
         </div>
       </li>
       <li class="c-nav__item o-mast__donate">
-        <a class="o-mast__donate-link c-nav__link c-nav__link--action" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732">
+        <a class="o-mast__donate-link c-nav__link c-nav__link--action" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %>" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732">
           <svg class="icon icon--size-med icon--left">
             <use class="icon--line icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
           </svg>

--- a/app/views/layouts/minimal.html.erb
+++ b/app/views/layouts/minimal.html.erb
@@ -22,7 +22,7 @@
         </a>
       </div>
       <div class="o-mast__action o-mast__donate">
-        <a class="o-mast__donate-link" target="_blank" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732"  data-ga-category="Menu" data-ga-action="Clickthrough" data-ga-label="Donate">
+        <a class="o-mast__donate-link" target="_blank" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732"  data-ga-category="Menu" data-ga-action="Clickthrough" data-ga-label="<%= request.path %>">
           <svg class="b-icon b-icon--size-med b-icon--left">
             <use class="b-icon--line b-icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
           </svg>

--- a/app/views/listen/index.html.erb
+++ b/app/views/listen/index.html.erb
@@ -3,16 +3,18 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta charset="utf-8">
   <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport">
-  <title>Listen Live</title>
+  <% add_to_page_title"Listen Live" %>
+  <title><%= page_title %></title>
   <script src="https://use.typekit.net/cka2qre.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
+  <%= render "shared/new/meta_header" %>
   <%= stylesheet_link_tag 'application' %>
   <%= javascript_include_tag "shared", "application" %>
   <script type="text/javascript" src="https://<%= Rails.configuration.x.assethost.server %>/assets/client.js?bust=20130523"></script>
   <%= javascript_include_tag "new/application" %>
 </head>
 
-<body style="display: flex; flex-direction: column">
+<body style="display: flex; flex-direction: column; height: 100vh">
   <nav class="o-mast o-listen-live__mast">
     <div class="o-mast__logo">
       <a href="/" class="o-mast__logo-link" class="track-event" data-ga-category="Menu" data-ga-action="Clickthrough" data-ga-label="Home">

--- a/app/views/listen/index.html.erb
+++ b/app/views/listen/index.html.erb
@@ -22,7 +22,7 @@
       </a>
     </div>
     <div class="o-mast__action o-mast__donate">
-      <a class="o-mast__donate-link" target="_blank" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732"  data-ga-category="Menu" data-ga-action="Clickthrough" data-ga-label="Donate">
+      <a class="o-mast__donate-link" target="_blank" href="https://scprcontribute.publicradio.org/contribute.php?_ga=1.210106262.2096948162.1473892732"  data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %>">
         <svg class="b-icon b-icon--size-med b-icon--left">
           <use class="b-icon--line b-icon--color-link" xlink:href="/static/images/scpr-sprite.svg#icon_line-donate"/>
         </svg>

--- a/app/views/outpost/shared/footer/preview/_document_footer.html.erb
+++ b/app/views/outpost/shared/footer/preview/_document_footer.html.erb
@@ -8,7 +8,6 @@
     social        =       new scpr.SocialTools();
     adSizer       =       new scpr.adSizer();
     audio         =       new scpr.Audio({widgetClass: '.story-audio', audioBar: '#audio-bar'});
-    eventTracking =       new scpr.EventTracking();
   });
 </script>
 

--- a/app/views/shared/footer/_document_footer.html.erb
+++ b/app/views/shared/footer/_document_footer.html.erb
@@ -6,13 +6,8 @@
   var megaM, smartTime;
 
   $(function() {
-    // smartTime         = new scpr.SmartTime();
     social            = new scpr.SocialTools();
     audio             = new scpr.Audio();
-    // modal             = new scpr.Modal();
-    // adSizer           = new scpr.adSizer();
-    // eventTracking     = new scpr.EventTracking();
-    // promoteFacebook   = new scpr.PromoteFacebook();
   });
 </script>
 

--- a/app/views/shared/new/_document_footer.html.erb
+++ b/app/views/shared/new/_document_footer.html.erb
@@ -8,7 +8,6 @@
     social        =       new scpr.SocialTools();
     adSizer       =       new scpr.adSizer();
     audio         =       new scpr.Audio({widgetClass: '.story-audio', audioBar: '#audio-bar'});
-    eventTracking =       new scpr.EventTracking();
   });
 </script>
 

--- a/app/views/shared/new/masthead/_main_nav.html.erb
+++ b/app/views/shared/new/masthead/_main_nav.html.erb
@@ -16,7 +16,7 @@
         <li><a href="https://plus.google.com/108872361044769229886/" title="Join with KPCC on Google Plus" class="gp">KPCC on Google+</a></li>
     </ul>
     <button class="search-trigger" value="Activate search tool">Search KPCC</button>
-    <h5 class="donate track-event" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="Donate"><a href="https://scprcontribute.publicradio.org/contribute.php">Donate Now</a></h5>
+    <h5 class="donate track-event" data-ga-category="Menu" data-ga-action="Donate" data-ga-label="<%= request.path %> "><a href="https://scprcontribute.publicradio.org/contribute.php">Donate Now</a></h5>
     <button class="shownav" aria-hidden="true">Show Nav</button>
 </section><!--/ .station -->
 


### PR DESCRIPTION
Some GA attributes were missing for donation clicks in the masthead and footer. This PR adds them back with new specifications (per @patrickdougall).

The events used to look like this:
`Category: Menu`
`Action: Donate`
`Label: Donate`

Patrick wants the new events to look like the following:
`Category: Menu`
`Action: Donate`
`Label: {url path}`

Other changes:
- Removes event tracking instantiation from the homepage and outpost (since this is being done GTM side now)
- Removes caching on the masthead (so that the request.path isn't also cached, also performance isn't dramatically affected when removed).
- Fixes Listen Live event tracking by including the GTM snippet properly via `<%= render "shared/new/meta_header" %>`