### PR TITLE
Make programs destroy their child records upon destruction.

### DIFF
--- a/app/models/external_program.rb
+++ b/app/models/external_program.rb
@@ -47,8 +47,8 @@ class ExternalProgram < ActiveRecord::Base
   #-------------------
   # Associations
   has_many :recurring_schedule_rules, as: :program, dependent: :destroy
-  has_many :episodes, dependent: :destroy, class_name: :ExternalEpisode
-  has_many :segments, class_name: :ExternalSegment
+  has_many :episodes, dependent: :destroy, class_name: :ExternalEpisode, dependent: :destroy
+  has_many :segments, class_name: :ExternalSegment, dependent: :destroy
 
   #-------------------
   # Validations

--- a/app/models/kpcc_program.rb
+++ b/app/models/kpcc_program.rb
@@ -32,8 +32,8 @@ class KpccProgram < ActiveRecord::Base
 
   #-------------------
   # Associations
-  has_many :segments, foreign_key: "show_id", class_name: "ShowSegment"
-  has_many :episodes, foreign_key: "show_id", class_name: "ShowEpisode"
+  has_many :segments, foreign_key: "show_id", class_name: "ShowSegment", dependent: :destroy
+  has_many :episodes, foreign_key: "show_id", class_name: "ShowEpisode", dependent: :destroy
   has_many :recurring_schedule_rules, as: :program, dependent: :destroy
   has_many :tags, as: :parent
 


### PR DESCRIPTION
#585

Does what it says on the tin using Rails' `dependent: destroy` option.
Did the same thing for both KPCC programs and external programs.