### PR TITLE
Allow for a heterogenous list in ShowEpisode pages

### DIFF
--- a/app/cells/episode/README.md
+++ b/app/cells/episode/README.md
@@ -1,0 +1,13 @@
+# Episode Cell
+https://www.scpr.org/programs/airtalk/:year/:month/:day/:id/
+This is a one-column cell that features the episode date and title at the top, and lists related content (usually show segments) underneath.
+
+---
+
+## Methods
+
+#### `related_content`
+- **Input:** @options[:content]
+- **Output:** Heterogeneous collection of content records, type: array
+- **Tests:** `spec/cells/episode.rb`
+- This is a passive method that takes and returns the content option. If the content option is nil, it defaults to an empty array. The content option is taken from the instance variable, @content, which is generated in this concern: https://github.com/SCPR/SCPRv4/blob/master/app/concerns/concern/controller/show_episodes.rb

--- a/app/cells/episode/show.erb
+++ b/app/cells/episode/show.erb
@@ -12,8 +12,8 @@
     <div class="o-featured-episode__segment">
       <figure class="o-featured-episode__segment-figure"><img src="<%= asset_path segment %>" style="background-image:url(<%= asset_path segment %>);"></figure>
       <div class="o-featured-episode__segment-description c-audio-widget">
-        <h3 class="o-featured-episode__segment-title"><%= link_to segment.short_title, segment.public_path %></h3>
-        <div class="o-featured-episode__segment-teaser"><%= segment.teaser %></div>
+        <h3 class="o-featured-episode__segment-title"><%= link_to segment.try(:short_title) || segment.try(:short_headline), segment.try(:public_path) %></h3>
+        <div class="o-featured-episode__segment-teaser"><%= segment.try(:teaser) %></div>
         <% if audio_file(segment) %>
           <a href="<%= ApplicationHelper.url_with_params(audio_file(segment).try(:url), context: segment.try(:show).try(:slug), via: 'website') %>" class="c-play__button" title="<%= segment.try(:title) || segment.try(:headline) %>" data-duration="<%= audio_file(segment).try(:duration) %>" data-ga-category="Article" data-ga-action="Play" data-ga-label="Player">
             <span class="o-featured-episode__segment-audio">

--- a/app/cells/episode_cell.rb
+++ b/app/cells/episode_cell.rb
@@ -36,7 +36,7 @@ class EpisodeCell < Cell::ViewModel
   end
 
   def related_content
-    model.try(:to_episode).try(:segments)
+    @options[:content] || []
   end
 
   def comment_count_for(object, options={})

--- a/app/views/programs/episode.erb
+++ b/app/views/programs/episode.erb
@@ -34,7 +34,7 @@
 <%= cell :ad, slot: "b", id: "o-ad--pos-b", order: 998 %>
 <%= cell :recent_content, @program, class: "o-recent-segments-cluster", order: 999 %>
 <%= cell :program_overview, @program, order: 1000 %>
-<%= cell :episode, @episode, program: @program, order: 1 %>
+<%= cell :episode, @episode, program: @program, content: @content, order: 1 %>
 <%= cell(:recent_episodes_list, @episodes, program: @program, order: 1001).call(:horizontal) %>
 <%= cell :archive_browser, @program, order: 1002 %>
 <%= cell :ad, slot: "c", id: "o-ad--pos-c", order: 1003 %>

--- a/spec/cells/episode_cell.rb
+++ b/spec/cells/episode_cell.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe EpisodeCell do
+  describe "GET" do
+    before :each do
+      # Create a featured program
+      @program = create :kpcc_program, slug: 'the-frame'
+      @featured_episode = create :show_episode, show: @program, headline: "--ShowEpisodexx"
+    end
+    
+    it "can render different data models" do
+      # Create a show segment, news story, and event
+      segment = create :show_segment, :published, headline: "--ShowSegmentxxx"
+      story = create :news_story, :published, headline: "--NewsStoryxx"
+      event = create :event, :published, headline: "--Eventxx"
+      
+      # Relate it to an episode and pass the published_content into @content
+      @content = [segment, story, event].map(&:to_article)
+      
+      # Create a cell instance with the necessary properties
+      cell_instance = cell(:episode, @featured_episode, program: @program, content: @content)
+      
+      # Expect these three content types to be listed
+      expect(cell_instance.call(:show)).to include "--ShowSegmentxx"
+      expect(cell_instance.call(:show)).to include "--NewsStoryxx"
+      expect(cell_instance.call(:show)).to include "--Eventxx"
+    end
+  end
+end


### PR DESCRIPTION
It used to be possible to include non-`ShowSegment` records in `ShowEpisode` pages. However, since AU, only `ShowSegments` have been showing up because it only pulls `ShowSegment` records in the cell (with `model.try(:to_episode).try(:segments)`. In this PR, we go back to using the `@content` instance variable that was supposed to be used to render this list, and make the cell more passive.

**Documentation:** https://github.com/SCPR/SCPRv4/blob/236b2c83bd071b742df37feb7932b21fe2c9a146/app/cells/episode/README.md

**Test:** https://github.com/SCPR/SCPRv4/blob/236b2c83bd071b742df37feb7932b21fe2c9a146/spec/cells/episode_cell.rb

**Staging demo:**
(Heterogeneous) https://scprv4-staging.scprdev.org/programs/take-two/2018/02/23/17893/
(Homogeneous) https://www.scpr.org/programs/take-two/2018/02/23/17893/

*Note: in the examples above, the staging link correctly shows the `NewsStory` record, "11 things to do this weekend in SoCal", whereas the production link doesn't