### PR TITLE
Bug: Checks asset type on an individual basis

### DIFF
--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -13,7 +13,7 @@ class ArticleCell < Cell::ViewModel
   property :category
 
   cache :show, expires_in: 10.minutes, :if => lambda { !@options[:preview] }  do
-    [model.try(:cache_key), 'v8']
+    [model.try(:cache_key), 'v9']
   end
 
   cache :meta_tags, expires_in: 10.minutes do

--- a/app/cells/asset/default/photo.erb
+++ b/app/cells/asset/default/photo.erb
@@ -6,8 +6,8 @@
     title="<%= title %>"
     role="img"
     aria-label="<%= title %>"
-    data-assethost="<%= assethost %>"
-    data-ah-videoid="<%= videoid %>"
+    data-assethost="<%= assethost asset %>"
+    data-ah-videoid="<%= videoid asset %>"
     style="background-image:url(<%= src %>);"
   />
   <% if caption || owner %>

--- a/app/cells/asset_cell.rb
+++ b/app/cells/asset_cell.rb
@@ -85,15 +85,15 @@ class AssetCell < Cell::ViewModel
     model.title || model.caption
   end
 
-  def assethost
-    if assets.first.try(:eight).try(:asset).try(:native)
+  def assethost asset
+    if asset.try(:eight).try(:asset).try(:native)
       assets.first.eight.asset.native["class"]
     end
   end
 
-  def videoid
-    if assets.first.try(:eight).try(:asset).try(:native)
-      assets.first.eight.asset.native["videoid"]
+  def videoid asset
+    if asset.try(:eight).try(:asset).try(:native)
+      asset.eight.asset.native["videoid"]
     end
   end
 


### PR DESCRIPTION
There was a bug where all inline images would be a video if the first asset (the lead asset) happens to be a video. The changes below make it so that if an asset cell is created, it only applies a `videoid` and `assethost` class variable for that individual asset.