### PR TITLE
List type changes

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,14 +1,10 @@
 class List < ActiveRecord::Base
 
-  CONTENT_TYPES = [
-    "NewsStory", 
-    "BlogEntry", 
-    "ShowSegment", 
-    "ContentShell",
-    "PijQuery",
-    "Event", 
-    "Program"
-  ]
+  CONTENT_TYPES = {
+    "article" => ["NewsStory", "BlogEntry", "ShowSegment", "Event"],
+    "program" => ["KpccProgram", "ExternalProgram"],
+    "episode" => ["ShowEpisode"]
+  }
 
   outpost_model
   has_status
@@ -66,9 +62,8 @@ class List < ActiveRecord::Base
   end
 
   def enforce_content_type
-    if content_type && content_type.length
-      items.where.not("item_type LIKE ?", "%#{content_type}%").destroy_all
-    end
+    model_names = CONTENT_TYPES[content_type]
+    items.where.not(item_type: model_names).destroy_all
   end
 
 end

--- a/app/views/outpost/lists/_form_fields.html.erb
+++ b/app/views/outpost/lists/_form_fields.html.erb
@@ -1,6 +1,6 @@
 <%= form_block "Details" do %>
   <%= f.input :title %>
-  <%= f.input :content_type, collection: List::CONTENT_TYPES, selected: record.content_type, include_blank: false, input_html: { id: "status-select" } %>
+  <%= f.input :content_type, collection: List::CONTENT_TYPES.keys, selected: record.content_type, include_blank: false, input_html: { id: "status-select" } %>
   <%= f.input :context %>
   <%= f.section 'status' %>
   <%= f.input :starts_at %>


### PR DESCRIPTION
List types are changed to match API endpoints that are useful to the iOS app.  So instead of the Rails model names, they're "article", "program", and "episode".