### PR TITLE
Adds `image_gravity` to `upcoming_event_list_cell`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,7 @@ end
 
 group :test, :development do
   gem "rspec-rails", "~> 3.2.1"
+  gem 'rspec-cells', '~> 0.3.3'
   gem 'rb-fsevent', '~> 0.9'
   gem 'launchy'
   gem 'guard', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,6 +430,9 @@ GEM
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
+    rspec-cells (0.3.4)
+      cells (>= 4.0.0, < 6.0.0)
+      rspec-rails (~> 3.2)
     rspec-core (3.2.0)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -599,6 +602,7 @@ DEPENDENCIES
   resque-pool!
   rest-client
   reverse_markdown
+  rspec-cells (~> 0.3.3)
   rspec-rails (~> 3.2.1)
   rspec_junit_formatter!
   ruby-mp3info (~> 0.8.2)

--- a/app/cells/upcoming_events_list/README.md
+++ b/app/cells/upcoming_events_list/README.md
@@ -1,0 +1,13 @@
+# Upcoming Events List Cell
+https://www.scpr.org/events/kpcc-in-person
+This is a two-column cell that lists current and upcoming events for the KPCC In Person Landing page.
+
+---
+
+## Methods
+
+#### `asset_position`
+- **Input:** Event
+- **Output:** Image gravity, type: string
+- **Tests:** `spec/cells/upcoming_events_list_spec.rb`
+- Since these images are in a square aspect ratio, there are many times when a subject is cut off. This method uses the `image_gravity` property exposed by AssetHost to apply the positioning via the css property, `background-position: {image_gravity}`.

--- a/app/cells/upcoming_events_list/show.erb
+++ b/app/cells/upcoming_events_list/show.erb
@@ -4,7 +4,7 @@
       <div class="o-events-list__item">
 
         <figure class="o-events-list__item-figure o-figure o-figure--<%= asset_aspect %>">
-          <img class="o-figure__img" src="<%= asset_path article %>" style="background-image: url(<%= asset_path article %>)">
+          <img class="o-figure__img" src="<%= asset_path article %>" style="background-image: url(<%= asset_path article %>); background-position: <%= asset_position article %>;">
         </figure>
 
         <header class="o-events-list__item-description">

--- a/app/cells/upcoming_events_list_cell.rb
+++ b/app/cells/upcoming_events_list_cell.rb
@@ -19,6 +19,10 @@ class UpcomingEventsListCell < Cell::ViewModel
      article.try(:asset).try(:small).try(:url) || '/static/images/fallback-img-rect.png'
   end
 
+  def asset_position(article)
+    article.try(:asset).try(:small).try(:asset).try(:json).try(:[], 'image_gravity') || 'center';
+  end
+
   def date(event)
     starts_at = event.try(:starts_at)
     ends_at = event.try(:ends_at)

--- a/spec/cells/upcoming_events_list_spec.rb
+++ b/spec/cells/upcoming_events_list_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe UpcomingEventsListCell do
+  describe "GET" do
+    before :each do
+      # Create a list of current and upcoming events and feed it into a cell instance
+      current_event = create :event, :published, starts_at: 2.hours.ago, ends_at: 2.hours.from_now, event_type: 'comm', headline: 'Public Media Potluck'
+      future_event  = create :event, :published, starts_at: 2.hours.from_now, ends_at: 3.hours.from_now, event_type: 'comm', headline: 'Blood Moon'
+      upcoming_events_list = [current_event, future_event]
+      @cell_instance = cell(:upcoming_events_list, upcoming_events_list)
+    end
+    
+    it "renders upcoming events" do
+      expect(@cell_instance.call).to include 'Public Media Potluck'
+      expect(@cell_instance.call).to include 'Blood Moon'
+    end
+    
+    it "renders asset with default gravity if no image_gravity is given" do
+      # Defaults to asset fallback (absent of image_gravity) when no asset is attached
+      test_event = create :event, :published, starts_at: 2.hours.ago, ends_at: 2.hours.from_now, event_type: 'comm'
+      
+      expect(test_event.asset.small).to eq 'center'
+    end
+    
+    it "renders asset with specified gravity if image_gravity is given" do
+      asset = create :asset
+      test_event = create :event, :published, starts_at: 2.hours.ago, ends_at: 2.hours.from_now, event_type: 'comm'
+      test_event.assets << asset
+      test_event.save!
+
+      expect(@cell_instance.call(:asset_position, test_event)).to eq 'Left'
+    end
+  end
+end

