### PR TITLE
Schedule Occurrence's filter function adjusts according to system tz

### DIFF
--- a/app/models/schedule_occurrence.rb
+++ b/app/models/schedule_occurrence.rb
@@ -30,7 +30,12 @@ class ScheduleOccurrence < ActiveRecord::Base
   scope :recurring, -> { where("recurring_schedule_rule_id is not null") }
   scope :one_time,  -> { where("recurring_schedule_rule_id is null") }
 
-  scope :filtered_by_date, ->(date) { where("DATE(starts_at) = ?", date) }
+  scope :filtered_by_date, ->(date) {
+    system_time_zone = Time.now.formatted_offset
+    rails_time_zone = Time.zone.now.formatted_offset
+    where("DATE(CONVERT_TZ(starts_at, :system_tz, :rails_tz)) = :date", date: date, system_tz: system_time_zone, rails_tz: rails_time_zone)
+    .order("starts_at")
+  }
 
   scope :problems, ->{
     occurrences = future.order("starts_at ASC")

--- a/app/models/schedule_occurrence.rb
+++ b/app/models/schedule_occurrence.rb
@@ -32,8 +32,8 @@ class ScheduleOccurrence < ActiveRecord::Base
 
   scope :filtered_by_date, ->(date) {
     system_time_zone = Time.now.formatted_offset
-    rails_time_zone = Time.zone.now.formatted_offset
-    where("DATE(CONVERT_TZ(starts_at, :system_tz, :rails_tz)) = :date", date: date, system_tz: system_time_zone, rails_tz: rails_time_zone)
+    application_time_zone = Time.now.in_time_zone.formatted_offset
+    where("DATE(CONVERT_TZ(starts_at, :system_tz, :application_tz)) = :date", date: date, system_tz: system_time_zone, application_tz: application_time_zone)
     .order("starts_at")
   }
 


### PR DESCRIPTION
There's an issue where filtering by date in the schedule occurrence page on outpost gives you dates in GMT. So if you chose "2018-02-01" for example, you would get results from "2018-01-31" and "2018-02-01".

### Problem
The MySQL database uses the system's time zone, so the original query `select * from schedule_occurrences where DATE(starts_at) = ?` would always return results for that day in GMT.

### Possible Solution
I thought of possibly changing the global time zone in MySQL, but doing so would only apply to records written afterward. Also, `starts_at` and `ends_at` are stored as `datetimes` which don't include timezone information, so there wouldn't be an easy way of ensuring a datetime is in the correct zone after the change.

### Another Solution
I eventually landed on getting the system time zone and comparing it with the Rails app timezone. Using `Time.now.formatted_offset` in rails console in prod yields `+00:00`, and using `Time.zone.now.formatted_offset` in prod yields `-08:00`. Using both of those offsets, you can convert the time_zone of Schedule Occurences' `starts_at` from GMT to PST/PDT using MySQL's `CONVERT_TZ()`.

For reference, doing the same in staging and locally produces `-08:00` when using `Time.now.formatted_offset`, and `-08:00` when using `Time.zone.now.formatted_offset`. When putting both of those offsets into `CONVERT_TZ()`, you get the original datetime, so local and staging records remain accurate as well.


I think this is probably the best solution because it doesn't alter any records and improves the specificity of query when the filter is called in outpost.

Let me know if that makes sense and if you have any questions/concerns.