### PR TITLE
Fixes podcast link bug for external program pages

### DIFF
--- a/app/cells/appeal/README.md
+++ b/app/cells/appeal/README.md
@@ -11,6 +11,12 @@ There are a few different appeal templates available.  For example, to render th
   cell(:appeal).call(:newsletter)
 ```
 
-## Notes
+---
 
-The newsletter styling is unfinished.  Finish that up and then deprecate the newsletter-appeal cell.
+## Methods
+
+#### `has_podcast_links`
+- **Input:** model (`kpccprogram`, `external_program`)
+- **Output:** boolean
+- **Tests:** `spec/cells/appeal_cell.rb`
+- This function uses the `ProgramPresenter` to check if there are podcast or xml links associated to the current program. It's then tied to the render of the `podcast` block so that we don't render the cell if we don't have any links.

--- a/app/cells/appeal/podcast.erb
+++ b/app/cells/appeal/podcast.erb
@@ -2,11 +2,11 @@
   <h4 class="o-appeal__heading b-heading b-heading--h4 b-heading--serif b-heading--bold b-heading--italic">Subscribe to<br /><%= model.title %>'s podcast</h4>
   <p class="o-appeal__caption">Receive every new episode, automatically, as soon as it's released.  Listen on your own time, your own way.</p>
   <% present model, ProgramPresenter do |p| %>
-    <% if p.send("podcast_link").present? %>
-      <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.send("podcast_link") %>">Subscribe via iTunes</a>
+    <% if !p.podcast_link.blank? %>
+      <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.podcast_link %>">Subscribe via iTunes</a>
     <% end %>
-    <% if p.send("rss_link").present? %>
-      <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.send("rss_link") %>">Any podcast app (XML)</a>
+    <% if !p.rss_link.blank? %>
+      <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.rss_link %>">Any podcast app (XML)</a>
     <% end %>
   <% end %>
 </aside>

--- a/app/cells/appeal/podcast.erb
+++ b/app/cells/appeal/podcast.erb
@@ -5,7 +5,9 @@
     <% if p.send("podcast_link").present? %>
       <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.send("podcast_link") %>">Subscribe via iTunes</a>
     <% end %>
+    <% if p.send("rss_link").present? %>
+      <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.send("rss_link") %>">Any podcast app (XML)</a>
+    <% end %>
   <% end %>
-  <a href="/podcasts/<%= model.try(:slug) %>" class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small">Any podcast app (XML)</a>
 </aside>
 

--- a/app/cells/appeal/podcast.erb
+++ b/app/cells/appeal/podcast.erb
@@ -2,10 +2,10 @@
   <h4 class="o-appeal__heading b-heading b-heading--h4 b-heading--serif b-heading--bold b-heading--italic">Subscribe to<br /><%= model.title %>'s podcast</h4>
   <p class="o-appeal__caption">Receive every new episode, automatically, as soon as it's released.  Listen on your own time, your own way.</p>
   <% present model, ProgramPresenter do |p| %>
-    <% if !p.podcast_link.blank? %>
+    <% if p.podcast_link.present? %>
       <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.podcast_link %>">Subscribe via iTunes</a>
     <% end %>
-    <% if !p.rss_link.blank? %>
+    <% if p.rss_link.present? %>
       <a class="o-appeal__submit c-btn c-btn--outline-secondary c-btn--small" href="<%= p.rss_link %>">Any podcast app (XML)</a>
     <% end %>
   <% end %>

--- a/app/cells/appeal_cell.rb
+++ b/app/cells/appeal_cell.rb
@@ -8,7 +8,17 @@ class AppealCell < Cell::ViewModel
   end
 
   def podcast
-    render
+    render if has_podcast_links
+  end
+
+  def has_podcast_links
+    present model, ProgramPresenter do |p|
+      if !p.send("podcast_link").blank? || !p.send("rss_link").blank?
+        return true
+      else
+        return false
+      end
+    end
   end
 
   def breaking_news

--- a/app/cells/appeal_cell.rb
+++ b/app/cells/appeal_cell.rb
@@ -13,7 +13,7 @@ class AppealCell < Cell::ViewModel
 
   def has_podcast_links
     present model, ProgramPresenter do |p|
-      if !p.podcast_link.blank? || !p.rss_link.blank?
+      if p.podcast_link.present? || p.rss_link.present?
         return true
       else
         return false

--- a/app/cells/appeal_cell.rb
+++ b/app/cells/appeal_cell.rb
@@ -13,7 +13,7 @@ class AppealCell < Cell::ViewModel
 
   def has_podcast_links
     present model, ProgramPresenter do |p|
-      if !p.send("podcast_link").blank? || !p.send("rss_link").blank?
+      if !p.podcast_link.blank? || !p.rss_link.blank?
         return true
       else
         return false

--- a/app/presenters/program_presenter.rb
+++ b/app/presenters/program_presenter.rb
@@ -35,13 +35,13 @@ class ProgramPresenter < ApplicationPresenter
   end
 
   def podcast_link
-    if link = abstract_program.podcast_url
+    if link = program.get_link("podcast")
       link
     end
   end
 
   def rss_link
-    if link = abstract_program.rss_url
+    if link = program.get_link("rss")
       link
     end
   end

--- a/spec/cells/appeal_cell.rb
+++ b/spec/cells/appeal_cell.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+describe AppealCell do
+  describe "GET" do
+    before :each do
+      # Create an external program
+      @program = build :external_program
+    end
+    
+    it "does not render the cell if no podcast or xml link is given" do
+      cell_instance = cell(:appeal, @program)
+      expect(cell_instance.call(:podcast)).to eq ""
+    end
+    
+    it "renders a podcast subscribe link if there is one" do
+      @program.related_links.build(title: "Podcast", url: "http://itunes.apple.com/some/itunes/link", link_type: "podcast")
+      cell_instance = cell(:appeal, @program)
+      expect(cell_instance.call(:podcast)).to include 'Subscribe via iTunes'
+    end
+    
+    it "renders an XML link if there is one" do
+      @program.related_links.build(title: "RSS", url: "show.com/airtalk", link_type: "rss")
+      cell_instance = cell(:appeal, @program)
+      expect(cell_instance.call(:podcast)).to include 'Any podcast app (XML)'
+    end
+  end
+end


### PR DESCRIPTION
The previous implementation of presenting podcast links in external pages was partially hardcoded. The changes here now get the proper links, `podcast` and `rss`, and shows them in the cell if they are available. If neither are available, the cell will not render. Assumptions are tested in the cell spec linked below.

**Documentation:** https://github.com/SCPR/SCPRv4/blob/bbe1ee345e830fe4564440aebbe67110c3f88129/app/cells/appeal/README.md

**Tests:** https://github.com/SCPR/SCPRv4/blob/bbe1ee345e830fe4564440aebbe67110c3f88129/spec/cells/appeal_cell.rb

**Staging demo:**
(XML) https://scprv4-staging.scprdev.org/programs/1a
(Neither) https://scprv4-staging.scprdev.org/programs/reveal/