### PR TITLE
Update homepage to include latest 5 LAist entries

### DIFF
--- a/app/helpers/homepage_helper.rb
+++ b/app/helpers/homepage_helper.rb
@@ -40,6 +40,20 @@ module HomepageHelper
   def media_extra content, contents
     render partial: "shared/media/components/extra", locals: {content: content, contents: contents}
   end
+  def latest_from_laist
+    # Perform a get request from the LAist API, and return an empty array if it fails
+    begin
+      response = RestClient.get('http://laist.com/mt/mt-data-api.cgi/v3/sites/1/entries?limit=5')
+      json_response = JSON.parse(response.body)
+      if json_response && json_response["items"]
+        json_response["items"]
+      else
+        []
+      end
+    rescue
+      []
+    end
+  end
   def latest_stories content
     # Takes a collection of any model objects
     # that respond to ContentBase obj_key method.

--- a/app/helpers/homepage_helper.rb
+++ b/app/helpers/homepage_helper.rb
@@ -43,7 +43,8 @@ module HomepageHelper
   def latest_from_laist
     # Perform a get request from the LAist API, and return an empty array if it fails
     begin
-      response = RestClient.get('http://laist.com/mt/mt-data-api.cgi/v3/sites/1/entries?limit=5')
+      api_base_url = Rails.configuration.x.api.laist.endpoint
+      response = RestClient.get("#{api_base_url}/sites/1/entries?limit=5")
       json_response = JSON.parse(response.body)
       if json_response && json_response["items"]
         json_response["items"]

--- a/app/views/better_homepage/_latest_from_laist.html.erb
+++ b/app/views/better_homepage/_latest_from_laist.html.erb
@@ -1,0 +1,14 @@
+<% if latest_from_laist.length > 0 %>
+<h6 class="b-heading b-heading--h6 b-heading--uppercase u-text-color--gray b-heading--medium">Latest LAist Headlines</h6>
+<ul class="c-list c-list--vert">
+    <% latest_from_laist.each do |article| %>
+    <li>
+      <div class="o-media o-media--small">
+        <h4>
+          <%= link_to article["title"], article["permalink"] %>
+        </h4>
+      </div>
+    </li>
+    <% end %>
+</ul>
+<% end %>

--- a/app/views/better_homepage/_latest_headlines.html.erb
+++ b/app/views/better_homepage/_latest_headlines.html.erb
@@ -1,10 +1,3 @@
-<div class="c-ad">
-  <div class="c-ad__container c-ad__container">
-    <div class="c-ad__banner">
-      <%= render "shared/ads/dfp", ad_key: 'slot_a' %>
-    </div>
-  </div>
-</div>
 <h6 class="b-heading b-heading--h6 b-heading--uppercase u-text-color--gray b-heading--medium">Latest NPR Headlines</h6>
 <ul class="c-list c-list--vert">
   <% latest_stories(content).each do |article| %>

--- a/app/views/better_homepage/_right_asides.html.erb
+++ b/app/views/better_homepage/_right_asides.html.erb
@@ -1,9 +1,21 @@
+<div class="c-ad">
+  <div class="c-ad__container c-ad__container">
+    <div class="c-ad__banner">
+      <%= render "shared/ads/dfp", ad_key: 'slot_a' %>
+    </div>
+  </div>
+</div>
+
 <aside class="right hp-latest-headlines" style="order:2;">
-  <%= render partial: "better_homepage/latest_headlines", locals: {content: @homepage.content} %>
+  <%= render partial: "better_homepage/latest_from_laist" %>
 </aside>
 
 <aside class="right ad" style="order:6;">
   <%= render partial: "better_homepage/c_ad", locals: {slot: "b"} %>
+</aside>
+
+<aside class="right hp-latest-headlines" style="order:7;">
+  <%= render partial: "better_homepage/latest_headlines", locals: {content: @homepage.content} %>
 </aside>
 
 <%= render_tag_cluster %>

--- a/app/views/better_homepage/_right_asides.html.erb
+++ b/app/views/better_homepage/_right_asides.html.erb
@@ -1,12 +1,11 @@
-<div class="c-ad">
-  <div class="c-ad__container c-ad__container">
-    <div class="c-ad__banner">
-      <%= render "shared/ads/dfp", ad_key: 'slot_a' %>
+<aside class="right hp-latest-headlines" style="order:2;">
+  <div class="c-ad">
+    <div class="c-ad__container c-ad__container">
+      <div class="c-ad__banner">
+        <%= render "shared/ads/dfp", ad_key: 'slot_a' %>
+      </div>
     </div>
   </div>
-</div>
-
-<aside class="right hp-latest-headlines" style="order:2;">
   <%= render partial: "better_homepage/latest_from_laist" %>
 </aside>
 


### PR DESCRIPTION
Major changes:

- There is a section at the right rail of the homepage that lists the latest 5 LAist entries
- "Latest NPR headlines" are moved down to position B
- Ad position A is moved outside of the "Latest NPR headlines" block

Note:

- There isn't any deduping logic, so editors have to be mindful of what is in the middle rail/ side rail