### PR TITLE
Fix cache api

### DIFF
--- a/app/controllers/api/public/v3/articles_controller.rb
+++ b/app/controllers/api/public/v3/articles_controller.rb
@@ -34,12 +34,19 @@ module Api::Public::V3
 
     def index
       @articles = Rails.cache.fetch('/api/v3/articles', expires_in: 5.minutes) do
-        ContentBase.search(@query, {
-          :classes => @classes,
-          :limit   => @limit,
-          :page    => @page,
-          :with    => @conditions
-        })
+        articles =
+          ContentBase.search(@query, {
+            :classes => @classes,
+            :limit   => @limit,
+            :page    => @page,
+            :with    => @conditions
+          })
+
+        if articles.empty?
+          return []
+        else
+          return articles
+        end
       end
 
       respond_with @articles

--- a/app/controllers/api/public/v3/articles_controller.rb
+++ b/app/controllers/api/public/v3/articles_controller.rb
@@ -33,12 +33,14 @@ module Api::Public::V3
     #---------------------------
 
     def index
-      @articles = ContentBase.search(@query, {
-        :classes => @classes,
-        :limit   => @limit,
-        :page    => @page,
-        :with    => @conditions
-      })
+      @articles = Rails.cache.fetch('/api/v3/articles', expires_in: 5.minutes) do
+        ContentBase.search(@query, {
+          :classes => @classes,
+          :limit   => @limit,
+          :page    => @page,
+          :with    => @conditions
+        })
+      end
 
       respond_with @articles
     end

--- a/app/controllers/api/public/v3/lists_controller.rb
+++ b/app/controllers/api/public/v3/lists_controller.rb
@@ -2,8 +2,9 @@ module Api::Public::V3
   class ListsController < BaseController
 
     def index
-      @lists = Rails.cache.fetch("/api/v3/lists/#{context}", expires_in: 5.minutes) do
-        if !context.empty?
+      @context = context
+      @lists = Rails.cache.fetch("/api/v3/lists/#{@context}", expires_in: 5.minutes) do
+        if !@context.empty?
           List.visible
             .where("FIND_IN_SET(?, context)", context)
             .order('position ASC').to_a

--- a/app/controllers/api/public/v3/lists_controller.rb
+++ b/app/controllers/api/public/v3/lists_controller.rb
@@ -2,14 +2,14 @@ module Api::Public::V3
   class ListsController < BaseController
 
     def index
-      @lists = Rails.cache.fetch('/api/v3/lists', expires_in: 5.minutes) do
+      @lists = Rails.cache.fetch("/api/v3/lists/#{context}", expires_in: 5.minutes) do
         if !context.empty?
           List.visible
             .where("FIND_IN_SET(?, context)", context)
-            .order('position ASC')
+            .order('position ASC').to_a
         else
           List.visible
-            .order('position ASC')
+            .order('position ASC').to_a
         end
       end
       respond_with @lists

--- a/app/controllers/api/public/v3/lists_controller.rb
+++ b/app/controllers/api/public/v3/lists_controller.rb
@@ -2,13 +2,15 @@ module Api::Public::V3
   class ListsController < BaseController
 
     def index
-      if !context.empty?
-        @lists = List.visible
-          .where("FIND_IN_SET(?, context)", context)
-          .order('position ASC')
-      else
-        @lists = List.visible
-          .order('position ASC')
+      @lists = Rails.cache.fetch('/api/v3/lists', expires_in: 5.minutes) do
+        if !context.empty?
+          List.visible
+            .where("FIND_IN_SET(?, context)", context)
+            .order('position ASC')
+        else
+          List.visible
+            .order('position ASC')
+        end
       end
       respond_with @lists
     end

--- a/app/controllers/api/public/v3/programs_controller.rb
+++ b/app/controllers/api/public/v3/programs_controller.rb
@@ -16,7 +16,10 @@ module Api::Public::V3
 
 
     def index
-      @programs = Program.where(@conditions)
+      @programs = Rails.cache.fetch('/api/v3/programs', expires_in: 5.minutes) do
+        Program.where(@conditions)
+      end
+
       respond_with @programs
     end
 

--- a/app/controllers/api/public/v3/programs_controller.rb
+++ b/app/controllers/api/public/v3/programs_controller.rb
@@ -16,7 +16,7 @@ module Api::Public::V3
 
 
     def index
-      @programs = Rails.cache.fetch('/api/v3/programs', expires_in: 5.minutes) do
+      @programs = Rails.cache.fetch("/api/v3/programs/#{@conditions}", expires_in: 5.minutes) do
         Program.where(@conditions)
       end
 

--- a/app/controllers/api/public/v3/schedule_occurrences_controller.rb
+++ b/app/controllers/api/public/v3/schedule_occurrences_controller.rb
@@ -21,6 +21,11 @@ module Api::Public::V3
       @schedule_occurrences = ScheduleOccurrence.block(@start_time, @length)
       @pledge_drive = false
       @display_pledge_status = params[:pledge_status]
