### PR TITLE
Show episodes

### DIFF
--- a/app/cells/popular_articles_cell.rb
+++ b/app/cells/popular_articles_cell.rb
@@ -37,7 +37,7 @@ class PopularArticlesCell < Cell::ViewModel
     if (@popular_articles_viewed || []).any?
       @popular_articles_viewed.try(:first, 4)
     else
-      NewsStory.published.order(public_datetime: :desc).all.limit(4)
+      NewsStory.published.order(public_datetime: :desc).all.limit(4).map(&:get_article)
     end
   end
 
@@ -45,7 +45,7 @@ class PopularArticlesCell < Cell::ViewModel
     if (@popular_articles_discussed || []).any?
       @popular_articles_discussed.try(:first, 4)
     else
-      NewsStory.published.order(public_datetime: :desc).all.limit(4).reverse
+      NewsStory.published.order(public_datetime: :desc).all.limit(4).reverse.map(&:get_article)
     end
   end
 

--- a/app/models/show_episode.rb
+++ b/app/models/show_episode.rb
@@ -16,6 +16,7 @@ class ShowEpisode < ActiveRecord::Base
   include Concern::Associations::FeatureAssociation
   include Concern::Associations::PmpContentAssociation::StoryProfile
   include Concern::Associations::EpisodeRundownAssociation
+  include Concern::Callbacks::GenerateShortHeadlineCallback
   include Concern::Callbacks::SetPublishedAtCallback
   #include Concern::Callbacks::CacheExpirationCallback
   include Concern::Callbacks::PublishNotificationCallback
@@ -112,6 +113,9 @@ class ShowEpisode < ActiveRecord::Base
 
   before_save :generate_body, if: -> { self.body.blank? && should_validate? }
 
+  def short_headline
+    super || self.headline
+  end
 
   def needs_validation?
     self.pending? || self.published?

--- a/app/views/shared/media/_media.html.erb
+++ b/app/views/shared/media/_media.html.erb
@@ -1,4 +1,8 @@
-<% story = (content.try(:content) || content) %>
+<% if content.class == HomepageContent %>
+  <% story = content.content %>
+<% else %>
+  <% story = content %>
+<% end %>
 <div class="story o-media o-media--<%= size %> <%= klass %>" data-obj-key='<%= story.obj_key %>'>  
   <% if size == "med" %>
     <%= media_label content.label, content.try(:label_path) %>

--- a/db/migrate/20180227011442_add_short_headline_to_show_episodes.rb
+++ b/db/migrate/20180227011442_add_short_headline_to_show_episodes.rb
@@ -1,0 +1,5 @@
+class AddShortHeadlineToShowEpisodes < ActiveRecord::Migration
+  def change
+    add_column :shows_episode, :short_headline, :string, length: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223193038) do
+ActiveRecord::Schema.define(version: 20180227011442) do
 
   create_table "abstracts", force: :cascade do |t|
     t.string   "source",               limit: 255
@@ -947,6 +947,7 @@ ActiveRecord::Schema.define(version: 20180223193038) do
     t.integer  "original_segment_id", limit: 4
     t.boolean  "needs_reindex",                          default: false
     t.text     "abstract",            limit: 65535
+    t.string   "short_headline",      limit: 255
     t.integer  "feature_type_id",     limit: 4
   end
 


### PR DESCRIPTION
Resolves #1132

In the rare instance that an episode referred to a homepage article, the homepage cache would try to render the episode as related content as if it were an article.  The problem is that not only do episodes not behave like articles, but it has a #content method that does a different thing than what is expected by the related links cell.

This should no longer be a problem now that episodes return a short_headline and the template no longer changes behavior depending on the presence of a #content method, but if there is a HomepageContent type.