### PR TITLE
Changes the GET request to GET from the RSS feed instead of the API

### DIFF
--- a/app/helpers/homepage_helper.rb
+++ b/app/helpers/homepage_helper.rb
@@ -41,13 +41,14 @@ module HomepageHelper
     render partial: "shared/media/components/extra", locals: {content: content, contents: contents}
   end
   def latest_from_laist
-    # Perform a get request from the LAist API, and return an empty array if it fails
+    # Perform a get request to the LAist RSS FEED, and return an empty array if it fails
     begin
-      api_base_url = Rails.configuration.x.api.laist.endpoint
-      response = RestClient.get("#{api_base_url}/sites/1/entries?limit=5")
-      json_response = JSON.parse(response.body)
-      if json_response && json_response["items"]
-        json_response["items"]
+      rss_feed_url = Rails.configuration.x.api.laist.rss_feed_url
+      response = RestClient.get(rss_feed_url)
+      response_hash = Hash.from_xml(response.body)
+
+      if response_hash && response_hash["rss"] && response_hash["rss"]["channel"] && response_hash["rss"]["channel"]["item"]
+        response_hash["rss"]["channel"]["item"].try(:first, 5)
       else
         []
       end

--- a/app/views/better_homepage/_latest_from_laist.html.erb
+++ b/app/views/better_homepage/_latest_from_laist.html.erb
@@ -5,7 +5,7 @@
     <li>
       <div class="o-media o-media--small">
         <h4>
-          <%= link_to article["title"], article["permalink"] %>
+          <%= link_to article["title"], article["link"] %>
         </h4>
       </div>
     </li>


### PR DESCRIPTION
In conjunction with this Movable Type PR: https://github.com/SCPR/movabletype-laist/pull/16

The changes proposed here will perform a GET request to the RSS feed instead of the API. This is so that the resulting feed doesn't include any `@sponsor` entries, but another nice side effect is that it will most likely be unaffected by the incomplete object bug that occasionally happens with the movabletype data api.