### PR TITLE
Adds a read timeout to the open-uri call

### DIFF
--- a/app/importers/rss_program_importer.rb
+++ b/app/importers/rss_program_importer.rb
@@ -24,7 +24,7 @@ class RssProgramImporter
   def sync
     feed = nil
     begin
-      open(@external_program.podcast_url, :allow_redirections => :all) do |rss|
+      open(@external_program.podcast_url, :allow_redirections => :all, :read_timeout => 30) do |rss|
         feed = RSS::Parser.parse(rss, false)
       end
     rescue => e


### PR DESCRIPTION
Found in this doc: https://docs.ruby-lang.org/en/2.0.0/OpenURI/OpenRead.html

> :read_timeout option specifies a timeout of read for http connections.

Adds a read timeout to escape if an rss feed isn't returning at a reasonable time period