### PR TITLE
Adds GTM Data Layer logic to Audio Player Events

### DIFF
--- a/app/assets/javascripts/README.md
+++ b/app/assets/javascripts/README.md
@@ -1,0 +1,58 @@
+# JavaScript Assets
+
+The JavaScript files in this directory serve as a way to enable dynamic interaction across the site. `aplicayshun.js` currently holds all the scripts required globally. You can find usage details for some major scripts below.
+
+---
+
+## `audio.js.coffee`
+
+Our audio widgets are powered by a class called, `scpr.Audio`. Creating a new instance of `scpr.Audio` on a page with a few options indicating interactive elements (play button, audio bar element, etc.), will enable playback functionality for that page.
+
+### Analytics
+
+Events are sent to analytics in multiple ways.
+- Google Analytics:
+    - We use the `sendEvent` method to send AudioPlayer events to our GA. This includes events such as 'start', 'Quartile1', 'Quartile2, 'Quartile3', and 'complete'.
+- Google Tag Manager:
+    - We use the `addToDataLayer` method to push general purpose data to our GTM. This includes primitive events such as 'play', 'pause', and 'change'
+
+#### How to verify events are sending
+
+For Google Analytics:
+- Open a page with an inline audio element
+- Open the network tab in dev tools and filter by our GA id
+- Click the 'play' button, and let it play to completion.
+- Five events should have sent: 'start', 'Quartile1', 'Quartile2', 'Quartile3', 'complete'
+
+For Google Tag Manager
+- Go to GTM and turn on "Preview" mode
+- Visit a page with multiple audio files, like this: https://scprv4-staging.scprdev.org/programs/take-two/2017/12/01/60481/cruising-through-the-2017-la-auto-show/
+- Choose the dataLayer tab
+- Click the play button
+- A dataLayer object with `eventAction: play` should show up
+- Minimize the GTM dev tool (because it's blocking the audio bar)
+- Press pause, and then click the second audio element (or click the second audio element and then click pause)
+- Maximize the GTM dev tool
+- Two more dataLayer objects with `eventAction: pause` and `eventAction: change` should show up
+
+---
+
+## `listen_live.js.coffee`
+The live stream is powered by a class called, `scpr.ListenLive`. Creating a new instance of `scpr.ListenLive` should enable live stream functionality for that page.
+
+### Analytics
+
+- Google Tag Manager:
+    - We use the `_addToDataLayer` method to push general purpose data to our GTM. This includes primitive events such as 'play' and 'pause'
+
+#### How to verify events are sending
+
+- Go to GTM and turn on "Preview" mode
+- Visit the live stream page
+- Choose the dataLayer tab
+- Click the play button
+- A dataLayer object with `eventAction: play` should show up
+- Minimize the GTM dev tool (because it's blocking the audio bar)
+- Press pause
+- Maximize the GTM dev tool
+- One more dataLayer object with `eventAction: pause` should show up

--- a/app/assets/javascripts/audio.js.coffee
+++ b/app/assets/javascripts/audio.js.coffee
@@ -16,7 +16,7 @@ class scpr.Audio
             wmode:    "window"
             play: (e) =>
                 # add a play event to the data layer for each play
-                @sendEvent
+                @addToDataLayer
                     action: 'play'
                     nonInteraction: false
                     value: 1
@@ -31,7 +31,7 @@ class scpr.Audio
                     @state.started = true
             pause: (e) =>
                 # add a pause event to the data layer for each pause
-                @sendEvent
+                @addToDataLayer
                     action: 'pause'
                     nonInteraction: false
                     value: 1
@@ -66,7 +66,7 @@ class scpr.Audio
                 # add a change event to the dataLayer
                 if @previousSource != e.jPlayer.status.src
                     @previousSource = e.jPlayer.status.src
-                    @sendEvent
+                    @addToDataLayer
                         action: 'change'
                         nonInteraction: false
                         value: 1
@@ -198,6 +198,7 @@ class scpr.Audio
 
     sendEvent: (options) ->
         options.nonInteraction ?= true
+
         # send an audio event to GA
         ga 'send',
             hitType: 'event'
@@ -207,7 +208,12 @@ class scpr.Audio
             nonInteraction: options.nonInteraction
             eventValue: options.value or 0
 
-        # also push to the dataLayer for other reporting purposes (e.g. NPR)
+    #----------
+
+    addToDataLayer: (options) ->
+        options.nonInteraction ?= true
+
+        # push to the dataLayer for general reporting purposes (e.g. NPR)
         dataLayer.push
             hitType: 'event'
             eventCategory: 'AudioPlayer'

--- a/app/assets/javascripts/audio.js.coffee
+++ b/app/assets/javascripts/audio.js.coffee
@@ -215,7 +215,7 @@ class scpr.Audio
 
         # push to the dataLayer for general reporting purposes (e.g. NPR)
         dataLayer.push
-            hitType: 'event'
+            event: 'AudioPlayer'
             eventCategory: 'AudioPlayer'
             eventAction: options.action
             eventLabel: @src()

--- a/app/assets/javascripts/audio.js.coffee
+++ b/app/assets/javascripts/audio.js.coffee
@@ -21,7 +21,7 @@ class scpr.Audio
                     nonInteraction: false
                     value: 1
 
-                # if no audio element has played yet, add a start event to the data layer
+                # if no audio element has played yet, send a start event to GA
                 if @state.started != true
                     @state = {}
                     @sendEvent

--- a/app/assets/javascripts/listen_live.js.coffee
+++ b/app/assets/javascripts/listen_live.js.coffee
@@ -69,6 +69,7 @@ class scpr.ListenLive
                     @_pause_timeout = null
 
                 @nielsen?.play() if !@_inPreroll
+                @_addToDataLayer('play', @options.url) if !@_inPreroll
 
             @player.on $.jPlayer.event.pause, (evt) =>
                 # set a timer to convert this pause to a stop in one minute
@@ -77,6 +78,7 @@ class scpr.ListenLive
                     @_shouldTryAd = true
                 , @options.pause_timeout * 1000
                 @nielsen?.stop() if !@_inPreroll
+                @_addToDataLayer('pause', @options.url) if !@_inPreroll
 
             @player.on $.jPlayer.event.error, (evt) =>
                 if evt.jPlayer.error.type == "e_url_not_set"
@@ -170,6 +172,14 @@ class scpr.ListenLive
                 show_splash_img = 'http://media.scpr.org/assets/images/programs/' + show_slug + '_splash@2x.jpg'
 
                 $('.wrapper, .wrapper-backdrop').css('background-image', 'url(' + show_splash_img + ')')
+
+        _addToDataLayer: (eventAction, eventLabel) ->
+            # push to the dataLayer for general reporting purposes (e.g. NPR)
+            dataLayer.push
+                event: 'LiveStream'
+                eventCategory: 'LiveStream'
+                eventAction: eventAction
+                eventLabel: eventLabel
 
     #----------
 

--- a/app/cells/listen_live/show.erb
+++ b/app/cells/listen_live/show.erb
@@ -107,8 +107,7 @@
 <script>
   llPlayer = new scpr.ListenLive.CurrentGen({
     schedule:   <%= model.map(&:listen_live_json).to_json.html_safe %>,
-    nielsen_enabled: <%= Rails.application.secrets.api['nielsen']['enabled'] %>,
-    gtm_enabled: true
+    nielsen_enabled: <%= Rails.application.secrets.api['nielsen']['enabled'] %>
   })
 
   $("#llcontent a").attr("target","_blank");

--- a/app/cells/listen_live/show.erb
+++ b/app/cells/listen_live/show.erb
@@ -107,7 +107,8 @@
 <script>
   llPlayer = new scpr.ListenLive.CurrentGen({
     schedule:   <%= model.map(&:listen_live_json).to_json.html_safe %>,
-    nielsen_enabled: <%= Rails.application.secrets.api['nielsen']['enabled'] %>
+    nielsen_enabled: <%= Rails.application.secrets.api['nielsen']['enabled'] %>,
+    gtm_enabled: true
   })
 
   $("#llcontent a").attr("target","_blank");


### PR DESCRIPTION
Changes proposed:
- `addToDataLayer` method is used to push to the dataLayer so that GTM scripts can access it
- adds `play`, `pause`, and `change` events to the dataLayer
- `change` event occurs when the current audio source being loaded is different from its immediate predecessor
- added comments/explanation for changes

To test:
- Go to GTM and turn on "Preview" mode
- Visit this page: https://scprv4-staging.scprdev.org/programs/take-two/2017/12/01/60481/cruising-through-the-2017-la-auto-show/
- Choose the dataLayer tab
- Click the play button
- A dataLayer object with `eventAction: play` should show up
- Minimize the GTM dev tool (because it's blocking the audio bar)
- Press pause, and then click the second audio element (or click the second audio element and then click pause)
- Maximize the GTM dev tool
- Two more dataLayer objects with `eventAction: pause` and `eventAction: change` should show up