### PR TITLE
Allow remote articles to pull in the latest headlines.

### DIFF
--- a/app/importers/npr_article_importer.rb
+++ b/app/importers/npr_article_importer.rb
@@ -37,17 +37,12 @@ module NprArticleImporter
 
       added = []
 
-      fetched_story_ids    = npr_stories.map(&:id)
+      npr_stories.each do |npr_story|
+        if existing_story = RemoteArticle.where(article_id: npr_story.id.to_s, source: SOURCE).first
+          existing_story.update headline: npr_story.title, teaser: npr_story.teaser, url: npr_story.link_for("html")
+          next
+        end
 
-      existing_story_ids   = RemoteArticle.where(article_id: fetched_story_ids, source: SOURCE)
-        .pluck(:article_id)
-        .compact
-        .map(&:to_s)
-
-      npr_stories.reject{ |s|
-        # Reject the story if the id is already present in our database.
-        existing_story_ids.include?(s.id.to_s)
-      }.each do |npr_story|
         cached_article = RemoteArticle.new(
           :source       => SOURCE,
           :article_id   => npr_story.id,
@@ -70,7 +65,7 @@ module NprArticleImporter
           log "NPR Story ##{npr_story.id} already exists"
         end
 
-      end # each
+      end
 
       added
     end

--- a/spec/fixtures/api/npr/stories-altered.json
+++ b/spec/fixtures/api/npr/stories-altered.json
@@ -1,0 +1,399 @@
+{
+  "version": "0.94",
+  "list": {
+    "title": {
+      "$text": "NPR: Stories from NPR"
+    },
+    "teaser": {
+      "$text": "Assorted stories from NPR"
+    },
+    "miniTeaser": {
+      "$text": "Custom NPR News Feed API.  Visit http://www.npr.org/templates/apidoc/index.php for more information."
+    },
+    "link": [
+      {
+        "type": "api",
+        "$text": "http://api.npr.org/query?&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+      }
+    ],
+    "story": [
+      {
+        "id": "187325945",
+        "link": [
+          {
+            "type": "html",
+            "$text": "http://www.npr.org/blogs/thetwo-way/2013/05/30/187325945/four-men-in-a-small-ship-face-the-northwest-passage?ft=3&f="
+          },
+          {
+            "type": "api",
+            "$text": "http://api.npr.org/query?id=187325945&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+          },
+          {
+            "type": "short",
+            "$text": "http://n.pr/11apkBs"
+          }
+        ],
+        "title": {
+          "$text": "Four Men In A Small Ship Face The Northwest Passage "
+        },
+        "partnerId": {
+          "$text": "187325945"
+        },
+        "subtitle": {},
+        "shortTitle": {},
+        "teaser": {
+          "$text": "The crew hopes to be the first to sail through the fabled Northwest Passage in one season aboard a custom-built 23-foot boat."
+        },
+        "miniTeaser": {
+          "$text": "Climate change has opened up an opportunity for the crew to row from west to east in one season."
+        },
+        "slug": {
+          "$text": "The Two-Way"
+        },
+        "thumbnail": {
+          "medium": {
+            "$text": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_sq-8b5f88944134580da7f9e065d6e8218a1044bfd8.jpg?s=13"
+          },
+          "large": {
+            "$text": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_sq-8b5f88944134580da7f9e065d6e8218a1044bfd8.jpg?s=11"
+          },
+          "provider": {
+            "$text": "AP"
+          }
+        },
+        "storyDate": {
+          "$text": "Thu, 30 May 2013 15:04:00 -0400"
+        },
+        "pubDate": {
+          "$text": "Thu, 30 May 2013 15:23:00 -0400"
+        },
+        "lastModifiedDate": {
+          "$text": "Thu, 30 May 2013 15:23:17 -0400"
+        },
+        "keywords": {},
+        "priorityKeywords": {},
+        "organization": [
+          {
+            "orgId": "1",
+            "orgAbbr": "NPR",
+            "name": {
+              "$text": "NPR"
+            },
+            "website": {
+              "$text": "http://www.npr.org/"
+            }
+          }
+        ],
+        "parent": [
+          {
+            "id": "127602855",
+            "type": "category",
+            "title": {
+              "$text": "America"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/templates/story/story.php?storyId=127602855&ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=127602855&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "127602464",
+            "type": "category",
+            "title": {
+              "$text": "International"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/templates/story/story.php?storyId=127602464&ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=127602464&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "103943429",
+            "type": "blog",
+            "slug": "true",
+            "title": {
+              "$text": "The Two-Way"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/blogs/thetwo-way/?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=103943429&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "1004",
+            "type": "topic",
+            "title": {
+              "$text": "World"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/sections/world/?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=1004&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "1003",
+            "type": "primaryTopic",
+            "title": {
+              "$text": "U.S."
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/sections/us/?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=1003&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "1003",
+            "type": "topic",
+            "title": {
+              "$text": "U.S."
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/sections/us/?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=1003&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "1002",
+            "type": "topic",
+            "title": {
+              "$text": "Home Page Top Stories"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=1002&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          },
+          {
+            "id": "1001",
+            "type": "topic",
+            "title": {
+              "$text": "News"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/sections/news/?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=1001&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          }
+        ],
+        "byline": [
+          {
+            "id": "187326083",
+            "name": {
+              "personId": "131724812",
+              "$text": "Scott Neuman"
+            },
+            "link": [
+              {
+                "type": "html",
+                "$text": "http://www.npr.org/people/131724812/scott-neuman?ft=3&f="
+              },
+              {
+                "type": "api",
+                "$text": "http://api.npr.org/query?id=131724812&apiKey=MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004"
+              }
+            ]
+          }
+        ],
+        "image": [
+          {
+            "id": "187326560",
+            "type": "primary",
+            "width": "200",
+            "src": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_wide-e39731259c533cd16ca6f72746009753b04b732a.jpg?s=12",
+            "hasBorder": "false",
+            "title": {
+              "$text": "A European Space Agency photo of the McClure Strait in the Canadian Arctic. The McClure Strait is the most direct route of the Northwest Passage and has been fully open since early August 2007."
+            },
+            "caption": {
+              "$text": "A European Space Agency photo of the McClure Strait in the Canadian Arctic. The McClure Strait is the most direct route of the Northwest Passage and has been fully open since early August 2007."
+            },
+            "link": {
+              "url": ""
+            },
+            "producer": {},
+            "provider": {
+              "url": "",
+              "$text": "AP"
+            },
+            "copyright": {},
+            "enlargement": {
+              "src": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_wide-e39731259c533cd16ca6f72746009753b04b732a.jpg",
+              "caption": {}
+            },
+            "crop": [
+              {
+                "type": "standard",
+                "src": "http://media.npr.org/assets/img/2013/05/30/ap070915029493-9d556b11a25881741515b0e5f0dc9f328c338931.jpg",
+                "height": "888",
+                "width": "1184"
+              },
+              {
+                "type": "square",
+                "src": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_sq-8b5f88944134580da7f9e065d6e8218a1044bfd8.jpg",
+                "height": "1184",
+                "width": "1184"
+              },
+              {
+                "type": "wide",
+                "src": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_wide-e39731259c533cd16ca6f72746009753b04b732a.jpg",
+                "height": "665",
+                "width": "1184"
+              },
+              {
+                "type": "enlargement",
+                "src": "http://media.npr.org/assets/img/2013/05/30/ap070915029493_wide-e39731259c533cd16ca6f72746009753b04b732a.jpg",
+                "height": "665",
+                "width": "1184"
+              }
+            ]
+          }
+        ],
+        "text": {
+          "paragraph": [
+            {
+              "num": "1",
+              "$text": "Only a few years ago, even large commercial vessels wouldn't take on the ice-bound Northwest Passage linking the Atlantic and Pacific via the Canadian north — but climate change has changed all that."
+            },
+            {
+              "num": "2",
+              "$text": "Now, a group of hearty adventurers hopes to be the first to row the 1,900-mile route this summer."
+            },
+            {
+              "num": "3",
+              "$text": "\"Several people have kayaked it [a section at a time] over several years. But no one has ever done this under human power in a single season. Not even close,\" Kevin Vallely, who is heading up the rowing team, told The Globe and Mail on Wednesday."
+            },
+            {
+              "num": "4",
+              "$text": "Vallely has completed his last shakedown cruise and plans to set off at the beginning of July from Inuvik in northern Canada with three crew mates in a custom-built, 23-foot rowboat. They expect to take 75 days to reach their eastern destination, the town of Pond Inlet. Along the way they're bracing for encounters with dangerous ice, storms and polar bears, not to mention the psychological challenge of four men in a small boat in those difficult circumstances."
+            },
+            {
+              "num": "5",
+              "$text": "\"We have guns\" as a precaution against polar bears, Vallely tells The Globe and Mail. \"But we'll have rubber bullets and bear bangers ... we don't want to kill a bear.\""
+            },
+            {
+              "num": "6",
+              "$text": "The newspaper says Vallely, \"who has done numerous wilderness treks over the past 20 years, said if your physical conditioning is just right, body fitness peaks during a long journey and then slowly deteriorates.\""
+            },
+            {
+              "num": "7"
+            },
+            {
+              "num": "8",
+              "$text": "\" 'Obviously you have to train enough that you don't get injured [by the exertion of the expedition]. But you don't want to train too much, because if you go into it Tour de France fit, in a couple of weeks you would be fried,' he said. 'So you go into it fit, but not crazy fit, and you build up and you get really strong about half-way through. And then you slowly start to fall apart. By the end you want to be tired, happy to be done, but not completely baked.' \""
+            },
+            {
+              "num": "9"
+            },
+            {
+              "num": "10",
+              "$text": "As we reported back in March, computer simulations of various climate change models indicate that Arctic ice will be so thin by the middle of the century that commercial shipping from North America to Russia or Asia via the Arctic could become routine."
+            },
+            {
+              "num": "11",
+              "$text": "In recent years, Arctic sea ice has shrunk to its smallest extent on record, opening up the Northwest Passage. A solo sailor in a 27-foot fiberglass sailboat was one of 18 private yachts to sail the route last year. [Copyright 2013 NPR]"
+            }
+          ]
+        },
+        "textWithHtml": {
+          "paragraph": [
+            {
+              "num": "1",
+              "$text": "Only a few years ago, even large commercial vessels wouldn't take on the ice-bound Northwest Passage linking the Atlantic and Pacific via the Canadian north — but climate change has changed all that."
+            },
+            {
+              "num": "2",
+              "$text": "Now, a group of hearty adventurers hopes to be the first to row the 1,900-mile route this summer."
+            },
+            {
+              "num": "3",
+              "$text": "\"Several people have kayaked it [a section at a time] over several years. But no one has ever done this under human power in a single season. Not even close,\" Kevin Vallely, who is heading up the rowing team, told <a href=\"http://www.theglobeandmail.com/news/british-columbia/four-man-crew-plans-to-conquer-the-northwest-passage-in-75-days/article12252309/\"><em>The Globe and Mail</em></a> on Wednesday."
+            },
+            {
+              "num": "4",
+              "$text": "Vallely has completed his last shakedown cruise and plans to set off at the beginning of July from Inuvik in northern Canada with three crew mates in a custom-built, 23-foot rowboat. They expect to take 75 days to reach their eastern destination, the town of Pond Inlet. Along the way they're bracing for encounters with dangerous ice, storms and polar bears, not to mention the psychological challenge of four men in a small boat in those difficult circumstances."
+            },
+            {
+              "num": "5",
+              "$text": "\"We have guns\" as a precaution against polar bears, Vallely tells <em>The Globe and Mail</em>. \"But we'll have rubber bullets and bear bangers ... we don't want to kill a bear.\""
+            },
+            {
+              "num": "6",
+              "$text": "The newspaper says Vallely, \"who has done numerous wilderness treks over the past 20 years, said if your physical conditioning is just right, body fitness peaks during a long journey and then slowly deteriorates.\""
+            },
+            {
+              "num": "7",
+              "$text": "<blockquote>"
+            },
+            {
+              "num": "8",
+              "$text": "\" 'Obviously you have to train enough that you don't get injured [by the exertion of the expedition]. But you don't want to train too much, because if you go into it Tour de France fit, in a couple of weeks you would be fried,' he said. 'So you go into it fit, but not crazy fit, and you build up and you get really strong about half-way through. And then you slowly start to fall apart. By the end you want to be tired, happy to be done, but not completely baked.' \""
+            },
+            {
+              "num": "9",
+              "$text": "</blockquote>"
+            },
+            {
+              "num": "10",
+              "$text": "As we <a href=\"http://www.npr.org/blogs/thetwo-way/2013/03/05/173519090/study-finds-climate-change-to-open-arctic-sea-routes-by-2050\">reported back in March</a>, computer simulations of various climate change models indicate that Arctic ice will be so thin by the middle of the century that commercial shipping from North America to Russia or Asia via the Arctic could become routine."
+            },
+            {
+              "num": "11",
+              "$text": "In recent years, Arctic sea ice has shrunk to its <a href=\"http://www.guardian.co.uk/environment/2012/sep/14/arctic-sea-ice-smallest-extent\">smallest extent on record</a>, opening up the Northwest Passage. A solo sailor in a <a href=\"http://articles.washingtonpost.com/2012-04-21/sports/35454042_1_city-dock-sailboat-lake-ogleton%20\">27-foot fiberglass sailboat</a> was one of 18 private yachts to sail the route last year.  <div class=\"fullattribution\">Copyright 2013 NPR. To see more, visit http://www.npr.org/.<img src=\"http://www.google-analytics.com/__utm.gif?utmac=UA-5828686-4&utmdt=Four+Men+In+A+Small+Boat+Face+The+Northwest+Passage+&utme=8(APIKey)9(MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004)\"/></div>"
+            }
+          ]
+        },
+        "fullText": {
+          "$text": "<div class=\"storytitle\">      <h1>Four Men In A Small Boat Face The Northwest Passage </h1>   <input type=\"hidden\" id=\"title187325945\" value=\"Four Men In A Small Boat Face The Northwest Passage \"></input>   <input type=\"hidden\" id=\"modelShortUrl187325945\" value=\"http://n.pr/11apkBu\"></input>   <input type=\"hidden\" id=\"modelFullUrl187325945\" value=\"http://www.npr.org/blogs/thetwo-way/2013/05/30/187325945/four-men-in-a-small-boat-face-the-northwest-passage\"></input></div><!-- END CLASS=\"STORYTITLE\" --><div id=\"story-meta\">      <div id=\"storybyline\" class=\"  linkLocation\">            <div class=\"bucketwrap byline\" id=\"res187325950\" previewTitle=\"bylines\">                  <p class=\"byline\">by <a rel=\"author\" href=\"http://www.npr.org/people/131724812/scott-neuman\"><span>Scott Neuman</span></a></p>      </div>      <!-- END CLASS=\"BUCKETWRAP BYLINE\" ID=\"RES187325950\" PREVIEWTITLE=\"BYLINES\" -->   </div>   <!-- END ID=\"STORYBYLINE\" CLASS=\"  LINKLOCATION\" -->   <div class=\"dateblock\">            <time datetime=\"2013-05-30\"><span class=\"date\">May 30, 2013</span><span class=\"time\"> 3:04 PM</span></time>   </div></div><!-- END ID=\"STORY-META\" --><div id=\"storytext\" class=\"storytext storylocation linkLocation\">      <div id=\"res187326560\" class=\"bucketwrap image large\" previewTitle=\"A European Space Agency photo of the McClure Strait in the Canadian Arctic. The McClure Strait is the most direct route of the Northwest Passage and has been fully open since early August 2007.\">            <div class=\"imagewrap\">                  <img src=\"http://media.npr.org/assets/img/2013/05/30/ap070915029493_wide-e39731259c533cd16ca6f72746009753b04b732a-s6.jpg\" title=\"A European Space Agency photo of the McClure Strait in the Canadian Arctic. The McClure Strait is the most direct route of the Northwest Passage and has been fully open since early August 2007.\" alt=\"A European Space Agency photo of the McClure Strait in the Canadian Arctic. The McClure Strait is the most direct route of the Northwest Passage and has been fully open since early August 2007.\" />         <a href=\"#\" class=\"enlargebtn\" title=\"Enlarge\">Enlarge image</a>         <a href=\"#\" class=\"enlargebtn enlarge-smallscreen\" title=\"Enlarge\">i</a>      </div>      <!-- END CLASS=\"IMAGEWRAP\" -->      <div class=\"captionwrap\">                  <div class=\"caption\">                        <p><i>A European Space Agency photo of the McClure Strait in the Canadian Arctic. The McClure Strait is the most direct route of the Northwest Passage and has been fully open since early August 2007.</i></p>         </div>         <!-- END CLASS=\"CAPTION\" -->      </div>      <!-- END CLASS=\"CAPTIONWRAP\" -->      <span class=\"creditwrap\"><span class=\"rightsnotice\">AP</span></span>   </div>   <p>Only a few years ago, even large commercial vessels wouldn't take on the ice-bound Northwest Passage linking the Atlantic and Pacific via the Canadian north — but climate change has changed all that.</p>   <p>Now, a group of hearty adventurers hopes to be the first to row the 1,900-mile route this summer.</p>   <p>\"Several people have kayaked it [a section at a time] over several years. But no one has ever done this under human power in a single season. Not even close,\" Kevin Vallely, who is heading up the rowing team, told <a href=\"http://www.theglobeandmail.com/news/british-columbia/four-man-crew-plans-to-conquer-the-northwest-passage-in-75-days/article12252309/\"><em>The Globe and Mail</em></a> on Wednesday.</p>   <p>Vallely has completed his last shakedown cruise and plans to set off at the beginning of July from Inuvik in northern Canada with three crew mates in a custom-built, 23-foot rowboat. They expect to take 75 days to reach their eastern destination, the town of Pond Inlet. Along the way they're bracing for encounters with dangerous ice, storms and polar bears, not to mention the psychological challenge of four men in a small boat in those difficult circumstances.</p>   <p>\"We have guns\" as a precaution against polar bears, Vallely tells <em>The Globe and Mail</em>. \"But we'll have rubber bullets and bear bangers ... we don't want to kill a bear.\"</p>   <p>The newspaper says Vallely, \"who has done numerous wilderness treks over the past 20 years, said if your physical conditioning is just right, body fitness peaks during a long journey and then slowly deteriorates.\"</p>   <blockquote class=\"edTag\"><div>   <p>\" 'Obviously you have to train enough that you don't get injured [by the exertion of the expedition]. But you don't want to train too much, because if you go into it Tour de France fit, in a couple of weeks you would be fried,' he said. 'So you go into it fit, but not crazy fit, and you build up and you get really strong about half-way through. And then you slowly start to fall apart. By the end you want to be tired, happy to be done, but not completely baked.' \"</p>   </div></blockquote>   <p>As we <a href=\"http://www.npr.org/blogs/thetwo-way/2013/03/05/173519090/study-finds-climate-change-to-open-arctic-sea-routes-by-2050\">reported back in March</a>, computer simulations of various climate change models indicate that Arctic ice will be so thin by the middle of the century that commercial shipping from North America to Russia or Asia via the Arctic could become routine.</p>   <p>In recent years, Arctic sea ice has shrunk to its <a href=\"http://www.guardian.co.uk/environment/2012/sep/14/arctic-sea-ice-smallest-extent\">smallest extent on record</a>, opening up the Northwest Passage. A solo sailor in a <a href=\"http://articles.washingtonpost.com/2012-04-21/sports/35454042_1_city-dock-sailboat-lake-ogleton%20\">27-foot fiberglass sailboat</a> was one of 18 private yachts to sail the route last year.</p></div><div class=\"fullattribution\">Copyright 2013 NPR. To see more, visit http://www.npr.org/.<img src=\"http://www.google-analytics.com/__utm.gif?utmac=UA-5828686-4&utmdt=Four+Men+In+A+Small+Boat+Face+The+Northwest+Passage+&utme=8(APIKey)9(MDA1OTI3MjQ5MDEyODUwMTE2MzM1YzNmZA004)\"/></div>"
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/api/pmp/marketplace_stories_altered.json
+++ b/spec/fixtures/api/pmp/marketplace_stories_altered.json
@@ -1,0 +1,695 @@
+{
+  "version": "1.0",
+  "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=story",
+  "links": {
+    "item": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs/2512a8ec-2a12-7111-d9c1-6e2c3690dbe8"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/4d39cdbe-1d80-22a9-ed5b-8cd87414f206"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/eefd52da-9525-48c7-616d-2dea652b0dc9"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/18ec6d38-0342-7365-f4d5-33c613bff41e"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/870ecf61-b920-f14f-c3ed-17b93c2d7ec6"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/41e9d664-7115-97af-f0ba-c11b4c4821e7"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/e9cb2193-84f4-492d-1314-a6e2ee623eb7"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/fc317f6f-2172-d0ba-e40c-b6cb57b3656f"
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs/fe111285-92c5-f5de-7b34-8a720d5fc750"
+      }
+    ],
+    "navigation": [
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b",
+        "rels": [
+          "self"
+        ],
+        "totalitems": 535,
+        "totalpages": 54,
+        "pagenum": 1
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b&offset=10",
+        "rels": [
+          "next"
+        ],
+        "pagenum": 2
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b",
+        "rels": [
+          "first"
+        ],
+        "pagenum": 1
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/docs?tag=marketplace&profile=b9ce545e-01a2-44d0-9a15-a73da4ed304b&offset=530",
+        "rels": [
+          "last"
+        ],
+        "pagenum": 54
+      }
+    ],
+    "query": [
+      {
+        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for users",
+        "rels": [
+          "urn:collectiondoc:query:users"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/groups{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for groups",
+        "rels": [
+          "urn:collectiondoc:query:groups"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/profiles{/guid}",
+        "title": "Access profiles",
+        "rels": [
+          "urn:collectiondoc:hreftpl:profiles"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/profiles{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for profiles",
+        "rels": [
+          "urn:collectiondoc:query:profiles"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/schemas{/guid}",
+        "title": "Access schemas",
+        "rels": [
+          "urn:collectiondoc:hreftpl:schemas"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/users{?limit,offset,tag,collection,text,searchsort,has}",
+        "title": "Query for schemas",
+        "rels": [
+          "urn:collectiondoc:query:schemas"
+        ],
+        "href-vars": {
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/docs{/guid}{?limit,offset}",
+        "title": "Access documents",
+        "rels": [
+          "urn:collectiondoc:hreftpl:docs"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href-template": "https://api-sandbox.pmp.io/docs{?guid,limit,offset,tag,collection,text,searchsort,has,author,distributor,distributorgroup,startdate,enddate,profile,language}",
+        "title": "Query for documents",
+        "rels": [
+          "urn:collectiondoc:query:docs"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "limit": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "offset": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "tag": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "collection": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "text": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "searchsort": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "has": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "author": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "distributor": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "distributorgroup": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "startdate": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "enddate": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "profile": "http://docs.pmp.io/wiki/Content-Retrieval",
+          "language": "http://docs.pmp.io/wiki/Content-Retrieval"
+        },
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      },
+      {
+        "href": "https://api-sandbox.pmp.io/guids",
+        "title": "Generate guids",
+        "rels": [
+          "urn:collectiondoc:query:guids"
+        ],
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "accept-post": [
+            "application/x-www-form-urlencoded"
+          ]
+        },
+        "type": "application/json"
+      }
+    ],
+    "edit": [
+      {
+        "href-template": "https://publish-sandbox.pmp.io/docs{/guid}",
+        "title": "Document Save",
+        "rels": [
+          "urn:collectiondoc:form:documentsave"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Collection.doc-JSON-Media-Type"
+        }
+      },
+      {
+        "href-template": "https://publish-sandbox.pmp.io/profiles{/guid}",
+        "title": "Profile Save",
+        "rels": [
+          "urn:collectiondoc:form:profilesave"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Profile-profile"
+        }
+      },
+      {
+        "href-template": "https://publish-sandbox.pmp.io/schemas{/guid}",
+        "title": "Schema Save",
+        "rels": [
+          "urn:collectiondoc:form:schemasave"
+        ],
+        "href-vars": {
+          "guid": "http://docs.pmp.io/wiki/Globaly-Unique-Identifiers-for-PMP-Documents"
+        },
+        "hints": {
+          "formats": [
+            "application/vnd.collection.doc+json"
+          ],
+          "allow": [
+            "PUT",
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Schema-profile"
+        }
+      },
+      {
+        "href": "https://publish-sandbox.pmp.io/files",
+        "title": "Upload a rich media file",
+        "rels": [
+          "urn:collectiondoc:form:mediaupload"
+        ],
+        "href-vars": {
+          "submission": "http://docs.pmp.io/wiki/Media-File-Upload"
+        },
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "accept-post": [
+            "multipart/form-data"
+          ]
+        }
+      }
+    ],
+    "auth": [
+      {
+        "href": "https://api-sandbox.pmp.io/auth/access_token",
+        "title": "Issue OAuth2 Token",
+        "rels": [
+          "urn:collectiondoc:form:issuetoken"
+        ],
+        "hints": {
+          "allow": [
+            "POST"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Authentication-Model#token-management"
+        }
+      },
+      {
+        "href": "https://publish-sandbox.pmp.io/auth/access_token",
+        "title": "Revoke OAuth2 Token",
+        "rels": [
+          "urn:collectiondoc:form:revoketoken"
+        ],
+        "hints": {
+          "allow": [
+            "DELETE"
+          ],
+          "docs": "http://docs.pmp.io/wiki/Authentication-Model#revoke-a-token"
+        }
+      }
+    ]
+  },
+  "items": [
+    {
+      "version": "1.0",
+      "href": "https://api-sandbox.pmp.io/docs/2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
+      "attributes": {
+        "valid": {
+          "from": "2013-09-30T20:43:01+00:00",
+          "to": "3013-09-30T20:43:01+00:00"
+        },
+        "created": "2014-01-30T05:30:53+00:00",
+        "modified": "2014-01-30T05:30:53+00:00",
+        "contenttemplated": "<p>This final note today,&nbsp;in which the phrase time is money,&nbsp;is established once again as a truism.</p>\n<p>From the 2013 Drive-Thru Performance Study,&nbsp;by the fast-food trade publication QSR Magazine:&nbsp;Last year, the average McDonald's drive-through customer waited 189.5 seconds for her order. That's a&nbsp;tad more than three minutes.</p>\n<p>It matters, because the big chains do 60-70 percent of their business at the drive-through window.</p>\n<p>The record?&nbsp;Wendy's...back in 2003.&nbsp;116 seconds, or less than two minutes.</p>\n<p>Nobody's been close since.</p>",
+        "guid": "2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
+        "teaser": "A new survey looks at the average time spent in the drive-through window.",
+        "contentencoded": "<p>This final note today,&nbsp;in which the phrase time is money,&nbsp;is established once again as a truism.</p>\n<p>From the 2013 Drive-Thru Performance Study,&nbsp;by the fast-food trade publication QSR Magazine:&nbsp;Last year, the average McDonald's drive-through customer waited 189.5 seconds for her order. That's a&nbsp;tad more than three minutes.</p>\n<p>It matters, because the big chains do 60-70 percent of their business at the drive-through window.</p>\n<p>The record?&nbsp;Wendy's...back in 2003.&nbsp;116 seconds, or less than two minutes.</p>\n<p>Nobody's been close since.</p>",
+        "byline": "Ryssdal, Kai",
+        "hreflang": "en",
+        "description": "A new survey looks at the average time spent in the drive-through window.",
+        "tags": [
+          "Final Note",
+          "APM_TESTING",
+          "PMP:Marketplace_PMP",
+          "Marketplace for Monday, September 30, 2013",
+          "2512a8ec2a127111d9c16e2c3690dbe8",
+          "Marketplace",
+          "Business"
+        ],
+        "published": "2013-09-30T20:43:01+00:00",
+        "title": "Serving trillions and trillions: In less than 3 minutes"
+      },
+      "links": {
+        "profile": [
+          {
+            "href": "https://api-sandbox.pmp.io/profiles/story",
+            "title": "APMStory"
+          }
+        ],
+        "distributor": [],
+        "copyright": [
+          {
+            "href": "http://www.publicradio.org/terms",
+            "title": "Copyright (C) 2013 American Public Media Group"
+          }
+        ],
+        "item": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/300b3409-4631-3f60-bd8f-e15e47b652b5"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df",
+            "title": "Marketplace for Monday, September 30, 2013"
+          }
+        ],
+        "alternate": [
+          {
+            "href": "http://www.marketplace.org/topics/business/final-note/serving-billions-and-billions-less-3-minutes",
+            "type": "text/html"
+          }
+        ],
+        "creator": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+          }
+        ],
+        "navigation": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs?guid=2512a8ec-2a12-7111-d9c1-6e2c3690dbe8",
+            "rels": [
+              "self"
+            ],
+            "totalitems": 1,
+            "totalpages": 1,
+            "pagenum": 1
+          }
+        ]
+      },
+      "items": [
+        {
+          "version": "1.0",
+          "href": "https://api-sandbox.pmp.io/docs/300b3409-4631-3f60-bd8f-e15e47b652b5",
+          "attributes": {
+            "valid": {
+              "from": "2013-05-23T23:46:03+00:00",
+              "to": "3013-05-23T23:46:03+00:00"
+            },
+            "created": "2014-01-30T05:30:36+00:00",
+            "modified": "2014-01-30T05:30:36+00:00",
+            "byline": "Mitchell Hartman",
+            "hreflang": "en",
+            "description": "At a McDonald's Drive-Through in Portland, Oregon, the Angus burgers have already been discontinued, though they're still available at other McDonald's in the city. The company has also discontinued the fruit and walnut salad and chicken selects, while adding a new egg-whites McMuffin.",
+            "tags": [
+              "Final Note",
+              "APM_TESTING",
+              "PMP:Marketplace_PMP",
+              "Marketplace for Monday, September 30, 2013",
+              "Marketplace",
+              "Business",
+              "300b340946313f60bd8fe15e47b652b5"
+            ],
+            "published": "2013-09-30T20:43:01+00:00",
+            "guid": "300b3409-4631-3f60-bd8f-e15e47b652b5",
+            "title": "McDonald's Drive Thru with cancelled Angus burgers 2.jpg"
+          },
+          "links": {
+            "profile": [
+              {
+                "href": "https://api-sandbox.pmp.io/profiles/image",
+                "title": "APMImage"
+              }
+            ],
+            "enclosure": [
+              {
+                "href": "http://www.marketplace.org/sites/default/files/styles/primary-image-610x340/public/McDonald's%20Drive%20Thru%20with%20cancelled%20Angus%20burgers%202.jpg",
+                "type": "image/jpeg",
+                "meta": {
+                  "width": "610",
+                  "crop": "primary",
+                  "height": "340"
+                }
+              },
+              {
+                "href": "http://www.marketplace.org/sites/default/files/styles/square_thumbnail/public/McDonald's%20Drive%20Thru%20with%20cancelled%20Angus%20burgers%202.jpg",
+                "type": "image/jpeg",
+                "meta": {
+                  "width": 180,
+                  "crop": "small",
+                  "height": 180
+                }
+              }
+            ],
+            "distributor": [],
+            "copyright": [
+              {
+                "href": "http://www.publicradio.org/terms",
+                "title": "Copyright (C) 2013 American Public Media Group"
+              }
+            ],
+            "collection": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+                "title": "Marketplace"
+              },
+              {
+                "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+                "title": "Marketplace"
+              }
+            ],
+            "creator": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+              }
+            ],
+            "item": [],
+            "navigation": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs?guid=300b3409-4631-3f60-bd8f-e15e47b652b5",
+                "rels": [
+                  "self"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "version": "1.0",
+      "href": "https://api-sandbox.pmp.io/docs/4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
+      "attributes": {
+        "valid": {
+          "from": "2013-09-30T19:52:58+00:00",
+          "to": "3013-09-30T19:52:58+00:00"
+        },
+        "created": "2014-01-30T05:30:51+00:00",
+        "modified": "2014-01-30T05:30:51+00:00",
+        "contenttemplated": "<p>As the House and Senate continue kicking spending plans back and forth, here is what you need to know:</p>\n<p><strong>A government shutdown does not mean an Obamacare shutdown</strong>. Even though House Republicans are pushing for changes to the Affordable Care Act, it is funded in such a way that it will continue even if there is a partial government shutdown. This means the “exchanges,” where people can search for coverage plans, <a href=\"http://www.marketplace.org/topics/economy/health-exchanges-go-live-tuesday-are-websites-ready\">are still set to be unveiled Tuesday as planned</a>.</p>\n<p><strong>A government shutdown will not save the government any money</strong>. In fact, a shutdown will cost the government money. <a href=\"http://www.marketplace.org/topics/economy/raising-debt-ceiling/shut-it-down-why-government-shutdown-costs-money\">Shutdowns that lasted about 22 days in the Clinton era cost about $1.5 billion</a>. A shutdown is not expected have a major effect on the October 17 deadline that the Obama Administration has given Congress to raise the nation’s borrowing limit.</p>\n<p><strong>Here is what will happen, according to President Obama, who spoke Monday afternoon:</strong></p>\n<blockquote>If you’re on Social Security, you will keep receiving your checks. If you’re on Medicare, your doctor will still see you. Everyone’s mail will still be delivered. And government operations related to national security or public safety will go on. Our troops will continue to serve with skill, honor, and courage. Air traffic controllers, prison guards, those who are with border control -- our Border Patrol will remain on their posts, but their paychecks will be delayed until the government reopens. NASA will shut down almost entirely, but Mission Control will remain open to support the astronauts serving on the Space Station.</blockquote>\n<p><strong>And here, according to the president, is what would change:</strong></p>\n<blockquote>Office buildings would close.&nbsp; Paychecks would be delayed.&nbsp; Vital services that seniors and veterans, women and children, businesses and our economy depend on would be hamstrung.&nbsp; Business owners would see delays in raising capital, seeking infrastructure permits, or rebuilding after Hurricane Sandy.&nbsp; Veterans who’ve sacrificed for their country will find their support centers unstaffed.&nbsp; Tourists will find every one of America’s national parks and monuments, from Yosemite to the Smithsonian to the Statue of Liberty, immediately closed.&nbsp; And of course, the communities and small businesses that rely on these national treasures for their livelihoods will be out of customers and out of luck.</blockquote>",
+        "guid": "4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
+        "teaser": "Democrats and Republicans appear unable to reach common ground on a budget before the government shuts down.",
+        "contentencoded": "<p>As the House and Senate continue kicking spending plans back and forth, here is what you need to know:</p>\n<p><strong>A government shutdown does not mean an Obamacare shutdown</strong>. Even though House Republicans are pushing for changes to the Affordable Care Act, it is funded in such a way that it will continue even if there is a partial government shutdown. This means the “exchanges,” where people can search for coverage plans, <a href=\"http://www.marketplace.org/topics/economy/health-exchanges-go-live-tuesday-are-websites-ready\">are still set to be unveiled Tuesday as planned</a>.</p>\n<p><strong>A government shutdown will not save the government any money</strong>. In fact, a shutdown will cost the government money. <a href=\"http://www.marketplace.org/topics/economy/raising-debt-ceiling/shut-it-down-why-government-shutdown-costs-money\">Shutdowns that lasted about 22 days in the Clinton era cost about $1.5 billion</a>. A shutdown is not expected have a major effect on the October 17 deadline that the Obama Administration has given Congress to raise the nation’s borrowing limit.</p>\n<p><strong>Here is what will happen, according to President Obama, who spoke Monday afternoon:</strong></p>\n<blockquote>If you’re on Social Security, you will keep receiving your checks. If you’re on Medicare, your doctor will still see you. Everyone’s mail will still be delivered. And government operations related to national security or public safety will go on. Our troops will continue to serve with skill, honor, and courage. Air traffic controllers, prison guards, those who are with border control -- our Border Patrol will remain on their posts, but their paychecks will be delayed until the government reopens. NASA will shut down almost entirely, but Mission Control will remain open to support the astronauts serving on the Space Station.</blockquote>\n<p><strong>And here, according to the president, is what would change:</strong></p>\n<blockquote>Office buildings would close.&nbsp; Paychecks would be delayed.&nbsp; Vital services that seniors and veterans, women and children, businesses and our economy depend on would be hamstrung.&nbsp; Business owners would see delays in raising capital, seeking infrastructure permits, or rebuilding after Hurricane Sandy.&nbsp; Veterans who’ve sacrificed for their country will find their support centers unstaffed.&nbsp; Tourists will find every one of America’s national parks and monuments, from Yosemite to the Smithsonian to the Statue of Liberty, immediately closed.&nbsp; And of course, the communities and small businesses that rely on these national treasures for their livelihoods will be out of customers and out of luck.</blockquote>",
+        "byline": "Gura, David",
+        "hreflang": "en",
+        "description": "Democrats and Republicans appear unable to reach common ground on a budget before the government shuts down.",
+        "tags": [
+          "APM_TESTING",
+          "PMP:Marketplace_PMP",
+          "4d39cdbe1d8022a9ed5b8cd87414f206",
+          "Marketplace for Monday, September 30, 2013",
+          "Marketplace",
+          "Economy"
+        ],
+        "published": "2013-09-30T19:52:58+00:00",
+        "title": "Why the shutdown won't save money: Fights in 90s cost $1.5B"
+      },
+      "links": {
+        "profile": [
+          {
+            "href": "https://api-sandbox.pmp.io/profiles/story",
+            "title": "APMStory"
+          }
+        ],
+        "distributor": [],
+        "copyright": [
+          {
+            "href": "http://www.publicradio.org/terms",
+            "title": "Copyright (C) 2013 American Public Media Group"
+          }
+        ],
+        "item": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/78e5706a-32dd-ba49-e386-b326945f1396"
+          }
+        ],
+        "collection": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+            "title": "Marketplace"
+          },
+          {
+            "href": "https://api-sandbox.pmp.io/docs/831c78f8-82b5-8825-5c2b-ca2f653b31df",
+            "title": "Marketplace for Monday, September 30, 2013"
+          }
+        ],
+        "alternate": [
+          {
+            "href": "http://www.marketplace.org/topics/economy/1201-am-will-my-lights-go-government-shutdown-explained",
+            "type": "text/html"
+          }
+        ],
+        "creator": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+          }
+        ],
+        "navigation": [
+          {
+            "href": "https://api-sandbox.pmp.io/docs?guid=4d39cdbe-1d80-22a9-ed5b-8cd87414f206",
+            "rels": [
+              "self"
+            ],
+            "totalitems": 1,
+            "totalpages": 1,
+            "pagenum": 1
+          }
+        ]
+      },
+      "items": [
+        {
+          "version": "1.0",
+          "href": "https://api-sandbox.pmp.io/docs/78e5706a-32dd-ba49-e386-b326945f1396",
+          "attributes": {
+            "valid": {
+              "from": "2013-09-30T23:01:42+00:00",
+              "to": "3013-09-30T23:01:42+00:00"
+            },
+            "created": "2014-01-30T05:30:34+00:00",
+            "modified": "2014-01-30T05:30:34+00:00",
+            "byline": "Gura, David",
+            "hreflang": "en",
+            "description": "",
+            "tags": [
+              "APM_TESTING",
+              "PMP:Marketplace_PMP",
+              "Marketplace for Monday, September 30, 2013",
+              "Marketplace",
+              "78e5706a32ddba49e386b326945f1396",
+              "Economy"
+            ],
+            "published": "2013-09-30T19:52:58+00:00",
+            "guid": "78e5706a-32dd-ba49-e386-b326945f1396",
+            "title": "marketplace_segment16_20130930_64.mp3"
+          },
+          "links": {
+            "profile": [
+              {
+                "href": "https://api-sandbox.pmp.io/profiles/audio",
+                "title": "APMAudio"
+              }
+            ],
+            "enclosure": [
+              {
+                "href": "apm-audio:/marketplace/segments/2013/09/30/marketplace_segment16_20130930_64.mp3",
+                "type": "audio/mpeg",
+                "meta": {
+                  "api": {
+                    "href": "http://api.publicradio.org/audio/v2?id=apm-audio:/marketplace/segments/2013/09/30/marketplace_segment16_20130930_64.mp3",
+                    "type": "application/json"
+                  }
+                }
+              }
+            ],
+            "distributor": [],
+            "copyright": [
+              {
+                "href": "http://www.publicradio.org/terms",
+                "title": "Copyright (C) 2013 American Public Media Group"
+              }
+            ],
+            "collection": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/36d4a0dd-34da-4ce3-a31e-112fd9d8d91c",
+                "title": "Marketplace"
+              },
+              {
+                "href": "https://api-sandbox.pmp.io/docs/85d8edb2-158d-4e24-87c3-07da07b9d067",
+                "title": "Marketplace"
+              }
+            ],
+            "creator": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs/98bf597a-2a6f-446c-9b7e-d8ae60122f0d"
+              }
+            ],
+            "item": [],
+            "navigation": [
+              {
+                "href": "https://api-sandbox.pmp.io/docs?guid=78e5706a-32dd-ba49-e386-b326945f1396",
+                "rels": [
+                  "self"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/spec/importers/pmp_article_importer_spec.rb
+++ b/spec/importers/pmp_article_importer_spec.rb
@@ -56,6 +56,22 @@ describe PmpArticleImporter do
       added = PmpArticleImporter.sync
       added.first.url.should match /marketplace\.org/
     end
+
+    it 'updates existing headlines' do
+      added = PmpArticleImporter.sync
+      added.first.headline.should match /billions and billions/
+      stub_request(:get, %r|pmp\.io/docs|)
+        .with(query: {"limit" => "10", "profile" => "story", "tag" => "marketplace"}).to_return({
+          :headers => {
+            :content_type   => "application/json"
+          },
+          :body => load_fixture('api/pmp/marketplace_stories_altered.json')
+        })
+      PmpArticleImporter.sync
+      cached = RemoteArticle.all
+      cached.first.headline.should match /trillions and trillions/
+    end
+
   end
 
   describe '#import' do


### PR DESCRIPTION
#492 Remote articles from NPR and PMP now will pull in updated headlines, teasers, and URLs.