+
+      @schedule_occurrences = Rails.cache.fetch('/api/v3/schedule', expires_in: 5.minutes) do
+        ScheduleOccurrence.block(@start_time, @length)
+      end
+
       respond_with @schedule_occurrences
     end
 

--- a/app/controllers/api/public/v3/schedule_occurrences_controller.rb
+++ b/app/controllers/api/public/v3/schedule_occurrences_controller.rb
@@ -18,11 +18,10 @@ module Api::Public::V3
     #---------------------------
 
     def index
-      @schedule_occurrences = ScheduleOccurrence.block(@start_time, @length)
       @pledge_drive = false
       @display_pledge_status = params[:pledge_status]
 
-      @schedule_occurrences = Rails.cache.fetch('/api/v3/schedule', expires_in: 5.minutes) do
+      @schedule_occurrences = Rails.cache.fetch("/api/v3/schedule/#{@start_time}/#{@length}/#{@pledge_drive}/#{@display_pledge_status}", expires_in: 5.minutes) do
         ScheduleOccurrence.block(@start_time, @length)
       end
 

--- a/app/controllers/api/public/v3/settings_controller.rb
+++ b/app/controllers/api/public/v3/settings_controller.rb
@@ -3,12 +3,19 @@ module Api::Public::V3
 
     def index
       @context  = [params[:context], 'global']
-      @settings = Setting.where(context: @context).where.not(context: nil).to_a
-      @pledge_drive = PledgeDrive.happening.order("starts_at DESC").first
-      if @pledge_drive
-        @settings.unshift @pledge_drive.to_setting
-        @settings.uniq!
+
+      @settings = Rails.cache.fetch('/api/v3/settings/#{params[:context]}', expires_in: 5.minutes) do
+        settings = Setting.where(context: @context).where.not(context: nil).to_a
+        pledge_drive = PledgeDrive.happening.order("starts_at DESC").first
+
+        if pledge_drive
+          settings.unshift pledge_drive.to_setting
+          settings.uniq!
+        end
+
+        settings
       end
+
       respond_with @settings
     end
     

--- a/app/controllers/api/public/v3/settings_controller.rb
+++ b/app/controllers/api/public/v3/settings_controller.rb
@@ -4,7 +4,7 @@ module Api::Public::V3
     def index
       @context  = [params[:context], 'global']
 
-      @settings = Rails.cache.fetch('/api/v3/settings/#{params[:context]}', expires_in: 5.minutes) do
+      @settings = Rails.cache.fetch("/api/v3/settings/#{@context}", expires_in: 5.minutes) do
         settings = Setting.where(context: @context).where.not(context: nil).to_a
         pledge_drive = PledgeDrive.happening.order("starts_at DESC").first
 

--- a/app/views/api/public/v3/articles/index.json.jbuilder
+++ b/app/views/api/public/v3/articles/index.json.jbuilder
@@ -2,6 +2,8 @@
 # break anything. The benchmarks showed a ~14% performance boost.
 json.partial! api_view_path("shared", "meta")
 
-json.articles do
-  json.partial! api_view_path("articles", "collection"), articles: @articles
+json.cache! ['/api/v3/articles', @query, @classes, @limit, @page, @conditions], expires_in: 5.minutes do
+	json.articles do
+		json.partial! api_view_path("articles", "collection"), articles: @articles
+	end
 end

--- a/app/views/api/public/v3/lists/index.json.jbuilder
+++ b/app/views/api/public/v3/lists/index.json.jbuilder
@@ -1,19 +1,21 @@
 json.partial! api_view_path("shared", "meta")
 
-json.lists do
-  json.array! @lists do |list|
-    json.id            list.id
-    json.title         list.title
-    json.types         list.content_type.split(',') if list.content_type
-    json.context       list.context
-    json.starts_at     list.starts_at
-    json.ends_at       list.ends_at
-    json.created_at    list.created_at
-    json.updated_at    list.updated_at
-    json.items do
-      json.partial! api_view_path("articles", "collection"),
-        articles: list.items.articles.length > 0 ?
-          list.items.articles : list.deduped_category_items
+json.cache! ['/api/v3/lists'], expires_in: 5.minutes do
+  json.lists do
+    json.array! @lists do |list|
+      json.id            list.id
+      json.title         list.title
+      json.types         list.content_type.split(',') if list.content_type
+      json.context       list.context
+      json.starts_at     list.starts_at
+      json.ends_at       list.ends_at
+      json.created_at    list.created_at
+      json.updated_at    list.updated_at
+      json.items do
+        json.partial! api_view_path("articles", "collection"),
+          articles: list.items.articles.length > 0 ?
+            list.items.articles : list.deduped_category_items
+      end
     end
   end
 end

