### PR TITLE
Fixes event asset display

### DIFF
--- a/app/assets/stylesheets/layouts/event.css.sass
+++ b/app/assets/stylesheets/layouts/event.css.sass
@@ -66,15 +66,6 @@
     margin-left: 45px
     margin-top: 45px
 
-  .o-event__hero-figure
-    .o-figure__img
-      height: auto
-      padding-top: 0px
-
-    .o-figure--portrait
-      .o-figure__img
-        width: 35%
-
   @media (max-width: $media-wide)
     .o-event__body, .o-event__RSVP, .o-event__figure, .o-event__headline, .o-event__type, .o-appeal, .o-more-events, .o-event__social-tools, .o-comments, .o-event__rule--ending
       width: ($col * 6) + ($gutter * 6)

--- a/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
+++ b/app/assets/stylesheets/scpr-style-guide-v4/objects/_figure.css.sass
@@ -19,7 +19,8 @@
 .o-figure--portrait .o-figure__img
   padding-top: (100 / 0.67) * 1%
 
-.o-figure--portrait.o-article__hero-figure .o-figure__img, .o-figure--slideshow .o-figure__img
+.o-figure--portrait.o-article__hero-figure .o-figure__img, .o-figure--slideshow .o-figure__img,
+.o-figure--portrait.o-event__hero-figure .o-figure__img, .o-figure--slideshow .o-figure__img,
   padding-top: (100 / 1.5) * 1%
   background-color: #363636
   background-position: center

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -2,11 +2,13 @@ class EventCell < Cell::ViewModel
   property :asset
 
   def hero_asset(figure_class)
-    if model.try(:asset_display) != :hidden || !model.try(:assets).try(:empty?)
-      if model.try(:asset_display) == :slideshow
-        AssetCell.new(asset, article: model, class: figure_class, template: "default/slideshow.html").call(:show)
+    if model.try(:asset_display) == :hidden || model.try(:asset_display) == "hidden" || assets.try(:empty?)
+      nil
+    else
+      if model.try(:asset_display) == :slideshow || model.try(:asset_display) == "slideshow"
+        AssetCell.new(asset, article: model, class: figure_class, template: "default/slideshow.html", featured: true).call(:show)
       else
-        AssetCell.new(asset, article: model, class: figure_class).call(:show)
+        AssetCell.new(asset, article: model, class: figure_class, featured: true).call(:show)
       end
     end
   end

--- a/app/cells/event_cell.rb
+++ b/app/cells/event_cell.rb
@@ -1,4 +1,5 @@
 class EventCell < Cell::ViewModel
+  property :assets
   property :asset
 
   def hero_asset(figure_class)

--- a/app/cells/highlighted_events_cell.rb
+++ b/app/cells/highlighted_events_cell.rb
@@ -4,7 +4,13 @@ class HighlightedEventsCell < Cell::ViewModel
   end
 
   def asset_path(resource)
-    resource.try(:asset).try(:eight).try(:url) || "/static/images/fallback-img-rect.png"
+    asset_display = resource.try(:asset_display)
+    assets = resource.try(:assets)
+    if asset_display == :hidden || asset_display == "hidden" || assets.try(:empty?)
+      nil
+    else
+      resource.try(:asset).try(:eight).try(:url) || "/static/images/fallback-img-rect.png"
+    end
   end
 
   def date(event)

--- a/app/cells/upcoming_events_cell.rb
+++ b/app/cells/upcoming_events_cell.rb
@@ -21,8 +21,14 @@ class UpcomingEventsCell < Cell::ViewModel
     end
   end
 
-  def asset_path(event)
-     event.try(:asset).try(:small).try(:url) || '/static/images/fallback-img-rect.png'
+  def asset_path(resource)
+    asset_display = resource.try(:asset_display)
+    assets = resource.try(:assets)
+    if asset_display == :hidden || asset_display == "hidden" || assets.try(:empty?)
+      nil
+    else
+      resource.try(:asset).try(:small).try(:url) || "/static/images/fallback-img-rect.png"
+    end
   end
 
   def time_adjective

--- a/app/cells/upcoming_events_list_cell.rb
+++ b/app/cells/upcoming_events_list_cell.rb
@@ -15,8 +15,14 @@ class UpcomingEventsListCell < Cell::ViewModel
     @options[:tab]
   end
 
-  def asset_path(article)
-     article.try(:asset).try(:small).try(:url) || '/static/images/fallback-img-rect.png'
+  def asset_path(resource)
+    asset_display = resource.try(:asset_display)
+    assets = resource.try(:assets)
+    if asset_display == :hidden || asset_display == "hidden" || assets.try(:empty?)
+      nil
+    else
+      resource.try(:asset).try(:small).try(:url) || "/static/images/fallback-img-rect.png"
+    end
   end
 
   def date(event)


### PR DESCRIPTION
Changes in this PR:
- Styling options for hero assets match article template styling
- Fix the asset_display check so that it returns nil if hidden
- Applies that logic to lists so that when it shows up in a list and its hidden, it also returns nil