### PR TITLE
Fixes slideshow sizing (plus numbering issue)

### DIFF
--- a/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
+++ b/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
@@ -19,6 +19,13 @@
 .o-figure--portrait .o-figure__img
   padding-top: (100 / 0.67) * 1%
 
+.o-figure--portrait.o-article__hero-figure .o-figure__img, .o-figure--slideshow .o-figure__img
+  padding-top: (100 / 1.5) * 1%
+  background-color: #363636
+  background-position: center
+  background-repeat: no-repeat
+  background-size: contain
+
 .o-figure--emphasized .o-figure__img
   border-bottom: 4px solid $color-primary
 

--- a/app/cells/asset/default/slideshow.html.erb
+++ b/app/cells/asset/default/slideshow.html.erb
@@ -4,7 +4,7 @@
 
   <div class="static-slides">
   <% slideshow_assets.each do |asset| %>
-    <figure class="slide o-figure <%= aspect asset %>">
+    <figure class="slide o-figure o-figure--slideshow">
       <img
         class="o-figure__img"
         src="<%= asset.try(:eight).try(:url) %>"
@@ -43,7 +43,7 @@
     slideshow = new scpr.NewSlideshow({
           el: "#asset_slideshow_<%=html_safe_id%>",
           staticSlides: "staticSlides_<%=html_safe_id%>",
-          assets: <%= assets.to_json.html_safe %>
+          assets: <%= slideshow_assets.to_json.html_safe %>
     });
     slideshow.bind("switch", function(idx) {
         // (1.) add slide change listener for analytics


### PR DESCRIPTION
The changes presented here fix the way portraits show up in slideshows, and also center contains the image and adds a grey background to portraits in the hero asset.

Also fixes a bug where inline assets would show up in the thumbnail lists