--- a/app/views/api/public/v3/lists/index.json.jbuilder
+++ b/app/views/api/public/v3/lists/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.partial! api_view_path("shared", "meta")
 
-json.cache! ['/api/v3/lists'], expires_in: 5.minutes do
+json.cache! ['/api/v3/lists', @context], expires_in: 5.minutes do
   json.lists do
     json.array! @lists do |list|
       json.id            list.id

--- a/app/views/api/public/v3/programs/index.json.jbuilder
+++ b/app/views/api/public/v3/programs/index.json.jbuilder
@@ -1,5 +1,7 @@
 json.partial! api_view_path("shared", "meta")
 
-json.programs do
-  json.partial! api_view_path("programs", "collection"), programs: @programs
+json.cache! ['/api/v3/programs', @conditions], expires_in: 5.minutes do
+	json.programs do
+	  json.partial! api_view_path("programs", "collection"), programs: @programs
+	end
 end

--- a/app/views/api/public/v3/schedule_occurrences/index.json.jbuilder
+++ b/app/views/api/public/v3/schedule_occurrences/index.json.jbuilder
@@ -1,9 +1,11 @@
 json.partial! api_view_path("shared", "meta")
 
-if @display_pledge_status
-  json.pledge_drive @pledge_drive || false
-end
-json.schedule_occurrences do
-  json.partial! api_view_path("schedule_occurrences", "collection"),
-    schedule_occurrences: @schedule_occurrences
+json.cache! ['/api/v3/schedule', @start_time, @length, @pledge_drive, @display_pledge_status], expires_in: 5.minutes do
+	if @display_pledge_status
+	  json.pledge_drive @pledge_drive || false
+	end
+	json.schedule_occurrences do
+	  json.partial! api_view_path("schedule_occurrences", "collection"),
+	    schedule_occurrences: @schedule_occurrences
+	end
 end

--- a/app/views/api/public/v3/settings/index.json.jbuilder
+++ b/app/views/api/public/v3/settings/index.json.jbuilder
@@ -1,7 +1,9 @@
 json.partial! api_view_path("shared", "meta")
 
-json.settings do
-  @settings.each do |setting|
-    json.set! setting.key, setting.value
-  end
+json.cache! ['/api/v3/settings', @context, @pledge_drive], expires_in: 5.minutes do
+	json.settings do
+		@settings.each do |setting|
+			json.set! setting.key, setting.value
+		end
+	end
 end


### PR DESCRIPTION
In this pull request, I added caching to all common API methods that are hit from mobile. The caching is in both the controller and the json builders to ensure quicker responses. I got the average of the response time of each API method before and after caching in SCPRv4 staging and got the percentage of reduced response time: 

- `/api/v3/schedule`: 
   - Average response time before caching: 757ms
   - Average response time after caching: 332ms
   - Response time reduced by: 56%
- `/api/v3/programs`:
   - Average response time before caching: 380ms
   - Average response time after caching: 119ms
   - Response time reduced by: 68%
- `/api/v3/articles`:
   - Average response time before caching: 147ms
   - Average response time after caching: 90ms
   - Response time reduced by: 38%
- `/api/v3/lists`:
   - Average response time before caching: 835ms
   - Average response time after caching: 298ms
   - Response time reduced by: 64%
- `/api/v3/settings`:
   - Average response time before caching: 145ms
   - Average response time after caching: 58ms
   - Response time reduced by: 60%
- `/api/v3/settings/ios`:
   - Average response time before caching: 381ms
   - Average response time after caching: 67ms
   - Response time reduced by: 82%
- `/api/v3/settings/android`:
   - Average response time before caching: 141ms
   - Average response time after caching: 57ms
   - Response time reduced by: 59%

Some issues I encountered was that the caching was not being implemented correctly in `/api/v3/articles` because each article had a `singleton` method so I had to strip it away before responding with it in its controller. Here's a link that explain in more details about stripping `singleton` methods: 
https://stackoverflow.com/questions/6391855/rails-cache-error-in-rails-3-1-typeerror-cant-dump-hash-with-default-proc/6392704#6392704

Here's the link on removing `singleton` methods:
https://stackoverflow.com/questions/23734582/how-to-programmatically-remove-singleton-information-on-an-instance-to-make-it

The other issue was when using `.where` method because it returns the scope and not the actual query. So I attached the `.to_a` method so an array of values are being returned instead of relations. Here is the link that explains more about the problems with caching relations:
https://stackoverflow.com/questions/11218917/confusion-caching-active-record-queries-with-rails-cache-fetch

I have tested on staging SCPRv4 by using `Rails.cache.read('cache-key')` and successfully received the caching. I have also made sure that the cache was missed after every 5 minutes.