### PR TITLE
Adds an 'obj_key' tag for Megaphone's API

### DIFF
--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -166,7 +166,6 @@ class Audio < ActiveRecord::Base
   # If the audio doesn't come from our servers (i.e. doesn't contain
   # the Rails.configuration.x.scpr.audio_url), then just leave it as-is
   def podcast_url
-    # self.url.gsub(Rails.configuration.x.scpr.audio_url, Rails.configuration.x.scpr.podcast_url)
     self.url.gsub(Rails.configuration.x.scpr.audio_url, Rails.configuration.x.scpr.podcast_url)
   end
 

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -167,7 +167,7 @@ class Audio < ActiveRecord::Base
   # the Rails.configuration.x.scpr.audio_url), then just leave it as-is
   def podcast_url
     # self.url.gsub(Rails.configuration.x.scpr.audio_url, Rails.configuration.x.scpr.podcast_url)
-    self.url
+    self.url.gsub(Rails.configuration.x.scpr.audio_url, Rails.configuration.x.scpr.podcast_url)
   end
 
 

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -166,7 +166,8 @@ class Audio < ActiveRecord::Base
   # If the audio doesn't come from our servers (i.e. doesn't contain
   # the Rails.configuration.x.scpr.audio_url), then just leave it as-is
   def podcast_url
-    self.url.gsub(Rails.configuration.x.scpr.audio_url, Rails.configuration.x.scpr.podcast_url)
+    # self.url.gsub(Rails.configuration.x.scpr.audio_url, Rails.configuration.x.scpr.podcast_url)
+    self.url
   end
 
 

--- a/app/views/podcasts/podcast.xml.builder
+++ b/app/views/podcasts/podcast.xml.builder
@@ -1,8 +1,9 @@
-cache ["v2", @podcast, @consumer], expires_in: 1.hour do # Podcasts will refresh every hour.
+cache ["v3", @podcast, @consumer], expires_in: 1.hour do # Podcasts will refresh every hour.
   xml.rss(
     'version'         => "2.0",
     'xmlns:atom'      => "http://www.w3.org/2005/Atom",
-    'xmlns:itunes'    => "http://www.itunes.com/dtds/podcast-1.0.dtd"
+    'xmlns:itunes'    => "http://www.itunes.com/dtds/podcast-1.0.dtd",
+    'xmlns:megaphone' => "https://developers.megaphone.fm"
   ) do
     xml.channel do
       xml.title @podcast.title
@@ -38,14 +39,15 @@ cache ["v2", @podcast, @consumer], expires_in: 1.hour do # Podcasts will refresh
         audio = article.audio.first
 
         xml.item do |item|
-          item.title              raw(article.title)
-          item.itunes :author,    raw(@podcast.author)
-          item.itunes :summary,   raw(article.teaser)
-          item.description        raw(article.teaser)
-          item.guid               article.public_url, :isPermaLink => true
-          item.pubDate            article.public_datetime.in_time_zone("GMT").strftime("%a, %d %b %Y %T %Z")
-          item.itunes :keywords,  raw(@podcast.keywords)
-          item.link               article.public_url
+          item.megaphone :externalId,   article.obj_key
+          item.title                    raw(article.title)
+          item.itunes :author,          raw(@podcast.author)
+          item.itunes :summary,         raw(article.teaser)
+          item.description              raw(article.teaser)
+          item.guid                     article.public_url, :isPermaLink => true
+          item.pubDate                  article.public_datetime.in_time_zone("GMT").strftime("%a, %d %b %Y %T %Z")
+          item.itunes :keywords,        raw(@podcast.keywords)
+          item.link                     article.public_url
 
           item.enclosure({
             :url => url_with_params(audio.podcast_url, {

--- a/app/views/podcasts/podcast.xml.builder
+++ b/app/views/podcasts/podcast.xml.builder
@@ -1,4 +1,4 @@
-cache ["v3", @podcast, @consumer], expires_in: 1.hour do # Podcasts will refresh every hour.
+cache ["v4", @podcast, @consumer], expires_in: 1.hour do # Podcasts will refresh every hour.
   xml.rss(
     'version'         => "2.0",
     'xmlns:atom'      => "http://www.w3.org/2005/Atom",


### PR DESCRIPTION
This change adds a `<megaphone:externalId>` tag to the xml so that we have an easy way to retrieve the episode from Megaphone's API.