### PR TITLE
Adds story tags to meta header

### DIFF
--- a/app/cells/article/meta_tags.erb
+++ b/app/cells/article/meta_tags.erb
@@ -9,6 +9,7 @@
 <meta name="twitter:description" value="<%= h(strip_tags(model.teaser)) %>">
 <meta property="article:published_time" content="<%= model.public_datetime %>" />
 <meta property="article:modified_time" content="<%= model.updated_at %>" />
+<meta property="article:tag" content="<%= model.try(:tags).try(:map, &:title).try(:join, ', ') %>" />
 
 <% if model.category %>
   <meta property="article:section" content="<% h(model.category.title) %>" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
     <!-- Use title if it's in the page YAML frontmatter -->
     <% add_to_page_title @TITLE_ELEMENTS.present? ? "89.3 KPCC" : "89.3 KPCC - Southern California Public Radio" %>
     <title><%= page_title %></title>
-    <title>89.3 KPCC - Southern California Public Radio</title>
     <script src="https://use.typekit.net/cka2qre.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>
 


### PR DESCRIPTION
This change creates a meta tag that contains a story's tags. Useful for analytics. Also removes an unnecessary `<title>` tag.