### PR TITLE
Rescues errors that occur when pulling in from PMP

### DIFF
--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -38,7 +38,6 @@ module PmpArticleImporter
       begin
         stories = query(query)
       rescue StandardError => err
-        NewRelic.log_error(err)
         stories = []
       end
 

--- a/app/importers/pmp_article_importer.rb
+++ b/app/importers/pmp_article_importer.rb
@@ -34,7 +34,14 @@ module PmpArticleImporter
 
     def download_stories news_agency_name, query={}
       added = []
-      stories = query(query)
+
+      begin
+        stories = query(query)
+      rescue StandardError => err
+        NewRelic.log_error(err)
+        stories = []
+      end
+
       log "#{stories.size} PMP stories from #{news_agency_name} found"
       stories.each do |story|
 
@@ -134,7 +141,7 @@ module PmpArticleImporter
         end
 
         audio = pmp_story.items.find do |i|
-          PROFILES[:audio].include? i.profile.first.title 
+          PROFILES[:audio].include? i.profile.first.title
         end
 
         # Import Audio


### PR DESCRIPTION
Changes:

- rescues any error that occurs during a PMP API call

The error that keeps happening is a 504, which is usually a timeout error. I was able to perform the queries manually through rails console, and they are giving back valid responses, so for now we'll rescue by defaulting the `stories` variable to an empty array.