--- a/spec/cells/upcoming_events_list_spec.rb
+++ b/spec/cells/upcoming_events_list_spec.rb
@@ -19,7 +19,7 @@ describe UpcomingEventsListCell do
       # Defaults to asset fallback (absent of image_gravity) when no asset is attached
       test_event = create :event, :published, starts_at: 2.hours.ago, ends_at: 2.hours.from_now, event_type: 'comm'
       
-      expect(test_event.asset.small).to eq 'center'
+      expect(@cell_instance.call(:asset_position, test_event)).to eq 'center'
     end
     
     it "renders asset with specified gravity if image_gravity is given" do

--- a/spec/controllers/sitemaps_controller_spec.rb
+++ b/spec/controllers/sitemaps_controller_spec.rb
@@ -11,8 +11,17 @@ describe SitemapsController do
       end
 
       it "renders sitemap.xml" do
+        # Defaults the template check to sitemap first
+        template = 'sitemaps/sitemap'
+
+        # Checks whether the current sitemap should render a news template instead
+        news_format = ['stories', 'blog_entries']
+        if news_format.include?(sitemap)
+          template = 'sitemaps/news'
+        end
+
         get sitemap.to_sym
-        response.should render_template 'sitemap/news'
+        response.should render_template template
         response.header['Content-Type'].should match /xml/
       end
     end

--- a/spec/controllers/sitemaps_controller_spec.rb
+++ b/spec/controllers/sitemaps_controller_spec.rb
@@ -12,7 +12,7 @@ describe SitemapsController do
 
       it "renders sitemap.xml" do
         get sitemap.to_sym
-        response.should render_template 'sitemap'
+        response.should render_template 'sitemap/news'
         response.header['Content-Type'].should match /xml/
       end
     end

--- a/spec/controllers/sitemaps_controller_spec.rb
+++ b/spec/controllers/sitemaps_controller_spec.rb
@@ -11,17 +11,8 @@ describe SitemapsController do
       end
 
       it "renders sitemap.xml" do
-        # Defaults the template check to sitemap first
-        template = 'sitemaps/sitemap'
-
-        # Checks whether the current sitemap should render a news template instead
-        news_format = ['stories', 'blog_entries']
-        if news_format.include?(sitemap)
-          template = 'sitemaps/news'
-        end
-
         get sitemap.to_sym
-        response.should render_template template
+        response.should render_template 'sitemap'
         response.header['Content-Type'].should match /xml/
       end
     end

--- a/spec/fixtures/api/assethost/asset.json
+++ b/spec/fixtures/api/assethost/asset.json
@@ -4,6 +4,7 @@
   "caption": "Futurama is brought to you by... Glagnar's Human Rinds! It's a buncha muncha cruncha human!",
   "owner": "Futurama",
   "size": "286x257",
+  "image_gravity": "Left",
   "sizes": {
     "thumb": {
       "width": 86,


### PR DESCRIPTION
Takes the new `image_gravity` property from AssetHost and adds it as a `background-position` value to images cropped into squares on this page: https://scpr.org/events/kpcc-in-person. 

**Documentation:** https://github.com/SCPR/SCPRv4/blob/9127f96ae3ccdf604cfb2540431b7eace3563a49/app/cells/upcoming_events_list/README.md

**Tests:** https://github.com/SCPR/SCPRv4/blob/9127f96ae3ccdf604cfb2540431b7eace3563a49/spec/cells/upcoming_events_list_spec.rb

**New dependencies added to Gemfile:**
- `rspec-cells`

**Misc:**
- Added to the sitemap test to indicate which templates should be expected for each sitemap