### PR TITLE
Looks for members in Parse and then populates Members if found

### DIFF
--- a/app/controllers/api/public/v3/members_controller.rb
+++ b/app/controllers/api/public/v3/members_controller.rb
@@ -2,11 +2,18 @@ module Api::Public::V3
   class MembersController < BaseController
     def show
       if !params[:id] || !(@member = Member.where(pledge_token: params[:id]).first)
-        render_not_found and return false
+        # Find out if it's in Parse
+        parse_user_query = Farse::Query.new("PfsUser")
+        parse_user_query.eq("pledgeToken", params[:id])
+        authorized_user = parse_user_query.get.first
+        if authorized_user.present?
+          authorized_user["viewsLeft"] = Farse::Increment.new(-1)
+          Member.create_from_parse(authorized_user)
+        else
+          render_not_found and return false
+        end
       end
-
       respond_with @member
     end
   end
 end
-

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,3 +1,16 @@
 class Member < ActiveRecord::Base
   validates :pledge_token, presence: true
+
+  def self.create_from_parse(authorized_user)
+      Member.create(
+          email: authorized_user["email"],
+          email_sent: authorized_user["emailSent"],
+          first_name: authorized_user["name"],
+          name: authorized_user["name"],
+          pfs_selected: authorized_user["pfsSelected"],
+          pledge_amount: authorized_user["pledgeAmount"],
+          pledge_token: authorized_user["pledgeToken"],
+          views_left: authorized_user["viewsLeft"]
+      )
+  end
 end


### PR DESCRIPTION
There's a bug where if a user is in the Parse DB, but uses the iOS app, they won't have access to KPCC+ because the iOS app looks for their token in the Member table only. This is the fix:

1. If a member comes in thru the web's listen live for KPCC+, we check the parse DB as usual, and if their token is correct, copy that record to the Member table.
1. If a member comes in thru the new iOS api call, check the Member table as usual but *also* if they don't exist in the member table, check Parse and if they exist, copy that record over.