### PR TITLE
If ends_at is nil, checks if starts_at is passed and event is all day

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -79,7 +79,7 @@ class Event < ActiveRecord::Base
 
   scope :past, -> {
     published
-    .where("ends_at < :now", now: Time.zone.now)
+    .where("ends_at < :now or starts_at < :now and is_all_day = 1", now: Time.zone.now)
     .order("starts_at desc")
   }
 


### PR DESCRIPTION
This PR is related to this page: https://www.scpr.org/events/kpcc-in-person/archive

It's missing a KPCC event found here: http://www.scpr.org/events/2018/01/13/2522/gubernatorial-town-hall--a-local-perspective/

When looking at the outpost link, I noticed that the `ends_at` field was blank. Looking in the model as to what constitutes a past event, I found this: https://github.com/SCPR/SCPRv4/blob/08f4239bc2209df1a14389262fca1faaf32e1a00/app/models/event.rb#L82

Basically, if ends_at is nil, it won't be selected by the statement. The changes proposed here add `or starts_at < :now and is_all_day = 1` to check for if the event's start time has passed and the event is registered as an all day event. It's unlikely that an event is `live`, does not have an `ends_at`, and does not have `all_day` selected. Also, just checking for if `starts_at < :now` would yield events that are still in progress, so it seems reasonable to check if it's an all day event as well.