### PR TITLE
Update newrelic agent to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "open_uri_redirections"
 gem "twitter", "~> 4.1"
 gem "oauth2", "~> 0.8"
 gem 'postmark-rails', "~> 0.6.0"
-gem 'newrelic_rpm', '~> 3.16'
+gem 'newrelic_rpm', '~> 4.0', '>= 4.0.0.332'
 gem 'parse-ruby-client', github: "sheerun/parse-ruby-client", ref: "a4eb5618c8167e88857b449cd522b23a8b0c02e9"
 gem 'farse-ruby-client', github: "scpr/parse-ruby-client"
 gem 'pmp', '0.5.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     multipart-post (1.2.0)
     mysql2 (0.3.21)
     netrc (0.11.0)
-    newrelic_rpm (3.16.2.321)
+    newrelic_rpm (4.7.1.340)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     oauth2 (0.9.3)
@@ -571,7 +571,7 @@ DEPENDENCIES
   kaminari (~> 0.15.0)
   launchy
   mysql2 (~> 0.3.18)
-  newrelic_rpm (~> 3.16)
+  newrelic_rpm (~> 4.0, >= 4.0.0.332)
   npr (~> 3.0)!
   oauth2 (~> 0.8)
   oink (~> 0.10.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_filter :add_params_for_newrelic
 
   def add_params_for_newrelic
-    NewRelic::Agent.add_custom_parameters(
+    NewRelic::Agent.add_custom_attributes(
       :request_referer => request.referer,
       :agent           => request.env['HTTP_USER_AGENT']
     )

--- a/app/controllers/outpost/base_controller.rb
+++ b/app/controllers/outpost/base_controller.rb
@@ -13,7 +13,7 @@ class Outpost::BaseController < Outpost::ApplicationController
 
   def add_params_for_newrelic
     if current_user
-      NewRelic::Agent.add_custom_parameters(
+      NewRelic::Agent.add_custom_attributes(
         :current_user_id   => current_user.id,
         :current_user_name => current_user.name
       )

--- a/config/initializers/new_relic.rb
+++ b/config/initializers/new_relic.rb
@@ -26,7 +26,6 @@ module NewRelic
     #------------------
 
     def log_error(e, options={})
-      # NewRelic::Agent.add_custom_parameters(custom_attributes)
       NewRelic::Agent.agent.error_collector.notice_error(e, options)
     end
   end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -2,3 +2,4 @@ development:
   developer_mode: true
   resque.capture_params: true
   rules.ignore_url_regexes: ["^/assets"]
+  host: staging-collector.newrelic.com


### PR DESCRIPTION
Updated Newrelic agent to the latest version and renamed deprecated methods to their new counterparts.  It appears to be reporting fine in staging.