### PR TITLE
Adds ContentShells to allowed content types for "article" selection

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,5 +1,11 @@
 class List < ActiveRecord::Base
 
+  CONTENT_TYPES = {
+    "article" => ["NewsStory", "BlogEntry", "ShowSegment", "Event", "ContentShell"],
+    "program" => ["KpccProgram", "ExternalProgram"],
+    "episode" => ["ShowEpisode"]
+  }
+
   outpost_model
   has_status
 
@@ -27,7 +33,7 @@ class List < ActiveRecord::Base
     ", Time.zone.now, Time.zone.now, Time.zone.now, Time.zone.now)
   }
 
-  before_save :sanitize_context
+  before_save :sanitize_context, :enforce_content_type
 
   status :draft do |s|
     s.id = 0
@@ -63,6 +69,11 @@ class List < ActiveRecord::Base
 
   def sanitize_context
     self.context = (self.context || "").split(",").map(&:strip).join(",")
+  end
+
+  def enforce_content_type
+    model_names = CONTENT_TYPES[content_type]
+    items.where.not(item_type: model_names).destroy_all
   end
 
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,11 +1,5 @@
 class List < ActiveRecord::Base
 
-  CONTENT_TYPES = {
-    "article" => ["NewsStory", "BlogEntry", "ShowSegment", "Event"],
-    "program" => ["KpccProgram", "ExternalProgram"],
-    "episode" => ["ShowEpisode"]
-  }
-
   outpost_model
   has_status
 
@@ -33,7 +27,7 @@ class List < ActiveRecord::Base
     ", Time.zone.now, Time.zone.now, Time.zone.now, Time.zone.now)
   }
 
-  before_save :sanitize_context, :enforce_content_type
+  before_save :sanitize_context
 
   status :draft do |s|
     s.id = 0
@@ -69,11 +63,6 @@ class List < ActiveRecord::Base
 
   def sanitize_context
     self.context = (self.context || "").split(",").map(&:strip).join(",")
-  end
-
-  def enforce_content_type
-    model_names = CONTENT_TYPES[content_type]
-    items.where.not(item_type: model_names).destroy_all
   end
 
 end

--- a/app/views/api/public/v3/articles/_article.json.jbuilder
+++ b/app/views/api/public/v3/articles/_article.json.jbuilder
@@ -1,5 +1,6 @@
-json.cache! [Api::Public::V3::VERSION, "v3", article] do
+json.cache! [Api::Public::V3::VERSION, "v4", article] do
   json.id           article.id
+  json.content_type article.obj_class
   json.title        article.title
   json.short_title  article.short_title
   json.published_at article.public_datetime

--- a/app/views/api/public/v3/articles/_article.json.jbuilder
+++ b/app/views/api/public/v3/articles/_article.json.jbuilder
@@ -1,6 +1,6 @@
 json.cache! [Api::Public::V3::VERSION, "v4", article] do
   json.id           article.id
-  json.content_type article.obj_class
+  json.type         article.obj_class
   json.title        article.title
   json.short_title  article.short_title
   json.published_at article.public_datetime

--- a/app/views/outpost/lists/_form_fields.html.erb
+++ b/app/views/outpost/lists/_form_fields.html.erb
@@ -1,6 +1,5 @@
 <%= form_block "Details" do %>
   <%= f.input :title %>
-  <%= f.input :content_type, collection: List::CONTENT_TYPES.keys, selected: record.content_type, include_blank: false, input_html: { id: "status-select" } %>
   <%= f.input :context %>
   <%= f.section "category" %>
   <%= f.section 'status' %>

--- a/app/views/outpost/lists/_form_fields.html.erb
+++ b/app/views/outpost/lists/_form_fields.html.erb
@@ -1,5 +1,6 @@
 <%= form_block "Details" do %>
   <%= f.input :title %>
+  <%= f.input :content_type, collection: List::CONTENT_TYPES.keys, selected: record.content_type, include_blank: false, input_html: { id: "status-select" } %>
   <%= f.input :context %>
   <%= f.section "category" %>
   <%= f.section 'status' %>
@@ -36,4 +37,3 @@
     );
   </script>
 <% end %>
-


### PR DESCRIPTION
Major changes:
- Can add a `ContentShell` to a list of articles in outpost
- Exposes a `type` property in the article object

For example, a content shell will return an object with `type: content_shell`.

The idea is that the app can use this information to decide how to render the contents, i.e. a "Go to link" button if the object is a `ContentShell`