### PR TITLE
Fix asset protocol

### DIFF
--- a/app/cells/article_cell.rb
+++ b/app/cells/article_cell.rb
@@ -13,11 +13,11 @@ class ArticleCell < Cell::ViewModel
   property :category
 
   cache :show, expires_in: 10.minutes, :if => lambda { !@options[:preview] }  do
-    [model.try(:cache_key), 'v9']
+    [model.try(:cache_key), 'v10']
   end
 
   cache :meta_tags, expires_in: 10.minutes do
-    [model.try(:cache_key), 'v2']
+    [model.try(:cache_key), 'v3']
   end
 
   def show

--- a/config/initializers/assethost.rb
+++ b/config/initializers/assethost.rb
@@ -7,6 +7,7 @@ end
 
 # Configure AssetHostClient
 AssetHostClient.setup do |config|
+  config.protocol         = Rails.configuration.x.assethost.protocol
   config.server           = Rails.configuration.x.assethost.server
   config.token            = Rails.configuration.x.assethost.token
   config.raise_on_errors  = Rails.configuration.x.assethost.raise_on_errors || false


### PR DESCRIPTION
Changes in this PR:

- Protocol is initialized in AssetHostClient initializer to ensure all requests to AH has the right protocol. This is taken from the Rails configuration variable for `assethost.protocol`.

After doing the above change and pushing to staging, I noticed that there were some assets that were still not switching to `https`. I found out that there are some assets that are cached indefinitely (no expiration date). @Ravenstine had fixed it in this commit: https://github.com/SCPR/asset_host_client/commit/d869cb63647fb7d6c9e3e42832394051eb3cc634#diff-ff89ed48a670a3ebd756b89a999da3a3, so this is no longer a problem for assets posted after this commit. However, there are probably a few assets prior to this commit that still live in the cache. When I manually cleared the problematic asset, e.g. `Rails.cache.delete('asset/asset-97679')` in rails console, the asset was re-fetched with the correct protocol.

I'm trying to think of how best to approach these (and whether it's even worth clearing these out).