### PR TITLE
Add google news sitemap tags to news and blog sitemaps.

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -19,7 +19,7 @@ class SitemapsController < ApplicationController
   def stories
     @changefreq = "hourly"
     @priority   = "1"
-    @content    = NewsStory.published.since(60.days.ago)
+    @content    = NewsStory.published.since(30.days.ago)
     render 'news', formats: :xml
   end
 

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -19,16 +19,16 @@ class SitemapsController < ApplicationController
   def stories
     @changefreq = "hourly"
     @priority   = "1"
-    @content    = NewsStory.published.since(30.days.ago)
-    render 'sitemap', formats: :xml
+    @content    = NewsStory.published.since(60.days.ago)
+    render 'news', formats: :xml
   end
 
   def blog_entries
     @changefreq = "hourly"
     @priority   = "0.9"
-    @content = BlogEntry.published.since(30.days.ago)
-
-    render 'sitemap', formats: :xml
+    @content    = BlogEntry.published.since(30.days.ago)
+    @genres     = "Blog"
+    render 'news', formats: :xml
   end
 
   def episodes

--- a/app/views/sitemaps/news.xml.builder
+++ b/app/views/sitemaps/news.xml.builder
@@ -1,0 +1,36 @@
+xml.instruct!(:xml, version: "1.0", encoding: "UTF-8")
+xml.urlset xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9", "xmlns:news" => "http://www.google.com/schemas/sitemap-news/0.9" do
+  @content.each do |object|
+    xml.url do
+      xml.loc         object.public_url
+      xml.changefreq  @changefreq || "daily"
+      xml.priority    @priority || "0.5"
+
+      if object.respond_to? :published_at
+        xml.lastmod   object.published_at.utc.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+      end
+
+      xml.tag! 'news:news' do
+
+        xml.tag! 'news:publication' do
+          xml.tag! 'news:name', '89.3 KPCC'
+          xml.tag! 'news:language', 'en'
+        end
+
+        if @genres
+          xml.tag! 'news:genres', @genres
+        end
+
+        xml.tag! 'news:publication_date', object.published_at.utc.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+        xml.tag! 'news:title', object.try(:headline) || object.try(:title)
+
+        if object.respond_to?(:tags) && object.tags.length > 0
+          xml.tag! 'news:keywords', [object.category].concat(object.tags).compact.map{|t| t.try(:title).try(:downcase)}.join(', ')
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Addresses #408

Adds new tags to existing news and blog entry sitemaps.  