### PR TITLE
Sets the global expiration for the cache to one week

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ Scprv4::Application.configure do
   config.eager_load     = true
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"]||{}
+  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"] || { :expires_in => 604800 }
   config.action_controller.action_on_unpermitted_parameters = :log
 
   # Not sure if we need this? - EWR

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,8 +3,10 @@ Scprv4::Application.configure do
   config.eager_load     = true
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"] || { :expires_in => 604800 }
   config.action_controller.action_on_unpermitted_parameters = :log
+
+  # The :expires_in value of 604800 is 1 week in seconds
+  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"] || { :expires_in => 604800 }
 
   # Not sure if we need this? - EWR
   config.active_record.raise_in_transactional_callbacks = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,7 +3,7 @@ Scprv4::Application.configure do
   config.eager_load     = true
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = true
-  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"]||{}
+  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"] || { :expires_in => 604800 }
   config.action_controller.action_on_unpermitted_parameters = :log
 
   config.active_record.raise_in_transactional_callbacks = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,8 +3,10 @@ Scprv4::Application.configure do
   config.eager_load     = true
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = true
-  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"] || { :expires_in => 604800 }
   config.action_controller.action_on_unpermitted_parameters = :log
+
+  # The :expires_in value of 604800 is 1 week in seconds
+  config.cache_store = :dalli_store, Rails.application.secrets.cache["servers"], Rails.application.secrets.cache["options"] || { :expires_in => 604800 }
 
   config.active_record.raise_in_transactional_callbacks = true
 


### PR DESCRIPTION
From the `dalli_store` docs, you can set a global expiration: https://github.com/petergoldstein/dalli#configuration
> **expires_in:** Global default for key TTL. Default is 0, which means no expiry.

This will take care of pages with mixed content errors, e.g. https://www.scpr.org/education, because those were stored in the cache before the 1 minute expiration write logic was put into effect.

![screen shot 2018-01-17 at 1 54 39 pm](https://user-images.githubusercontent.com/16679701/35129650-5df33e1e-fc71-11e7-934a-cad7fb13dc1f.png)


This is in conjunction with another PR that adds expirations to cache reads: https://github.com/SCPR/asset_host_client/pull/2

Note: Pages with ads will continue to have mixed content errors because ads are served with the `http` protocol for some reason. Will create another ticket to address this in the future.