### PR TITLE
Adds more conditions to register transition from Recurring to Distinct

### DIFF
--- a/app/models/schedule_occurrence.rb
+++ b/app/models/schedule_occurrence.rb
@@ -47,7 +47,7 @@ class ScheduleOccurrence < ActiveRecord::Base
   belongs_to :recurring_schedule_rule
 
   before_update :detach_from_recurring_rule, if: -> {
-    self.is_recurring? && (self.starts_at_changed? || self.ends_at_changed?)
+    self.is_recurring? && (self.starts_at_changed? || self.ends_at_changed? || self.program_id_changed? || (self.event_title_changed? && self.info_url_changed?))
   }
 
 


### PR DESCRIPTION
Changes the Schedule Occurrence record from a `recurring` occurrence to a `distinct` occurrence if any of these properties are changed:
- `starts_at`
- `ends_at`
- `program_id`
- `(event_title & info_url)`

Before, only `starts_at` and `ends_at` were properties that transitioned an occurrence to `distinct`.

Distinct occurrences have a higher priority over recurring occurrences and are not overwritten during the daily job, `BuildRecurringSchedule` (which deletes all future occurrences and replaces them).

Way to test:
1. Go to a recurring occurrence in outpost (e.g. https://scprv4-staging.scprdev.org/outpost/schedule_occurrences/867375/edit)
2. Change the program and save
3. The record should now be a `distinct` occurrence.
4. Run the job `rake scprv4:schedule:build` in `scprv4_staging`
5. The record should remain without being overwritten, the schedule for that day should still show the distinct occurrence, and the usual program for that time slot will be generated in the list. (before, the edited occurrence would be overridden by the usual program).